### PR TITLE
task: create shared setup completion orchestrator

### DIFF
--- a/packages/ui/src/lib/server/setup-completion-response.test.ts
+++ b/packages/ui/src/lib/server/setup-completion-response.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it, mock } from 'bun:test';
+import { completeSetupCommandResponse, completeSetupRouteResponse } from './setup-completion-response';
+
+describe('setup completion response helpers', () => {
+	it('builds command response and calls orchestrator once', async () => {
+		const secretsEnvPath = '/tmp/config/secrets.env';
+		const completeSetup = mock(async () => ({
+			state: { completed: true },
+			apply: { ok: true, generated: {}, warnings: [] }
+		}));
+
+		const result = await completeSetupCommandResponse(
+			{} as never,
+			{} as never,
+			secretsEnvPath,
+			completeSetup as never
+		);
+
+		expect(completeSetup).toHaveBeenCalledTimes(1);
+		expect(completeSetup).toHaveBeenCalledWith({} as never, {} as never, { secretsEnvPath });
+		expect(result.ok).toBeTrue();
+		expect(result.data.completed).toBeTrue();
+		expect(result.apply.ok).toBeTrue();
+	});
+
+	it('builds setup route response and calls orchestrator once', async () => {
+		const secretsEnvPath = '/tmp/config/secrets.env';
+		const completeSetup = mock(async () => ({
+			state: { completed: true },
+			apply: { ok: true, generated: {}, warnings: [] }
+		}));
+
+		const result = await completeSetupRouteResponse(
+			{} as never,
+			{} as never,
+			secretsEnvPath,
+			completeSetup as never
+		);
+
+		expect(completeSetup).toHaveBeenCalledTimes(1);
+		expect(completeSetup).toHaveBeenCalledWith({} as never, {} as never, { secretsEnvPath });
+		expect(result.ok).toBeTrue();
+		expect(result.state.completed).toBeTrue();
+		expect(result.apply.ok).toBeTrue();
+	});
+});

--- a/packages/ui/src/lib/server/setup-completion-response.ts
+++ b/packages/ui/src/lib/server/setup-completion-response.ts
@@ -1,0 +1,25 @@
+import type { SetupManager } from '@openpalm/lib/admin/setup-manager';
+import type { StackManager } from '@openpalm/lib/admin/stack-manager';
+import { completeSetupOrchestration } from './setup-completion';
+
+type CompleteSetupFn = typeof completeSetupOrchestration;
+
+export async function completeSetupCommandResponse(
+	setupManager: SetupManager,
+	stackManager: StackManager,
+	secretsEnvPath: string,
+	completeSetup: CompleteSetupFn = completeSetupOrchestration
+) {
+	const result = await completeSetup(setupManager, stackManager, { secretsEnvPath });
+	return { ok: true as const, data: result.state, apply: result.apply };
+}
+
+export async function completeSetupRouteResponse(
+	setupManager: SetupManager,
+	stackManager: StackManager,
+	secretsEnvPath: string,
+	completeSetup: CompleteSetupFn = completeSetupOrchestration
+) {
+	const result = await completeSetup(setupManager, stackManager, { secretsEnvPath });
+	return { ok: true as const, state: result.state, apply: result.apply };
+}

