### PR TITLE
feat(release): add ARM64/Apple Silicon support to Docker image builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,6 +134,9 @@ jobs:
         with:
           ref: ${{ needs.prepare-tag.outputs.tag }}
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -157,6 +160,7 @@ jobs:
         with:
           context: .
           file: ${{ matrix.dockerfile }}
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Add QEMU emulation and multi-platform build targets (linux/amd64, linux/arm64) so published Docker images include Apple Silicon manifests.

https://claude.ai/code/session_01Qx5wnz8Gowze72Suq2XdHY