### PR TITLE
refactor: extract kiosk ISO heredocs into standalone files under scri…

### DIFF
--- a/docs/debian13-kiosk-iso.md
+++ b/docs/debian13-kiosk-iso.md
@@ -12,7 +12,7 @@ This guide creates a Debian 13 (trixie) kiosk ISO for Raspberry Pi class hardwar
 
 ## What this produces
 
-The build script `scripts/build-debian13-kiosk-iso.sh` composes a live-build tree and outputs:
+The build script `scripts/iso/build-debian13-kiosk-iso.sh` composes a live-build tree and outputs:
 
 - `.build/out/openpalm-debian13-kiosk-<arch>.iso`
 
@@ -49,13 +49,13 @@ KIOSK_USER=operator \
 KIOSK_PASSWORD='ChangeMeNow123!' \
 OPENPALM_ADMIN_URL='http://127.0.0.1:8100' \
 DEBIAN_ARCH=arm64 \
-./scripts/build-debian13-kiosk-iso.sh
+./scripts/iso/build-debian13-kiosk-iso.sh
 ```
 
 For standard x86_64 systems:
 
 ```bash
-DEBIAN_ARCH=amd64 ./scripts/build-debian13-kiosk-iso.sh
+DEBIAN_ARCH=amd64 ./scripts/iso/build-debian13-kiosk-iso.sh
 ```
 
 ### Optional overrides

--- a/scripts/iso/files/bin/openpalm-bootstrap.sh
+++ b/scripts/iso/files/bin/openpalm-bootstrap.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+OPENPALM_HOME='/opt/openpalm'
+export OPENPALM_CONFIG_HOME='/var/lib/openpalm/config'
+export OPENPALM_STATE_HOME='/var/lib/openpalm/state'
+export OPENPALM_DATA_HOME='/var/lib/openpalm/data'
+export OPENPALM_WORK_DIR='/var/lib/openpalm/work'
+
+mkdir -p "$OPENPALM_CONFIG_HOME" "$OPENPALM_STATE_HOME" "$OPENPALM_DATA_HOME" "$OPENPALM_WORK_DIR"
+
+if [[ ! -f "$OPENPALM_CONFIG_HOME/secrets.env" ]]; then
+  cp "$OPENPALM_HOME/assets/secrets.env" "$OPENPALM_CONFIG_HOME/secrets.env"
+  chmod 600 "$OPENPALM_CONFIG_HOME/secrets.env"
+fi
+
+if [[ ! -f "$OPENPALM_CONFIG_HOME/Caddyfile" ]]; then
+  cp "$OPENPALM_HOME/assets/Caddyfile" "$OPENPALM_CONFIG_HOME/Caddyfile"
+fi
+
+if [[ ! -f "$OPENPALM_STATE_HOME/docker-compose.yml" ]]; then
+  cp "$OPENPALM_HOME/assets/docker-compose.yml" "$OPENPALM_STATE_HOME/docker-compose.yml"
+fi
+
+if [[ ! -d "$OPENPALM_CONFIG_HOME/channels" ]]; then
+  mkdir -p "$OPENPALM_CONFIG_HOME/channels"
+fi
+
+if [[ -f "$OPENPALM_HOME/image-cache/openpalm-images.tar.zst" && ! -f /var/lib/openpalm/.images-loaded ]]; then
+  zstd -dc "$OPENPALM_HOME/image-cache/openpalm-images.tar.zst" | docker load
+  touch /var/lib/openpalm/.images-loaded
+fi
+
+cd "$OPENPALM_STATE_HOME"
+docker compose --env-file "$OPENPALM_CONFIG_HOME/secrets.env" -f "$OPENPALM_STATE_HOME/docker-compose.yml" up -d

--- a/scripts/iso/files/bin/openpalm-kiosk-session.sh
+++ b/scripts/iso/files/bin/openpalm-kiosk-session.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+xset -dpms
+xset s off
+xset s noblank
+
+exec chromium --kiosk --noerrdialogs --disable-infobars __OPENPALM_ADMIN_URL__

--- a/scripts/iso/files/hooks/0100-openpalm-configure.chroot
+++ b/scripts/iso/files/hooks/0100-openpalm-configure.chroot
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+useradd -m -s /bin/bash '__KIOSK_USER__'
+echo '__KIOSK_USER__:__KIOSK_PASSWORD__' | chpasswd
+chage -d 0 '__KIOSK_USER__'
+usermod -aG docker '__KIOSK_USER__'
+
+chmod +x /usr/local/bin/openpalm-kiosk-session.sh /usr/local/bin/openpalm-bootstrap.sh
+systemctl enable lightdm.service
+systemctl enable docker.service
+systemctl enable openpalm-stack.service
+systemctl enable openpalm-stack.timer
+
+cat > /etc/apt/apt.conf.d/52openpalm-auto-upgrades <<'APTCONF'
+APT::Periodic::Update-Package-Lists "1";
+APT::Periodic::Unattended-Upgrade "1";
+APT::Periodic::AutocleanInterval "7";
+Unattended-Upgrade::Automatic-Reboot "true";
+Unattended-Upgrade::Automatic-Reboot-Time "03:30";
+APTCONF

--- a/scripts/iso/files/lightdm/50-openpalm.conf
+++ b/scripts/iso/files/lightdm/50-openpalm.conf
@@ -1,0 +1,4 @@
+[Seat:*]
+user-session=openpalm-kiosk
+greeter-hide-users=false
+allow-guest=false

--- a/scripts/iso/files/package-lists/openpalm-kiosk.list.chroot
+++ b/scripts/iso/files/package-lists/openpalm-kiosk.list.chroot
@@ -1,0 +1,13 @@
+lightdm
+xserver-xorg-core
+xinit
+openbox
+chromium
+x11-xserver-utils
+docker.io
+docker-compose-v2
+ca-certificates
+curl
+git
+unattended-upgrades
+apt-listchanges

--- a/scripts/iso/files/systemd/openpalm-stack.service
+++ b/scripts/iso/files/systemd/openpalm-stack.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Ensure OpenPalm stack is running
+After=network-online.target docker.service
+Wants=network-online.target docker.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/local/bin/openpalm-bootstrap.sh
+
+[Install]
+WantedBy=multi-user.target

--- a/scripts/iso/files/systemd/openpalm-stack.timer
+++ b/scripts/iso/files/systemd/openpalm-stack.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Periodic OpenPalm stack reconciliation
+
+[Timer]
+OnBootSec=2min
+OnUnitActiveSec=5min
+Unit=openpalm-stack.service
+
+[Install]
+WantedBy=timers.target

--- a/scripts/iso/files/xsessions/openpalm-kiosk.desktop
+++ b/scripts/iso/files/xsessions/openpalm-kiosk.desktop
@@ -1,0 +1,6 @@
+[Desktop Entry]
+Name=OpenPalm Kiosk
+Comment=OpenPalm admin kiosk session
+Exec=/usr/local/bin/openpalm-kiosk-session.sh
+Type=Application
+DesktopNames=OpenPalmKiosk


### PR DESCRIPTION
…pts/iso

Move build-debian13-kiosk-iso.sh into scripts/iso/ and extract all inline heredocs into separate template files under scripts/iso/files/. The build script now copies or renders these files (substituting placeholders like __KIOSK_USER__) instead of emitting them with cat.

This makes individual config files (systemd units, lightdm config, package lists, hooks, session scripts) independently editable and reviewable without wading through the monolithic build script.

https://claude.ai/code/session_01M4K8bFWvXp4TAvBsKFXR2p