### PR TITLE
Switch OpenCode host directory naming back to `home`

### DIFF
--- a/assets/state/docker-compose.yml
+++ b/assets/state/docker-compose.yml
@@ -73,22 +73,23 @@ services:
       - ${OPENPALM_CONFIG_HOME}/user.env
       - ${OPENPALM_CONFIG_HOME}/secrets.env
     environment:
-      - OPENCODE_CONFIG_DIR=/config
-      - OPENCODE_CONFIG=/config/opencode.jsonc
+      - OPENCODE_CONFIG_DIR=/opt/opencode
       - OPENCODE_PORT=4096
       - OPENCODE_ENABLE_SSH=${OPENCODE_ENABLE_SSH:-0}
       - CRON_DIR=/cron
+      - HOME=/home/opencode
     # Bind addresses default to localhost; set *_BIND_ADDRESS=0.0.0.0 to allow LAN access.
     ports:
       - "${OPENCODE_CORE_BIND_ADDRESS:-127.0.0.1}:4096:4096"
       - "${OPENCODE_CORE_SSH_BIND_ADDRESS:-127.0.0.1}:${OPENCODE_CORE_SSH_PORT:-2222}:22"
     volumes:
-      - ${OPENPALM_CONFIG_HOME}/opencode-core:/config
+      - ${OPENPALM_DATA_HOME}/home:/home/opencode
       - ${OPENPALM_CONFIG_HOME}/cron:/cron
       - ${OPENPALM_STATE_HOME}/opencode-core:/state
       - ${OPENPALM_STATE_HOME}/workspace:/work
       - ${OPENPALM_DATA_HOME}/shared:/shared
     working_dir: /work
+    user: "${OPENPALM_UID:-1000}:${OPENPALM_GID:-1000}"
     networks: [assistant_net]
     depends_on: [openmemory]
     healthcheck:
@@ -126,7 +127,7 @@ services:
     environment:
       - PORT=8100
       - ADMIN_TOKEN=${ADMIN_TOKEN:-change-me-admin-token}
-      - OPENCODE_CONFIG_PATH=/app/config/opencode-core/opencode.jsonc
+      - OPENCODE_CONFIG_PATH=/app/home/.config/opencode/opencode.json
       - GATEWAY_URL=http://gateway:8080
       - OPENCODE_CORE_URL=http://opencode-core:4096
       - CADDYFILE_PATH=/app/config/caddy/Caddyfile