--- a/packages/ui/src/lib/server/setup-completion.test.ts
+++ b/packages/ui/src/lib/server/setup-completion.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it, mock } from 'bun:test';
+import { completeSetupOrchestration } from './setup-completion';
+
+describe('setup-completion orchestrator', () => {
+	it('writes POSTGRES_PASSWORD when missing before stack apply', async () => {
+		const applyResult = { ok: true, generated: {}, warnings: [] } as never;
+		const existsSyncMock = mock(() => false);
+		const readFileSyncMock = mock(() => '');
+		const parseRuntimeEnvContentMock = mock(() => ({}));
+		const updateRuntimeEnvContentMock = mock(() => 'POSTGRES_PASSWORD=generated-token\n');
+		const generateTokenMock = mock(() => 'generated-token');
+		const mkdirSyncMock = mock(() => undefined);
+		const dirnameMock = mock(() => '/tmp/config');
+		const writeFileSyncMock = mock(() => undefined);
+		const applyStackMock = mock(async () => applyResult);
+		const composeActionMock = mock(async () => ({ ok: true, stdout: '', stderr: '' }));
+		const syncAutomationsMock = mock(() => undefined);
+		const completeSetupMock = mock(() => ({ completed: true }));
+		const listAutomationsMock = mock(() => [{ id: 'auto-1' }]);
+
+		const result = await completeSetupOrchestration(
+			{ completeSetup: completeSetupMock } as never,
+			{ listAutomations: listAutomationsMock } as never,
+			({
+				secretsEnvPath: '/tmp/config/secrets.env',
+				existsSync: existsSyncMock,
+				readFileSync: readFileSyncMock,
+				parseRuntimeEnvContent: parseRuntimeEnvContentMock,
+				updateRuntimeEnvContent: updateRuntimeEnvContentMock,
+				generateToken: generateTokenMock,
+				mkdirSync: mkdirSyncMock,
+				dirname: dirnameMock,
+				writeFileSync: writeFileSyncMock,
+				applyStack: applyStackMock,
+				composeAction: composeActionMock,
+				syncAutomations: syncAutomationsMock
+			} as never)
+		);
+
+		expect(generateTokenMock).toHaveBeenCalledWith(32);
+		expect(writeFileSyncMock).toHaveBeenCalledTimes(1);
+		expect(applyStackMock).toHaveBeenCalledTimes(1);
+		expect(composeActionMock).toHaveBeenCalledTimes(1);
+		expect(syncAutomationsMock).toHaveBeenCalledTimes(1);
+		expect(completeSetupMock).toHaveBeenCalledTimes(1);
+		expect(result.apply).toBe(applyResult);
+		expect(result.state.completed).toBeTrue();
+	});
+
+	it('skips POSTGRES_PASSWORD write when already configured', async () => {
+		const writeFileSyncMock = mock(() => undefined);
+
+		await completeSetupOrchestration(
+			{ completeSetup: () => ({ completed: true }) } as never,
+			{ listAutomations: () => [] } as never,
+			({
+				secretsEnvPath: '/tmp/config/secrets.env',
+				existsSync: () => true,
+				readFileSync: () => 'POSTGRES_PASSWORD=already-set\n',
+				parseRuntimeEnvContent: () => ({ POSTGRES_PASSWORD: 'already-set' }),
+				updateRuntimeEnvContent: () => 'unused',
+				generateToken: () => 'unused',
+				mkdirSync: () => undefined,
+				dirname: () => '/tmp/config',
+				writeFileSync: writeFileSyncMock,
+				applyStack: async () => ({ ok: true }),
+				composeAction: async () => ({ ok: true, stdout: '', stderr: '' }),
+				syncAutomations: () => undefined
+			} as never)
+		);
+
+		expect(writeFileSyncMock).not.toHaveBeenCalled();
+	});
+
+	it('throws when startup compose action fails', async () => {
+		expect(
+			completeSetupOrchestration(
+				{ completeSetup: () => ({ completed: true }) } as never,
+				{ listAutomations: () => [] } as never,
+				({
+					secretsEnvPath: '/tmp/config/secrets.env',
+					existsSync: () => true,
+					readFileSync: () => 'POSTGRES_PASSWORD=already-set\n',
+					parseRuntimeEnvContent: () => ({ POSTGRES_PASSWORD: 'already-set' }),
+					updateRuntimeEnvContent: () => 'unused',
+					generateToken: () => 'unused',
+					mkdirSync: () => undefined,
+					dirname: () => '/tmp/config',
+					writeFileSync: () => undefined,
+					applyStack: async () => ({ ok: true }),
+					composeAction: async () => ({ ok: false, stdout: '', stderr: 'compose failed' }),
+					syncAutomations: () => undefined
+				} as never)
+			)
+		).rejects.toThrow('core_startup_failed:compose failed');
+	});
+});

