### PR TITLE
Improve CLI release workflow and remove Windows ARM64 support

### DIFF
--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -39,6 +39,8 @@ jobs:
           node-version: "22"
           registry-url: "https://registry.npmjs.org"
 
+      - run: bun install --frozen-lockfile
+
       # Ensure npm is new enough for trusted publishing (>= 11.5.1)
       - name: Update npm
         run: npm install -g npm@latest
@@ -69,6 +71,7 @@ jobs:
     permissions:
       contents: read
     strategy:
+      fail-fast: false
       matrix:
         include:
           - target: bun-linux-x64
@@ -81,12 +84,10 @@ jobs:
             artifact: openpalm-darwin-arm64
           - target: bun-windows-x64
             artifact: openpalm-windows-x64.exe
-          - target: bun-windows-arm64
-            artifact: openpalm-windows-arm64.exe
     steps:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v2
-      - run: bun install
+      - run: bun install --frozen-lockfile
       - name: Build ${{ matrix.artifact }}
         run: bun build packages/cli/src/main.ts --compile --target=${{ matrix.target }} --outfile dist/${{ matrix.artifact }}
       - uses: actions/upload-artifact@v4
@@ -97,15 +98,28 @@ jobs:
   release:
     runs-on: ubuntu-latest
     needs: build-binaries
+    if: ${{ !cancelled() && needs.build-binaries.result != 'cancelled' }}
     permissions:
       contents: write
     steps:
+      - name: Resolve tag name
+        id: tag
+        run: |
+          REF="${GITHUB_REF#refs/tags/}"
+          echo "tag_name=${REF}" >> "$GITHUB_OUTPUT"
+
       - uses: actions/download-artifact@v4
         with:
           path: dist
           merge-multiple: true
+
+      - name: Generate checksums
+        working-directory: dist
+        run: sha256sum * > checksums-sha256.txt
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
+          tag_name: ${{ steps.tag.outputs.tag_name }}
           generate_release_notes: true
           files: dist/*

--- a/dev/version.ts
+++ b/dev/version.ts
@@ -70,13 +70,6 @@ export const COMPONENTS: Record<string, ComponentMeta> = {
     context: "packages/cli",
     packageJson: "packages/cli/package.json",
     image: false,
-    extraFiles: [
-      {
-        path: "packages/cli/src/main.ts",
-        pattern: /const VERSION = "[^"]+"/,
-        replacement: (v: string) => `const VERSION = "${v}"`,
-      },
-    ],
   },
 };
 

--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "cli:build:darwin-x64": "bun build packages/cli/src/main.ts --compile --target=bun-darwin-x64 --outfile dist/openpalm-darwin-x64",
     "cli:build:darwin-arm64": "bun build packages/cli/src/main.ts --compile --target=bun-darwin-arm64 --outfile dist/openpalm-darwin-arm64",
     "cli:build:windows-x64": "bun build packages/cli/src/main.ts --compile --target=bun-windows-x64 --outfile dist/openpalm-windows-x64.exe",
-    "cli:build:windows-arm64": "bun build packages/cli/src/main.ts --compile --target=bun-windows-arm64 --outfile dist/openpalm-windows-arm64.exe",
     "ver": "bun run dev/version.ts",
     "ver:status": "bun run dev/version.ts status",
     "ver:bump": "bun run dev/version.ts bump",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -34,8 +34,7 @@
     "build:linux-arm64": "bun build src/main.ts --compile --target=bun-linux-arm64 --outfile dist/openpalm-linux-arm64",
     "build:darwin-x64": "bun build src/main.ts --compile --target=bun-darwin-x64 --outfile dist/openpalm-darwin-x64",
     "build:darwin-arm64": "bun build src/main.ts --compile --target=bun-darwin-arm64 --outfile dist/openpalm-darwin-arm64",
-    "build:windows-x64": "bun build src/main.ts --compile --target=bun-windows-x64 --outfile dist/openpalm-windows-x64.exe",
-    "build:windows-arm64": "bun build src/main.ts --compile --target=bun-windows-arm64 --outfile dist/openpalm-windows-arm64.exe"
+    "build:windows-x64": "bun build src/main.ts --compile --target=bun-windows-x64 --outfile dist/openpalm-windows-x64.exe"
   },
   "dependencies": {
     "@openpalm/lib": "workspace:*"


### PR DESCRIPTION
## Summary
This PR refines the CLI release and build process by improving workflow reliability, removing Windows ARM64 support, and simplifying version management.

## Key Changes

- **Workflow improvements:**
  - Added `bun install --frozen-lockfile` to ensure reproducible builds
  - Added `fail-fast: false` to build matrix to allow all platforms to complete even if one fails
  - Added explicit tag name resolution in release job
  - Added SHA256 checksum generation for release artifacts
  - Added conditional check to prevent release job from running if build is cancelled

- **Platform support:**
  - Removed Windows ARM64 build target from CI/CD pipeline
  - Removed `build:windows-arm64` script from both root and CLI package.json files

- **Version management:**
  - Removed automatic version file patching from the version management system (removed `extraFiles` configuration for `packages/cli/src/main.ts`)
  - This simplifies the versioning process by relying on package.json as the single source of truth

## Implementation Details

The release workflow now explicitly extracts the tag name from the git reference and uses it when creating the GitHub release, ensuring consistency between the git tag and the release. The addition of checksum generation provides integrity verification for downloaded binaries.

The removal of Windows ARM64 support aligns with reducing maintenance burden while focusing on the most commonly used platforms (x64 and ARM64 for macOS/Linux).

https://claude.ai/code/session_01Um1J387zfwp4Z9fn2YQ9Nu