### PR TITLE
test(ui): tighten setup command pre-auth skip condition

### DIFF
--- a/packages/ui/e2e/08-command-api.pw.ts
+++ b/packages/ui/e2e/08-command-api.pw.ts
@@ -1,11 +1,21 @@
 import { test, expect } from '@playwright/test';
-import { cmd } from './helpers';
+import { authedGet, cmd } from './helpers';
 
 test.describe('command endpoint coverage', () => {
 	test('setup commands allow unauthenticated local requests before setup is complete', async ({
 		request
 	}) => {
 		const status = await request.get('/setup/status');
+		if (status.status() === 401) {
+			const authedStatus = await authedGet(request, '/setup/status');
+			expect(authedStatus.status()).toBe(200);
+			const authedSetup = await authedStatus.json();
+			expect(authedSetup.completed).toBe(true);
+			test.skip(
+				true,
+				'Instance is already configured; setup status requires auth after completion.'
+			);
+		}
 		expect(status.status()).toBe(200);
 		const setup = await status.json();
 		test.skip(setup.completed === true, 'Instance is already configured; setup commands require auth.');


### PR DESCRIPTION
### Motivation
- Prevent masking real auth regressions by the previous test that skipped immediately on an unauthenticated `GET /setup/status` `401` response.
- Ensure `401` is only accepted when the instance is actually already configured (`completed === true`).
- Preserve first-boot behavior where an unauthenticated `GET /setup/status` must return `200` and allow the setup command flow.

### Description
- Modify `packages/ui/e2e/08-command-api.pw.ts` to import `authedGet` from `packages/ui/e2e/helpers.ts`.
- When an unauthenticated `GET /setup/status` returns `401`, perform an authenticated `GET /setup/status`, assert the response is `200` and `completed === true`, then call `test.skip(...)`.
- Keep the original path unchanged for the `200` case so the setup command flow still runs on first-boot.

### Testing
- Ran `cd packages/ui && bun x playwright test e2e/08-command-api.pw.ts` and the tests in that file passed.
- Ran the full suite with `bun run test:ui`, and API tests passed but browser-based Playwright suites failed in this environment due to missing Playwright browser executables (`chromium_headless_shell`).
- The change ensures the specific regression (silent skip on `401`) is detected by asserting the authenticated status before skipping.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699bae8ebc448327b31ce2812c2fe291)