--- a/packages/ui/src/lib/server/setup-completion.ts
+++ b/packages/ui/src/lib/server/setup-completion.ts
@@ -1,0 +1,78 @@
+import type { SetupManager } from '@openpalm/lib/admin/setup-manager';
+import type { StackManager } from '@openpalm/lib/admin/stack-manager';
+import { applyStack } from '@openpalm/lib/admin/stack-apply-engine';
+import { composeAction } from '@openpalm/lib/admin/compose-runner';
+import { syncAutomations } from '@openpalm/lib/admin/automations';
+import { parseRuntimeEnvContent, updateRuntimeEnvContent } from '@openpalm/lib/admin/runtime-env';
+import { generateToken } from '@openpalm/lib/tokens';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname } from 'node:path';
+
+const SetupCoreServices = [
+	'caddy',
+	'assistant',
+	'gateway',
+	'openmemory',
+	'openmemory-ui',
+	'postgres',
+	'qdrant'
+] as const;
+
+type SetupCompletionDependencies = {
+	secretsEnvPath: string;
+	existsSync: typeof existsSync;
+	readFileSync: typeof readFileSync;
+	parseRuntimeEnvContent: typeof parseRuntimeEnvContent;
+	updateRuntimeEnvContent: typeof updateRuntimeEnvContent;
+	generateToken: typeof generateToken;
+	mkdirSync: typeof mkdirSync;
+	dirname: typeof dirname;
+	writeFileSync: typeof writeFileSync;
+	applyStack: typeof applyStack;
+	composeAction: typeof composeAction;
+	syncAutomations: typeof syncAutomations;
+};
+
+const defaultDependencies: SetupCompletionDependencies = {
+	secretsEnvPath: '/config/secrets.env',
+	existsSync,
+	readFileSync,
+	parseRuntimeEnvContent,
+	updateRuntimeEnvContent,
+	generateToken,
+	mkdirSync,
+	dirname,
+	writeFileSync,
+	applyStack,
+	composeAction,
+	syncAutomations
+};
+
+function ensurePostgresPassword(dependencies: SetupCompletionDependencies) {
+	const current = dependencies.existsSync(dependencies.secretsEnvPath)
+		? dependencies.readFileSync(dependencies.secretsEnvPath, 'utf8')
+		: '';
+	const existingSecrets = dependencies.parseRuntimeEnvContent(current);
+	if (existingSecrets.POSTGRES_PASSWORD) return;
+
+	const next = dependencies.updateRuntimeEnvContent(current, {
+		POSTGRES_PASSWORD: dependencies.generateToken(32)
+	});
+	dependencies.mkdirSync(dependencies.dirname(dependencies.secretsEnvPath), { recursive: true });
+	dependencies.writeFileSync(dependencies.secretsEnvPath, next, 'utf8');
+}
+
+export async function completeSetupOrchestration(
+	setupManager: SetupManager,
+	stackManager: StackManager,
+	overrides: Partial<SetupCompletionDependencies> = {}
+) {
+	const dependencies = { ...defaultDependencies, ...overrides };
+	ensurePostgresPassword(dependencies);
+	const apply = await dependencies.applyStack(stackManager);
+	const startup = await dependencies.composeAction('up', [...SetupCoreServices]);
+	if (!startup.ok) throw new Error(`core_startup_failed:${startup.stderr}`);
+	dependencies.syncAutomations(stackManager.listAutomations());
+	const state = setupManager.completeSetup();
+	return { state, apply };
+}