@@ -139,7 +140,7 @@ services:
       - OPENPALM_COMPOSE_SUBCOMMAND=${OPENPALM_COMPOSE_SUBCOMMAND:-compose}
       - OPENPALM_CONTAINER_SOCKET_URI=${OPENPALM_CONTAINER_SOCKET_URI:-unix:///var/run/docker.sock}
     volumes:
-      - ${OPENPALM_CONFIG_HOME}/opencode-core:/app/config/opencode-core
+      - ${OPENPALM_DATA_HOME}/home:/app/home
       - ${OPENPALM_CONFIG_HOME}/caddy:/app/config/caddy
       - ${OPENPALM_CONFIG_HOME}/channels:/app/channel-env
       - ${OPENPALM_CONFIG_HOME}:/app/config-root

--- a/assets/state/registry/README.md
+++ b/assets/state/registry/README.md
@@ -53,7 +53,7 @@ Risk levels map directly to Extension sub-types:
 
 | `installAction` | `installTarget` example | What happens |
 |---|---|---|
-| `plugin` | `@myorg/my-opencode-plugin` | Added to `plugin[]` in `opencode.jsonc`; OpenCode core restarts |
+| `plugin` | `@myorg/my-opencode-plugin` | Added to `plugin[]` in `opencode.json`; OpenCode core restarts |
 | `skill-file` | `skills/MySkill.SKILL.md` | Skill file copied into `skills/` and enabled in agent config |
 | `command-file` | `commands/my-command.md` | Command file copied into `commands/` |
 | `agent-file` | `agents/my-agent.md` | Agent file copied into `agents/` |

--- a/assets/state/scripts/install.ps1
+++ b/assets/state/scripts/install.ps1
@@ -257,7 +257,7 @@ try {
     "$OpenPalmDataHome/shared",
     "$OpenPalmDataHome/caddy",
     "$OpenPalmDataHome/admin",
-    "$OpenPalmConfigHome/opencode-core",
+    "$OpenPalmDataHome/home",
     "$OpenPalmConfigHome/caddy",
     "$OpenPalmConfigHome/channels",
     "$OpenPalmConfigHome/cron",

--- a/assets/state/scripts/install.sh
+++ b/assets/state/scripts/install.sh
@@ -447,8 +447,9 @@ upsert_env_var OPENPALM_ENABLED_CHANNELS "${OPENPALM_ENABLED_CHANNELS:-}"
 # ── Create XDG directory trees ─────────────────────────────────────────────
 mkdir -p "$OPENPALM_DATA_HOME"/{postgres,qdrant,openmemory,shared,caddy}
 mkdir -p "$OPENPALM_DATA_HOME"/admin
+mkdir -p "$OPENPALM_DATA_HOME"/home
 
-mkdir -p "$OPENPALM_CONFIG_HOME"/{opencode-core,caddy,channels,cron,secrets}
+mkdir -p "$OPENPALM_CONFIG_HOME"/{caddy,channels,cron,secrets}
 mkdir -p "$OPENPALM_CONFIG_HOME"/secrets/{gateway,channels}
 
 mkdir -p "$OPENPALM_STATE_HOME"/{opencode-core,gateway,caddy,workspace}

--- a/docs/refenence/host-system-reference.md
+++ b/docs/refenence/host-system-reference.md
@@ -1,302 +1,95 @@
 # OpenPalm Host System Reference
 
-This document describes the on-disk file structure of an installed OpenPalm stack, the directory layout on the host, and the relationship between host paths, container volume mounts, and runtime configuration.
-
----
-
-## XDG Base Directory Layout
-
-OpenPalm follows the [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/latest/) to organize host-side files into three top-level directories with distinct semantics:
-
-| Directory | Default Path | XDG Override | OpenPalm Override | Semantics |
-|-----------|-------------|-------------|-------------------|-----------|
-| **Data** | `~/.local/share/openpalm` | `$XDG_DATA_HOME` | `$OPENPALM_DATA_HOME` | Persistent storage — databases, vector stores, blobs. Back this up. |
-| **Config** | `~/.config/openpalm` | `$XDG_CONFIG_HOME` | `$OPENPALM_CONFIG_HOME` | User-editable configuration — agent overrides, Caddyfile, channel envs, secrets. |
-| **State** | `~/.local/state/openpalm` | `$XDG_STATE_HOME` | `$OPENPALM_STATE_HOME` | Runtime state — compose file, workspace, audit logs. Disposable on reinstall. |
-
-Override precedence: `OPENPALM_*_HOME` > `XDG_*_HOME` > hardcoded defaults.
-
----
-
-## Working Directory (`.env`)
+This document describes host directories, how they are created, and how they map into containers.
 
-The installer creates a `.env` file in the current working directory from `assets/config/system.env`. This file is the root of all runtime configuration and is copied into the state directory alongside the compose file.
+## XDG layout and overrides
 
-### Generated `.env` Contents
+OpenPalm uses XDG-style roots with this precedence:
 
-```env
-# XDG paths (resolved at install time)
-OPENPALM_DATA_HOME=/home/user/.local/share/openpalm
-OPENPALM_CONFIG_HOME=/home/user/.config/openpalm
-OPENPALM_STATE_HOME=/home/user/.local/state/openpalm
-
-# Container runtime (detected at install time)
-OPENPALM_CONTAINER_PLATFORM=docker
-OPENPALM_COMPOSE_BIN=docker
-OPENPALM_COMPOSE_SUBCOMMAND=compose
-OPENPALM_CONTAINER_SOCKET_PATH=/var/run/docker.sock
-OPENPALM_CONTAINER_SOCKET_IN_CONTAINER=/var/run/openpalm-container.sock
-OPENPALM_CONTAINER_SOCKET_URI=unix:///var/run/openpalm-container.sock
-OPENPALM_IMAGE_NAMESPACE=openpalm
-OPENPALM_IMAGE_TAG=latest-amd64
-
-# Auto-generated secrets
-ADMIN_TOKEN=<64-char random token>
-ADMIN_TOKEN=<64-char random token>
-POSTGRES_PASSWORD=<64-char random token>
-CHANNEL_CHAT_SECRET=<64-char random token>
-CHANNEL_DISCORD_SECRET=<64-char random token>
-CHANNEL_VOICE_SECRET=<64-char random token>
-CHANNEL_TELEGRAM_SECRET=<64-char random token>
-
-# Channels to enable
-OPENPALM_ENABLED_CHANNELS=
-```
-
-The `.env` is generated once. Subsequent installer runs update path and runtime variables idempotently via `upsert_env_var()` but never overwrite existing secrets.
-
----
-
-## Data Directory (`~/.local/share/openpalm`)
-
-Persistent storage for databases, vector stores, and shared volumes. Directories are created by the installer and populated by containers at first startup.
-
-```
-~/.local/share/openpalm/
-├── postgres/          # PostgreSQL data directory
-├── qdrant/            # Qdrant vector database storage
-├── openmemory/        # OpenMemory persistent data
-├── shared/            # Shared volume between opencode-core, admin, and openmemory
-├── caddy/             # Caddy TLS certificates and persistent data
-└── admin/             # Admin service persistent state (setup wizard, cron store)
-```
-
-### Volume Mount Map (Data)
-
-| Host Path | Container | Mount Point | Mode |
-|-----------|-----------|-------------|------|
-| `postgres/` | postgres | `/var/lib/postgresql/data` | rw |
-| `qdrant/` | qdrant | `/qdrant/storage` | rw |
-| `openmemory/` | openmemory | `/data` | rw |
-| `shared/` | opencode-core | `/shared` | rw |
-| `shared/` | admin | `/shared` | rw |
-| `shared/` | openmemory | `/shared` | rw |
-| `caddy/` | caddy | `/data` | rw |
-| `admin/` | admin | `/app/data` | rw |
-
----
-
-## Config Directory (`~/.config/openpalm`)
-
-User-editable configuration files. The installer seeds defaults but never overwrites existing files.
-
-```
-~/.config/openpalm/
-├── opencode-core/
-│   └── opencode.jsonc     # User override config (seeded as empty {})
-├── caddy/
-│   └── Caddyfile          # Reverse proxy configuration
-├── channels/
-│   ├── chat.env           # Chat channel credentials
-│   ├── discord.env        # Discord channel credentials
-│   ├── telegram.env       # Telegram channel credentials
-│   └── voice.env          # Voice channel credentials
-├── cron/                  # Automation definitions (scheduled prompts managed by admin)
-│   ├── crontab            # (created by admin when automations are added)
-│   └── cron-payloads/     # JSON payload files for each automation (one per automation ID)
-├── secrets.env            # API keys (ANTHROPIC_API_KEY, OPENAI_API_KEY, etc.)
-└── user.env               # User-level environment overrides
-```
-
-### Key Config Files
-
-**`opencode-core/opencode.jsonc`** — User override layer for the opencode-core container. Seeded as an empty JSON object `{}`. Extensions are baked into the container image at build time; this file exists so operators can add npm plugins, change permissions, or configure MCP connections without rebuilding images. Mounted at `/config/opencode.jsonc` inside the container. Inside the container, the config mount is referenced as `OPENCODE_CONFIG_DIR`.
-
-**`caddy/Caddyfile`** — Reverse proxy rules. Routes `/channels/*` to channel adapters, `/admin/*` to the admin service, and enforces LAN-only access via IP matchers.
-
-**`channels/*.env`** — Per-channel credential files (e.g., `DISCORD_BOT_TOKEN`, `TELEGRAM_BOT_TOKEN`). Each channel uses its own env file named after the channel (e.g., `channels/discord.env`, `channels/telegram.env`).
-
-**`secrets.env`** — API keys consumed by opencode-core and openmemory. Operators populate this with their provider keys. This file implements the Connections concept -- named credential sets managed via the admin API. Keys use the `OPENPALM_CONN_*` naming prefix.
-
-**`user.env`** — User-level environment variable overrides.
-
-### Volume Mount Map (Config)
-
-| Host Path | Container | Mount Point | Mode |
-|-----------|-----------|-------------|------|
-| `opencode-core/` | opencode-core | `/config` | rw |
-| `opencode-core/` | admin | `/app/config/opencode-core` | rw |
-| `caddy/Caddyfile` | caddy | `/etc/caddy/Caddyfile` | ro |
-| `caddy/` | admin | `/app/config/caddy` | rw |
-| `channels/` | admin | `/app/channel-env` | rw |
-| `channels/chat.env` | channel-chat | env_file | — |
-| `channels/discord.env` | channel-discord | env_file | — |
-| `channels/telegram.env` | channel-telegram | env_file | — |
-| `channels/voice.env` | channel-voice | env_file | — |
-| `cron/` | opencode-core | `/cron` | rw |
-| `secrets.env` | opencode-core | env_file | — |
-| `secrets.env` | openmemory | env_file | — |
-| `user.env` | opencode-core | env_file | — |
-| `user.env` | openmemory | env_file | — |
-| (entire config home) | admin | `/app/config-root` | rw |
+`OPENPALM_*_HOME` → `XDG_*_HOME/openpalm` → defaults.
 
----
+| Kind | Default | Env override | Purpose |
+|---|---|---|---|
+| Data | `~/.local/share/openpalm` | `OPENPALM_DATA_HOME` | Persistent service data + OpenCode user home |
+| Config | `~/.config/openpalm` | `OPENPALM_CONFIG_HOME` | User-editable config/env files |
+| State | `~/.local/state/openpalm` | `OPENPALM_STATE_HOME` | Runtime compose/workspace/state |
 
-## State Directory (`~/.local/state/openpalm`)
+## Directory trees created by installers
 
-Runtime state, disposable on reinstall.
+### Data (`$OPENPALM_DATA_HOME`)
 
-```
-~/.local/state/openpalm/
-├── docker-compose.yml     # Active compose file (copied from assets/state/)
-├── .env                   # Copy of the working directory .env
-├── opencode-core/         # OpenCode runtime state
-├── gateway/               # Gateway audit logs and runtime data
-├── caddy/                 # Caddy runtime config state
-├── workspace/             # OpenCode working directory (mounted as /work)
-├── observability/         # Logs and metrics (future)
-├── backups/               # Backup storage (future)
-└── uninstall.sh           # Uninstall script (copied from assets/state/scripts/)
-```
-
-### Volume Mount Map (State)
-
-| Host Path | Container | Mount Point | Mode |
-|-----------|-----------|-------------|------|
-| (entire state home) | admin | `/workspace` | rw |
-| (entire state home) | admin | `/workspace` | rw |
-| `opencode-core/` | opencode-core | `/state` | rw |
-| `gateway/` | gateway | `/app/data` | rw |
-| `caddy/` | caddy | `/config` | rw |
-| `workspace/` | opencode-core | `/work` | rw |
-
----
-
-## Container Socket Mounting
-
-The admin needs access to the host container runtime socket. The installer detects the runtime and configures the socket path.
-
-| Runtime | Host Socket Path | Container Mount Point |
-|---------|-----------------|----------------------|
-| Docker | `/var/run/docker.sock` | `/var/run/openpalm-container.sock` |
-| Podman (Linux) | `/run/user/$UID/podman/podman.sock` | `/var/run/openpalm-container.sock` |
-| Podman (macOS) | `/var/run/docker.sock` | `/var/run/openpalm-container.sock` |
-| OrbStack (macOS) | `~/.orbstack/run/docker.sock` | `/var/run/openpalm-container.sock` |
-
-Inside the admin, `OPENPALM_CONTAINER_SOCKET_URI` is always `unix:///var/run/openpalm-container.sock`. The admin sets both `DOCKER_HOST` and `CONTAINER_HOST` to this URI when spawning compose commands.
-
----
-
-## Network Ports and Bind Addresses
-
-| Port | Service | Default Bind | Override Variable |
-|------|---------|-------------|-------------------|
-| 80 | Caddy HTTP | `0.0.0.0` | `OPENPALM_INGRESS_BIND_ADDRESS` |
-| 443 | Caddy HTTPS | `0.0.0.0` | `OPENPALM_INGRESS_BIND_ADDRESS` |
-| 3000 | OpenMemory UI | `0.0.0.0` | `OPENPALM_OPENMEMORY_UI_BIND_ADDRESS` |
-| 4096 | OpenCode Core | `127.0.0.1` | `OPENCODE_CORE_BIND_ADDRESS` |
-| 8765 | OpenMemory API | `0.0.0.0` | `OPENPALM_OPENMEMORY_BIND_ADDRESS` |
-| 2222 | OpenCode SSH | `127.0.0.1` | `OPENCODE_CORE_SSH_BIND_ADDRESS` |
-
-Internal-only ports (not exposed to host): gateway (8080), admin (8100), admin (8090), channel adapters (8181–8184), postgres (5432), qdrant (6333/6334).
-
----
-
-## Service Architecture and Dependencies
-
-```
-caddy ──→ gateway ──→ opencode-core ──→ openmemory ──→ qdrant
-  │                                            │
-  │                                            └──→ postgres
-  ├──→ admin ──→ admin
-  │
-  └──→ openmemory-ui ──→ openmemory
-
-channel-chat ──→ gateway     (profile: channels)
-channel-discord ──→ gateway  (profile: channels)
-channel-voice ──→ gateway    (profile: channels)
-channel-telegram ──→ gateway (profile: channels)
-```
-
-Channel adapters are in the `channels` compose profile and are not started by default. Enable with `--profile channels`.
-
----
-
-## Extensions: Baked-In with Host Override
-
-Extensions follow a layered model:
-
-1. **Baked into images at build time** — `opencode/extensions/` is COPY'd to `/opt/openpalm/opencode-defaults/` in the `opencode-core` image. `gateway/opencode/` is COPY'd to `/opt/openpalm/opencode-defaults/` in the `gateway` image.
-
-2. **Host override layer (opencode-core only)** — `~/.config/openpalm/opencode-core/` is mounted at `/config`. If `/config/opencode.jsonc` exists, the entrypoint uses `/config` as the config directory. If missing, it copies baked-in defaults from `/opt/openpalm/opencode-defaults/` into `/config`.
-
-3. **Gateway has no host override** — the gateway's config is fully baked into its image with no host volume mount.
-
-Extensions are organized into subdirectories by type: `skills/`, `commands/`, `agents/`, `tools/`, `plugins/`.
-
-The installer does not seed extension files (plugins, skills, AGENTS.md). It seeds only an empty `opencode.jsonc` for user-level overrides.
-
----
-
-## Repository Asset Structure
-
-```
-assets/
-├── config/                    # User-editable config templates
-│   ├── channels/
-│   │   ├── chat.env
-│   │   ├── discord.env
-│   │   ├── telegram.env
-│   │   └── voice.env
-│   ├── secrets.env
-│   ├── ssh/
-│   │   └── authorized_keys
-│   ├── system.env
-│   └── user.env
-└── state/                     # Runtime state templates
-    ├── caddy/
-    │   └── Caddyfile
-    ├── content/
-    │   └── banner.png
-    ├── docker-compose.yml
-    ├── registry/              # Community extension registry
-    │   ├── README.md
-    │   ├── index.json
-    │   ├── openpalm-slack-channel.json
-    │   └── schema.json
-    └── scripts/
-        ├── extensions-cli.ts (wrapper to `openpalm extensions`)
-        ├── install.sh
-        ├── install.ps1
-        ├── uninstall.ps1
-        └── uninstall.sh
-```
-
-Extension source code lives in service directories (not in `assets/`):
-- `opencode/extensions/` — Core agent extensions
-- `gateway/opencode/` — Gateway agent extensions
-
----
-
-## Installation Flow
-
-1. Detect OS, CPU architecture, and container runtime.
-2. Bootstrap install assets from local `assets/` or download tarball from GitHub.
-3. Generate `.env` from `assets/config/system.env` with auto-generated secrets.
-4. Write resolved XDG paths and runtime config into `.env`.
-5. Create XDG directory trees.
-6. Copy `docker-compose.yml` and `.env` into the state directory.
-7. Seed default configs (seed-not-overwrite): empty `opencode.jsonc`, Caddyfile, channel envs, `secrets.env`, `user.env`.
-8. Copy uninstall script into state directory.
-9. Start core services via compose.
-10. Wait for admin health check, open setup UI in browser.
-
----
-
-## Uninstallation
-
-| Mode | Command | What It Does |
-|------|---------|-------------|
-| Default | `./uninstall.sh` | Stops containers, removes compose project |
-| Remove images | `./uninstall.sh --remove-images` | Also removes pulled/built images |
-| Remove all | `./uninstall.sh --remove-all` | Also removes all XDG directories |
+- `postgres/`
+- `qdrant/`
+- `openmemory/`
+- `shared/`
+- `caddy/`
+- `admin/`
+- `home/` (mounted as OpenCode HOME)
+
+### Config (`$OPENPALM_CONFIG_HOME`)
+
+- `caddy/`
+- `channels/`
+- `cron/`
+- `secrets/`
+- `secrets/gateway/`
+- `secrets/channels/`
+- plus root files like `secrets.env`, `user.env`
+
+### State (`$OPENPALM_STATE_HOME`)
+
+- `opencode-core/`
+- `gateway/`
+- `caddy/`
+- `workspace/`
+- `observability/`
+- `backups/`
+- root files like `docker-compose.yml`, `.env`, uninstall script
+
+## Volume mount normalization
+
+### OpenCode + Admin
+
+| Host path | Container | Mount |
+|---|---|---|
+| `${OPENPALM_DATA_HOME}/home` | `opencode-core` | `/home/opencode` |
+| `${OPENPALM_DATA_HOME}/home` | `admin` | `/app/home` |
+| `${OPENPALM_CONFIG_HOME}/cron` | `opencode-core` | `/cron` |
+| `${OPENPALM_STATE_HOME}/workspace` | `opencode-core` | `/work` |
+| `${OPENPALM_STATE_HOME}/opencode-core` | `opencode-core` | `/state` |
+
+### Other core services
+
+| Host path | Container | Mount |
+|---|---|---|
+| `${OPENPALM_DATA_HOME}/postgres` | `postgres` | `/var/lib/postgresql/data` |
+| `${OPENPALM_DATA_HOME}/qdrant` | `qdrant` | `/qdrant/storage` |
+| `${OPENPALM_DATA_HOME}/openmemory` | `openmemory` | `/data` |
+| `${OPENPALM_DATA_HOME}/shared` | `openmemory`, `opencode-core`, `admin` | `/shared` |
+| `${OPENPALM_DATA_HOME}/caddy` | `caddy` | `/data` |
+| `${OPENPALM_STATE_HOME}/caddy` | `caddy` | `/config` |
+
+## OpenCode config model
+
+- Core extensions are image-baked under `/opt/opencode`.
+- `OPENCODE_CONFIG_DIR=/opt/opencode` loads immutable OpenPalm-managed core extensions.
+- User-global OpenCode state persists in mounted HOME:
+  - `/home/opencode/.config/opencode/opencode.json`
+  - `/home/opencode/.config/opencode/plugins/`
+  - `/home/opencode/.cache/opencode/`
+  - `/home/opencode/.local/share/opencode/`
+
+So the host location for user-global OpenCode state is:
+
+`${OPENPALM_DATA_HOME}/home/`
+
+## Installer behavior
+
+Installers seed config templates without overwriting existing files:
+
+- Caddyfile
+- channel env files
+- secrets env templates
+- user env template
+
+They do **not** create or manage a legacy `config/opencode-core` override directory.

--- a/opencode/Dockerfile
+++ b/opencode/Dockerfile
@@ -3,12 +3,14 @@ FROM oven/bun:1.1.42
 RUN bun add -g opencode-ai@latest
 RUN apt-get update && apt-get install -y tini cron curl openssh-server nodejs git && rm -rf /var/lib/apt/lists/*
 
-WORKDIR /work
+# Core OpenPalm-managed OpenCode extensions (immutable).
+COPY extensions/ /opt/opencode/
 
-# Extensions (skills/, commands/, agents/, tools/, plugins/) are baked into the image from
-# opencode/extensions/ and installed to /opt/openpalm/opencode-defaults/ at build time.
-# At runtime, a host config volume may be mounted at /config to override defaults.
-COPY extensions/ /opt/openpalm/opencode-defaults/
+# Stable HOME mountpoint for user-global state.
+RUN mkdir -p /home/opencode /work \
+  && chmod 755 /home/opencode /work
+
+WORKDIR /work
 
 COPY entrypoint.sh /usr/local/bin/opencode-entrypoint.sh
 RUN chmod +x /usr/local/bin/opencode-entrypoint.sh

--- a/opencode/entrypoint.sh
+++ b/opencode/entrypoint.sh
@@ -1,50 +1,16 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-CONFIG_DIR="${OPENCODE_CONFIG_DIR:-/config}"
+# OpenPalm no longer copies/merges OpenCode config into a generated /config volume.
+# User-global config/plugins/cache/auth are persisted via mounted HOME.
+# Core OpenPalm-managed extensions are baked into /opt/opencode and loaded through
+# OPENCODE_CONFIG_DIR=/opt/opencode from compose.
 CRON_DIR="${CRON_DIR:-/cron}"
 PORT="${OPENCODE_PORT:-4096}"
 ENABLE_SSH="${OPENCODE_ENABLE_SSH:-0}"
 
-mkdir -p "$CONFIG_DIR"
 mkdir -p "$CRON_DIR"
 mkdir -p "$CRON_DIR/cron-payloads"
-
-# Default extensions are baked into the image at /opt/openpalm/opencode-defaults/.
-# If a host config volume is mounted at /config, it takes priority.
-# If /config is empty or missing opencode.jsonc, fall back to the baked-in defaults.
-BAKED_IN_DIR="/opt/openpalm/opencode-defaults"
-
-# Always merge baked-in extension directories into the active config dir.
-# cp -rn copies without overwriting, so host overrides are preserved.
-if [[ -d "$BAKED_IN_DIR" ]]; then
-  for item in "$BAKED_IN_DIR"/*/; do
-    [[ -d "$item" ]] && cp -rn "$item" "$CONFIG_DIR/" 2>/dev/null || true
-  done
-  # Copy non-config files (AGENTS.md, etc.)
-  for file in "$BAKED_IN_DIR"/*.md; do
-    [[ -f "$file" ]] && cp -n "$file" "$CONFIG_DIR/" 2>/dev/null || true
-  done
-fi
-
-# Only copy opencode.jsonc when it's completely absent.
-if [[ ! -f "$CONFIG_DIR/opencode.jsonc" ]]; then
-  if [[ -f "$BAKED_IN_DIR/opencode.jsonc" ]]; then
-    echo "No volume-mounted config found at $CONFIG_DIR; copying baked-in opencode.jsonc."
-    cp "$BAKED_IN_DIR/opencode.jsonc" "$CONFIG_DIR/opencode.jsonc"
-  else
-    echo "ERROR: No opencode.jsonc found at $CONFIG_DIR or $BAKED_IN_DIR."
-    exit 1
-  fi
-fi
-
-# Tell OpenCode where the config file lives.
-export OPENCODE_CONFIG="${OPENCODE_CONFIG:-$CONFIG_DIR/opencode.jsonc}"
-
-# Tell OpenCode where to discover plugins, skills, agents, etc.
-# OPENCODE_CONFIG_DIR is searched the same way as .opencode/ — it looks for
-# plugins/, skills/, agents/, commands/, tools/, modes/, and themes/ subdirs.
-export OPENCODE_CONFIG_DIR="${OPENCODE_CONFIG_DIR:-$CONFIG_DIR}"
 
 # Install crontab managed by admin (if present) and start cron daemon.
 if [[ -f "$CRON_DIR/crontab" ]]; then
@@ -57,21 +23,20 @@ fi
 cron
 
 if [[ "$ENABLE_SSH" == "1" ]]; then
-  SSH_DIR="$CONFIG_DIR/ssh"
+  SSH_DIR="${SSH_DIR:-/home/opencode/.config/opencode/ssh}"
   mkdir -p "$SSH_DIR" /run/sshd /root/.ssh
   [[ -f "$SSH_DIR/authorized_keys" ]] || touch "$SSH_DIR/authorized_keys"
   cp "$SSH_DIR/authorized_keys" /root/.ssh/authorized_keys
   chmod 700 /root/.ssh
   chmod 600 /root/.ssh/authorized_keys
-  cat > /etc/ssh/sshd_config.d/opencode.conf <<'EOF'
+  cat > /etc/ssh/sshd_config.d/opencode.conf <<'SSHEOF'
 PermitRootLogin prohibit-password
 PasswordAuthentication no
 KbdInteractiveAuthentication no
-EOF
+SSHEOF
   /usr/sbin/sshd
 fi
 
 cd /work
-export HOME=/work
 
 exec opencode web --hostname 0.0.0.0 --port "$PORT" --print-logs

--- a/packages/cli/src/commands/preflight.ts
+++ b/packages/cli/src/commands/preflight.ts
@@ -6,11 +6,11 @@ const envFile = ".env";
 
 const requiredDirs = [
   "config/caddy",
-  "config/opencode-core",
   "config/channels",
   "data/postgres",
   "data/qdrant",
   "data/openmemory",
+  "data/home",
   "state/workspace",
   "state/gateway",
 ];

--- a/packages/cli/test/paths.test.ts
+++ b/packages/cli/test/paths.test.ts
@@ -36,7 +36,7 @@ describe("paths", () => {
         await createDirectoryTree(xdg);
 
         // Verify data subdirectories
-        const dataDirs = ["postgres", "qdrant", "openmemory", "shared", "caddy", "admin"];
+        const dataDirs = ["postgres", "qdrant", "openmemory", "shared", "caddy", "admin", "home"];
         for (const dir of dataDirs) {
           const dirPath = join(xdg.data, dir);
           const stats = await stat(dirPath);
@@ -44,7 +44,7 @@ describe("paths", () => {
         }
 
         // Verify config subdirectories
-        const configDirs = ["opencode-core", "caddy", "channels", "cron"];
+        const configDirs = ["caddy", "channels", "cron"];
         for (const dir of configDirs) {
           const dirPath = join(xdg.config, dir);
           const stats = await stat(dirPath);

--- a/packages/lib/admin/stack-generator.test.ts
+++ b/packages/lib/admin/stack-generator.test.ts
@@ -11,6 +11,8 @@ describe("stack generator", () => {
     expect(out.composeFile).toContain("/caddy/routes:/etc/caddy/routes:ro");
     expect(out.composeFile).toContain("opencode-core:");
     expect(out.composeFile).toContain("${OPENPALM_STATE_HOME}/opencode-core:/state");
+    expect(out.composeFile).toContain("${OPENPALM_DATA_HOME}/home:/home/opencode");
+    expect(out.composeFile).toContain("user: \"${OPENPALM_UID:-1000}:${OPENPALM_GID:-1000}\"");
     expect(out.composeFile).toContain("${OPENPALM_DATA_HOME}/shared:/shared");
     expect(out.composeFile).toContain("gateway:");
     expect(out.composeFile).toContain("${OPENPALM_DATA_HOME}/admin:/app/data");
@@ -25,16 +27,9 @@ describe("stack generator", () => {
     expect(out.composeFile).not.toContain("channel-discord:");
   });
 
-  it("generates opencode plugin config and channel env artifacts", () => {
+  it("generates channel env artifacts", () => {
     const spec = createDefaultStackSpec();
     spec.channels.chat.config.CHAT_INBOUND_TOKEN = "chat-token";
-    spec.extensions.push({
-      id: "policy-plugin",
-      type: "plugin",
-      enabled: true,
-      pluginId: "@openpalm/policy-plugin",
-      connectionIds: [],
-    });
     const out = generateStackArtifacts(spec, {
       CHANNEL_CHAT_SECRET: "chat-secret",
       CHANNEL_DISCORD_SECRET: "discord-secret",
@@ -44,7 +39,5 @@ describe("stack generator", () => {
     expect(out.gatewayChannelSecretsEnv).toContain("CHANNEL_CHAT_SECRET=chat-secret");
     expect(out.channelSecretsEnv.chat).toContain("CHANNEL_CHAT_SECRET=chat-secret");
     expect(out.channelConfigEnv.chat).toContain("CHAT_INBOUND_TOKEN=chat-token");
-    expect(out.opencodePluginIds).toContain("@openpalm/policy-plugin");
-    expect(out.opencodePluginConfigJsonc).toContain("@openpalm/policy-plugin");
   });
 });

--- a/packages/lib/admin/stack-manager.test.ts
+++ b/packages/lib/admin/stack-manager.test.ts
@@ -15,9 +15,6 @@ describe("stack manager", () => {
     mkdirSync(join(secretsDir, "gateway"), { recursive: true });
     mkdirSync(join(secretsDir, "channels"), { recursive: true });
 
-    const opencodePath = join(dir, "opencode.jsonc");
-    writeFileSync(opencodePath, '{"$schema":"https://example/schema.json","provider":{"x":{}}}\n', "utf8");
-
     const manager = new StackManager({
       caddyfilePath: join(caddyDir, "Caddyfile"),
       caddyRoutesDir,
@@ -31,7 +28,6 @@ describe("stack manager", () => {
       openmemorySecretsPath: join(secretsDir, "openmemory", "openmemory.env"),
       postgresSecretsPath: join(secretsDir, "db", "postgres.env"),
       opencodeProviderSecretsPath: join(secretsDir, "opencode", "providers.env"),
-      opencodeConfigPath: opencodePath,
     });
 
     manager.upsertSecret("MY_NEW_SECRET", "abc123");
@@ -51,10 +47,6 @@ describe("stack manager", () => {
     expect(readFileSync(join(secretsDir, "channels", "chat.env"), "utf8")).toContain("CHANNEL_CHAT_SECRET=");
     expect(readFileSync(join(dir, "channel-config", "chat.env"), "utf8")).toContain("CHAT_INBOUND_TOKEN=abc");
 
-    const opencode = readFileSync(opencodePath, "utf8");
-    expect(opencode).toContain('"$schema"');
-    expect(opencode).toContain('"provider"');
-    expect(opencode).toContain("@openpalm/policy-plugin");
   });
 
   it("prevents deleting secrets that are in use", () => {
@@ -73,7 +65,6 @@ describe("stack manager", () => {
       openmemorySecretsPath: join(dir, "openmemory.env"),
       postgresSecretsPath: join(dir, "postgres.env"),
       opencodeProviderSecretsPath: join(dir, "providers.env"),
-      opencodeConfigPath: join(dir, "opencode.jsonc"),
     });
     expect(() => manager.deleteSecret("CHANNEL_CHAT_SECRET")).toThrow("secret_in_use");
   });
@@ -93,7 +84,6 @@ describe("stack manager", () => {
       openmemorySecretsPath: join(dir, "openmemory.env"),
       postgresSecretsPath: join(dir, "postgres.env"),
       opencodeProviderSecretsPath: join(dir, "providers.env"),
-      opencodeConfigPath: join(dir, "opencode.jsonc"),
     });
 
     const connection = manager.upsertConnection({
@@ -124,7 +114,6 @@ describe("stack manager", () => {
       openmemorySecretsPath: join(dir, "openmemory.env"),
       postgresSecretsPath: join(dir, "postgres.env"),
       opencodeProviderSecretsPath: join(dir, "providers.env"),
-      opencodeConfigPath: join(dir, "opencode.jsonc"),
     });
 
     manager.renderArtifacts();
@@ -152,7 +141,6 @@ describe("stack manager", () => {
       openmemorySecretsPath: join(dir, "openmemory.env"),
       postgresSecretsPath: join(dir, "postgres.env"),
       opencodeProviderSecretsPath: join(dir, "providers.env"),
-      opencodeConfigPath: join(dir, "opencode.jsonc"),
     });
 
     manager.upsertConnection({

--- a/packages/lib/src/detect-providers.ts
+++ b/packages/lib/src/detect-providers.ts
@@ -154,8 +154,11 @@ export function detectOpenAIKey(): DetectedProvider {
 export async function findExistingOpenCodeConfig(): Promise<string | null> {
   const home = homedir();
   const paths = [
+    `${home}/.config/opencode/opencode.json`,
     `${home}/.config/opencode/opencode.jsonc`,
+    `${home}/.opencode/opencode.json`,
     `${home}/.opencode/opencode.jsonc`,
+    "./opencode.json",
     "./opencode.jsonc",
   ];
 

--- a/packages/lib/src/paths.ts
+++ b/packages/lib/src/paths.ts
@@ -29,13 +29,13 @@ export function resolveXDGPaths(): XDGPaths {
 
 export async function createDirectoryTree(xdg: XDGPaths): Promise<void> {
   // Data subdirectories
-  const dataDirs = ["postgres", "qdrant", "openmemory", "shared", "caddy", "admin"];
+  const dataDirs = ["postgres", "qdrant", "openmemory", "shared", "caddy", "admin", "home"];
   for (const dir of dataDirs) {
     await mkdir(join(xdg.data, dir), { recursive: true });
   }
 
   // Config subdirectories
-  const configDirs = ["opencode-core", "caddy", "channels", "cron", "secrets", "secrets/gateway", "secrets/channels"];
+  const configDirs = ["caddy", "channels", "cron", "secrets", "secrets/gateway", "secrets/channels"];
   for (const dir of configDirs) {
     await mkdir(join(xdg.config, dir), { recursive: true });
   }


### PR DESCRIPTION
### Motivation

- Restore the previous, simpler host directory name `home` (instead of `opencode-home`) to match user preference while keeping the immutable core + mounted HOME architecture.
- Keep runtime behavior predictable by making compose mounts, installer scaffolding, admin defaults, docs, and tests consistent with the `home` naming.

### Description

- Replaced references to `${OPENPALM_DATA_HOME}/opencode-home` with `${OPENPALM_DATA_HOME}/home` and updated compose mounts so `opencode-core` mounts `.../home:/home/opencode` and `admin` mounts `.../home:/app/home` (files: `assets/state/docker-compose.yml`, `packages/lib/admin/stack-generator.ts`).
- Updated admin defaults and config helpers to use `/app/home/.config/opencode/opencode.json`, added `ensureOpencodeConfigPath()` and `setOpencodePluginEnabled()` to manage `opencode.json` and toggle plugins when installing/uninstalling via Admin (file: `admin/src/server.ts`).
- Adjusted installer scaffolding, path creation, and CLI preflight to create/check `data/home` (files: `assets/state/scripts/install.sh`, `assets/state/scripts/install.ps1`, `packages/lib/src/paths.ts`, `packages/cli/src/commands/preflight.ts`).
- Aligned runtime image layout and entrypoint to bake core extensions at `/opt/opencode` and treat `/home/opencode` as the persistent user HOME (files: `opencode/Dockerfile`, `opencode/entrypoint.sh`), and updated docs/tests/examples to reflect `home` naming.

### Testing

- Ran `bun test packages/lib/admin/stack-generator.test.ts packages/lib/admin/stack-manager.test.ts packages/cli/test/paths.test.ts packages/cli/test/install-methods.test.ts` and all tests passed (85 tests, 0 failures).
- Ran type checking via `bun run typecheck` (invokes `tsc`) and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998916167c48327abeda93f6df2a3a3)