--- a/packages/ui/src/routes/command/command-setup-flow.test.ts
+++ b/packages/ui/src/routes/command/command-setup-flow.test.ts
@@ -3,6 +3,12 @@ import { describe, expect, it } from 'bun:test';
 const commandFile = new URL('./+server.ts', import.meta.url).pathname;
 
 describe('command/+server.ts — setup flow safeguards', () => {
+	it('setup.complete delegates to shared completion orchestrator', async () => {
+		const content = await Bun.file(commandFile).text();
+		expect(content).toContain("import { completeSetupCommandResponse } from '$lib/server/setup-completion-response';");
+		expect(content).toContain('await completeSetupCommandResponse(setupManager, stackManager, SECRETS_ENV_PATH)');
+	});
+
 	it('setup.channels updates stack spec enabled flags', async () => {
 		const content = await Bun.file(commandFile).text();
 		expect(content).toContain("const spec = stackManager.getSpec();");

--- a/packages/ui/src/routes/setup/complete/+server.ts
+++ b/packages/ui/src/routes/setup/complete/+server.ts
@@ -1,18 +1,9 @@
 import { json, unauthorizedJson, errorJson } from '$lib/server/json';
 import { getSetupManager, getStackManager } from '$lib/server/init';
 import { isLocalRequest } from '$lib/server/auth';
-import { readSecretsEnv } from '$lib/server/env-helpers';
-import { applyStack } from '@openpalm/lib/admin/stack-apply-engine';
-import { composeAction } from '@openpalm/lib/admin/compose-runner';
-import { syncAutomations } from '@openpalm/lib/admin/automations';
-import { updateRuntimeEnvContent } from '@openpalm/lib/admin/runtime-env';
-import { generateToken } from '@openpalm/lib/tokens';
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
-import { dirname } from 'node:path';
+import { completeSetupRouteResponse } from '$lib/server/setup-completion-response';
 import { SECRETS_ENV_PATH } from '$lib/server/config';
 import type { RequestHandler } from './$types';
-
-const CoreStartupServices = ['caddy', 'assistant', 'gateway', 'openmemory', 'openmemory-ui', 'postgres', 'qdrant'] as const;
 
 export const POST: RequestHandler = async ({ locals, request }) => {
 	const setupManager = await getSetupManager();
@@ -26,21 +17,7 @@ export const POST: RequestHandler = async ({ locals, request }) => {
 	}
 
 	try {
-		// Auto-generate POSTGRES_PASSWORD if not already set (required for compose interpolation).
-		// Write synchronously so it is available when applyStack reads secrets.
-		const existingSecrets = readSecretsEnv();
-		if (!existingSecrets.POSTGRES_PASSWORD) {
-			const current = existsSync(SECRETS_ENV_PATH) ? readFileSync(SECRETS_ENV_PATH, 'utf8') : '';
-			const next = updateRuntimeEnvContent(current, { POSTGRES_PASSWORD: generateToken(32) });
-			mkdirSync(dirname(SECRETS_ENV_PATH), { recursive: true });
-			writeFileSync(SECRETS_ENV_PATH, next, 'utf8');
-		}
-		const applyResult = await applyStack(stackManager);
-		const startupResult = await composeAction('up', [...CoreStartupServices]);
-		if (!startupResult.ok) throw new Error(`core_startup_failed:${startupResult.stderr}`);
-		syncAutomations(stackManager.listAutomations());
-		const state = setupManager.completeSetup();
-		return json(200, { ok: true, state, apply: applyResult });
+		return json(200, await completeSetupRouteResponse(setupManager, stackManager, SECRETS_ENV_PATH));
 	} catch (error) {
 		const message = error instanceof Error ? error.message : String(error);
 		if (message.startsWith('secret_validation_failed:')) {

--- a/packages/ui/src/routes/setup/complete/setup-completion-orchestrator.test.ts
+++ b/packages/ui/src/routes/setup/complete/setup-completion-orchestrator.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from 'bun:test';
+
+const setupCompleteFile = new URL('./+server.ts', import.meta.url).pathname;
+
+describe('setup/complete/+server.ts — shared completion orchestrator', () => {
+	it('delegates setup completion through completeSetupOrchestration', async () => {
+		const content = await Bun.file(setupCompleteFile).text();
+		expect(content).toContain("import { completeSetupRouteResponse } from '$lib/server/setup-completion-response';");
+		expect(content).toContain('await completeSetupRouteResponse(setupManager, stackManager, SECRETS_ENV_PATH)');
+	});
+});


### PR DESCRIPTION
## Summary
- centralize setup completion orchestration in `packages/ui/src/lib/server/setup-completion.ts` and reuse it through response helpers for both `/command` `setup.complete` and `/setup/complete`
- preserve endpoint-specific response contracts while removing duplicated stack-apply/core-startup logic
- add behavior and delegation tests for orchestration and completion response helpers; keep setup flow route assertions aligned

## Validation
- `bun test src/lib/server/setup-completion.test.ts src/lib/server/setup-completion-response.test.ts src/routes/command/command-setup-flow.test.ts src/routes/setup/complete/setup-completion-orchestrator.test.ts`
- `bun test --timeout 30000 test/api/03-setup-api.test.ts test/api/08-command-api.test.ts`

## Task Tracking
- task plan reference: `.plans/tasks.json`
- all tasks in `.plans/tasks.json` are marked `\"completed\"`