### PR TITLE
test: comprehensive unit tests for admin src/lib (231 tests, 93.8% coverage)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ core/admin/build/
 core/admin/.env
 core/admin/.env.local
 core/admin/test-results/.last-run.json
+core/admin/coverage/

--- a/bun.lock
+++ b/bun.lock
@@ -4,6 +4,9 @@
   "workspaces": {
     "": {
       "name": "op-mvp",
+      "devDependencies": {
+        "@vitest/coverage-v8": "^4.0.18",
+      },
     },
     "channels/api": {
       "name": "@openpalm/channel-api",
@@ -75,6 +78,16 @@
     },
   },
   "packages": {
+    "@babel/helper-string-parser": ["@babel/helper-string-parser@7.27.1", "", {}, "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA=="],
+
+    "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
+
+    "@babel/parser": ["@babel/parser@7.29.0", "", { "dependencies": { "@babel/types": "^7.29.0" }, "bin": "./bin/babel-parser.js" }, "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww=="],
+
+    "@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
+
+    "@bcoe/v8-coverage": ["@bcoe/v8-coverage@1.0.2", "", {}, "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA=="],
+
     "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.3", "", { "os": "aix", "cpu": "ppc64" }, "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg=="],
 
     "@esbuild/android-arm": ["@esbuild/android-arm@0.27.3", "", { "os": "android", "cpu": "arm" }, "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA=="],
@@ -295,6 +308,8 @@
 
     "@vitest/browser-playwright": ["@vitest/browser-playwright@4.0.18", "", { "dependencies": { "@vitest/browser": "4.0.18", "@vitest/mocker": "4.0.18", "tinyrainbow": "^3.0.3" }, "peerDependencies": { "playwright": "*", "vitest": "4.0.18" } }, "sha512-gfajTHVCiwpxRj1qh0Sh/5bbGLG4F/ZH/V9xvFVoFddpITfMta9YGow0W6ZpTTORv2vdJuz9TnrNSmjKvpOf4g=="],
 
+    "@vitest/coverage-v8": ["@vitest/coverage-v8@4.0.18", "", { "dependencies": { "@bcoe/v8-coverage": "^1.0.2", "@vitest/utils": "4.0.18", "ast-v8-to-istanbul": "^0.3.10", "istanbul-lib-coverage": "^3.2.2", "istanbul-lib-report": "^3.0.1", "istanbul-reports": "^3.2.0", "magicast": "^0.5.1", "obug": "^2.1.1", "std-env": "^3.10.0", "tinyrainbow": "^3.0.3" }, "peerDependencies": { "@vitest/browser": "4.0.18", "vitest": "4.0.18" }, "optionalPeers": ["@vitest/browser"] }, "sha512-7i+N2i0+ME+2JFZhfuz7Tg/FqKtilHjGyGvoHYQ6iLV0zahbsJ9sljC9OcFcPDbhYKCet+sG8SsVqlyGvPflZg=="],
+
     "@vitest/expect": ["@vitest/expect@4.0.18", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "@types/chai": "^5.2.2", "@vitest/spy": "4.0.18", "@vitest/utils": "4.0.18", "chai": "^6.2.1", "tinyrainbow": "^3.0.3" } }, "sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ=="],
 
     "@vitest/mocker": ["@vitest/mocker@4.0.18", "", { "dependencies": { "@vitest/spy": "4.0.18", "estree-walker": "^3.0.3", "magic-string": "^0.30.21" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^6.0.0 || ^7.0.0-0" }, "optionalPeers": ["msw", "vite"] }, "sha512-HhVd0MDnzzsgevnOWCBj5Otnzobjy5wLBe4EdeeFGv8luMsGcYqDuFRMcttKWZA5vVO8RFjexVovXvAM4JoJDQ=="],
@@ -322,6 +337,8 @@
     "aria-query": ["aria-query@5.3.1", "", {}, "sha512-Z/ZeOgVl7bcSYZ/u/rh0fOpvEpq//LZmdbkXyc7syVzjPAhfOa9ebsdTSjEBDU4vs5nC98Kfduj1uFo0qyET3g=="],
 
     "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
+
+    "ast-v8-to-istanbul": ["ast-v8-to-istanbul@0.3.12", "", { "dependencies": { "@jridgewell/trace-mapping": "^0.3.31", "estree-walker": "^3.0.3", "js-tokens": "^10.0.0" } }, "sha512-BRRC8VRZY2R4Z4lFIL35MwNXmwVqBityvOIwETtsCSwvjl0IdgFsy9NhdaA6j74nUdtJJlIypeRhpDam19Wq3g=="],
 
     "axobject-query": ["axobject-query@4.1.0", "", {}, "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ=="],
 
@@ -389,7 +406,7 @@
 
     "estraverse": ["estraverse@5.3.0", "", {}, "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="],
 
-    "estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
+    "estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
 
     "esutils": ["esutils@2.0.3", "", {}, "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="],
 
@@ -423,6 +440,8 @@
 
     "hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
 
+    "html-escaper": ["html-escaper@2.0.2", "", {}, "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg=="],
+
     "ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
 
     "import-fresh": ["import-fresh@3.3.1", "", { "dependencies": { "parent-module": "^1.0.0", "resolve-from": "^4.0.0" } }, "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ=="],
@@ -440,6 +459,14 @@
     "is-reference": ["is-reference@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.6" } }, "sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw=="],
 
     "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
+
+    "istanbul-lib-coverage": ["istanbul-lib-coverage@3.2.2", "", {}, "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg=="],
+
+    "istanbul-lib-report": ["istanbul-lib-report@3.0.1", "", { "dependencies": { "istanbul-lib-coverage": "^3.0.0", "make-dir": "^4.0.0", "supports-color": "^7.1.0" } }, "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw=="],
+
+    "istanbul-reports": ["istanbul-reports@3.2.0", "", { "dependencies": { "html-escaper": "^2.0.0", "istanbul-lib-report": "^3.0.0" } }, "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA=="],
+
+    "js-tokens": ["js-tokens@10.0.0", "", {}, "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q=="],
 
     "js-yaml": ["js-yaml@4.1.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
 
@@ -466,6 +493,10 @@
     "lodash.merge": ["lodash.merge@4.6.2", "", {}, "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="],
 
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
+
+    "magicast": ["magicast@0.5.2", "", { "dependencies": { "@babel/parser": "^7.29.0", "@babel/types": "^7.29.0", "source-map-js": "^1.2.1" } }, "sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ=="],
+
+    "make-dir": ["make-dir@4.0.0", "", { "dependencies": { "semver": "^7.5.3" } }, "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw=="],
 
     "minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
 
@@ -625,15 +656,17 @@
 
     "@eslint/plugin-kit/@eslint/core": ["@eslint/core@0.17.0", "", { "dependencies": { "@types/json-schema": "^7.0.15" } }, "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ=="],
 
+    "@rollup/plugin-commonjs/estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
+
     "@rollup/plugin-commonjs/is-reference": ["is-reference@1.2.1", "", { "dependencies": { "@types/estree": "*" } }, "sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ=="],
+
+    "@rollup/pluginutils/estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
 
     "@typescript-eslint/eslint-plugin/ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
 
     "@typescript-eslint/typescript-estree/minimatch": ["minimatch@10.2.4", "", { "dependencies": { "brace-expansion": "^5.0.2" } }, "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg=="],
 
     "@typescript-eslint/visitor-keys/eslint-visitor-keys": ["eslint-visitor-keys@5.0.1", "", {}, "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA=="],
-
-    "@vitest/mocker/estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
 
     "eslint/@eslint/core": ["@eslint/core@0.17.0", "", { "dependencies": { "@types/json-schema": "^7.0.15" } }, "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ=="],
 

--- a/core/admin/src/lib/opencode/client.server.test.ts
+++ b/core/admin/src/lib/opencode/client.server.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Tests for opencode/client.server.ts — OpenCode REST API client.
+ *
+ * Verifies:
+ * 1. getOpenCodeProviders returns parsed array on success
+ * 2. Returns empty array on HTTP error
+ * 3. Returns empty array on network failure (graceful degradation)
+ * 4. Handles { providers: [...] } wrapper shape
+ * 5. Handles unexpected response shapes gracefully
+ */
+import { describe, test, expect, vi, beforeEach, afterEach } from "vitest";
+
+const fetchMock = vi.fn();
+
+// Mock global fetch
+vi.stubGlobal("fetch", fetchMock);
+
+describe("getOpenCodeProviders", () => {
+  beforeEach(() => {
+    fetchMock.mockReset();
+  });
+
+  test("returns array when API returns an array directly", async () => {
+    const providers = [{ id: "openai", name: "OpenAI" }, { id: "anthropic", name: "Anthropic" }];
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => providers
+    });
+
+    const { getOpenCodeProviders } = await import("./client.server.js");
+    const result = await getOpenCodeProviders();
+    expect(result).toEqual(providers);
+  });
+
+  test("returns providers from wrapped { providers: [...] } shape", async () => {
+    const providers = [{ id: "openai" }];
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ providers })
+    });
+
+    const { getOpenCodeProviders } = await import("./client.server.js");
+    const result = await getOpenCodeProviders();
+    expect(result).toEqual(providers);
+  });
+
+  test("returns empty array on HTTP error response", async () => {
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: async () => ({ error: "internal" })
+    });
+
+    const { getOpenCodeProviders } = await import("./client.server.js");
+    const result = await getOpenCodeProviders();
+    expect(result).toEqual([]);
+  });
+
+  test("returns empty array on network error (graceful degradation)", async () => {
+    fetchMock.mockRejectedValue(new Error("ECONNREFUSED"));
+
+    const { getOpenCodeProviders } = await import("./client.server.js");
+    const result = await getOpenCodeProviders();
+    expect(result).toEqual([]);
+  });
+
+  test("returns empty array for unexpected response shape", async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ something: "unexpected" })
+    });
+
+    const { getOpenCodeProviders } = await import("./client.server.js");
+    const result = await getOpenCodeProviders();
+    expect(result).toEqual([]);
+  });
+
+  test("returns empty array for null response body", async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => null
+    });
+
+    const { getOpenCodeProviders } = await import("./client.server.js");
+    const result = await getOpenCodeProviders();
+    expect(result).toEqual([]);
+  });
+});

--- a/core/admin/src/lib/server/control-plane.test.ts
+++ b/core/admin/src/lib/server/control-plane.test.ts
@@ -1,0 +1,1472 @@
+/**
+ * Comprehensive tests for control-plane.ts exported functions.
+ *
+ * Covers: pure utility functions, channel validation/discovery, access scope
+ * management, channel install/uninstall, secrets management, audit logging,
+ * connection key management, artifact staging, XDG directory setup, and
+ * lifecycle state transitions.
+ *
+ * Tests verify behavior documented in docs/core-principles.md and docs/api-spec.md.
+ */
+import { describe, test, expect, beforeEach, afterEach } from "vitest";
+import {
+  mkdirSync,
+  writeFileSync,
+  readFileSync,
+  existsSync,
+  rmSync,
+  readdirSync
+} from "node:fs";
+import { randomBytes } from "node:crypto";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  createState,
+  randomHex,
+  sha256,
+  discoverChannels,
+  isAllowedService,
+  isAllowedAction,
+  isValidChannel,
+  normalizeCaller,
+  buildComposeFileList,
+  buildArtifactMeta,
+  detectAccessScope,
+  installChannelFromRegistry,
+  uninstallChannel,
+  ensureSecrets,
+  updateSecretsEnv,
+  readSecretsEnvFile,
+  patchSecretsEnvFile,
+  maskConnectionValue,
+  appendAudit,
+  stagedEnvFile,
+  stagedStackEnvFile,
+  buildEnvFiles,
+  discoverStagedChannelYmls,
+  applyInstall,
+  applyUpdate,
+  applyUninstall,
+  persistArtifacts,
+  ensureXdgDirs,
+  ensureOpenCodeConfig,
+  ensureCoreCaddyfile,
+  setCoreCaddyAccessScope,
+  CORE_SERVICES,
+  ALLOWED_CONNECTION_KEYS,
+  REQUIRED_LLM_PROVIDER_KEYS,
+  PLAIN_CONFIG_KEYS,
+  REGISTRY_CHANNEL_NAMES,
+  type ControlPlaneState,
+  type CallerType,
+  type AuditEntry
+} from "./control-plane.js";
+
+// ── Test helpers ────────────────────────────────────────────────────────
+
+function makeTempDir(): string {
+  const dir = join(tmpdir(), `openpalm-test-${randomBytes(4).toString("hex")}`);
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function seedConfigChannels(
+  configDir: string,
+  channels: { name: string; yml: string; caddy?: string }[]
+): void {
+  const channelsDir = join(configDir, "channels");
+  mkdirSync(channelsDir, { recursive: true });
+  for (const ch of channels) {
+    writeFileSync(join(channelsDir, `${ch.name}.yml`), ch.yml);
+    if (ch.caddy) {
+      writeFileSync(join(channelsDir, `${ch.name}.caddy`), ch.caddy);
+    }
+  }
+}
+
+function seedSecretsEnv(configDir: string, content: string): void {
+  mkdirSync(configDir, { recursive: true });
+  writeFileSync(join(configDir, "secrets.env"), content);
+}
+
+function makeTestState(overrides: Partial<ControlPlaneState> = {}): ControlPlaneState {
+  const stateDir = makeTempDir();
+  const configDir = makeTempDir();
+  const dataDir = makeTempDir();
+  return {
+    adminToken: "test-admin-token",
+    setupToken: "test-setup-token",
+    postgresPassword: "test-pg-password",
+    stateDir,
+    configDir,
+    dataDir,
+    services: {},
+    installedExtensions: new Set<string>(),
+    artifacts: { compose: "", caddyfile: "" },
+    artifactMeta: [],
+    audit: [],
+    channelSecrets: {},
+    ...overrides
+  };
+}
+
+let tempDirs: string[] = [];
+
+function trackDir(dir: string): string {
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  for (const dir of tempDirs) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+  tempDirs = [];
+});
+
+// ── Pure Utility Functions ──────────────────────────────────────────────
+
+describe("randomHex", () => {
+  test("returns hex string of expected length", () => {
+    const result = randomHex(16);
+    expect(result).toHaveLength(32); // 16 bytes = 32 hex chars
+    expect(result).toMatch(/^[a-f0-9]+$/);
+  });
+
+  test("returns different values on successive calls", () => {
+    const a = randomHex(16);
+    const b = randomHex(16);
+    expect(a).not.toBe(b);
+  });
+
+  test("respects byte count parameter", () => {
+    expect(randomHex(4)).toHaveLength(8);
+    expect(randomHex(32)).toHaveLength(64);
+    expect(randomHex(1)).toHaveLength(2);
+  });
+});
+
+describe("sha256", () => {
+  test("produces consistent hash for same input", () => {
+    const hash1 = sha256("hello world");
+    const hash2 = sha256("hello world");
+    expect(hash1).toBe(hash2);
+  });
+
+  test("produces known hash for known input", () => {
+    // SHA-256 of empty string
+    expect(sha256("")).toBe(
+      "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    );
+  });
+
+  test("different inputs produce different hashes", () => {
+    expect(sha256("a")).not.toBe(sha256("b"));
+  });
+
+  test("returns 64-char lowercase hex string", () => {
+    const hash = sha256("test");
+    expect(hash).toHaveLength(64);
+    expect(hash).toMatch(/^[a-f0-9]+$/);
+  });
+});
+
+// ── Channel Name Validation & Discovery ─────────────────────────────────
+
+describe("discoverChannels", () => {
+  let configDir: string;
+
+  beforeEach(() => {
+    configDir = trackDir(makeTempDir());
+  });
+
+  test("returns empty array when channels dir does not exist", () => {
+    const result = discoverChannels(configDir);
+    expect(result).toEqual([]);
+  });
+
+  test("discovers .yml files as channels", () => {
+    seedConfigChannels(configDir, [
+      { name: "chat", yml: "services:\n  channel-chat:\n    image: chat:latest\n" }
+    ]);
+
+    const result = discoverChannels(configDir);
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe("chat");
+    expect(result[0].hasRoute).toBe(false);
+    expect(result[0].ymlPath).toContain("chat.yml");
+    expect(result[0].caddyPath).toBeNull();
+  });
+
+  test("detects hasRoute when .caddy file is present", () => {
+    seedConfigChannels(configDir, [
+      {
+        name: "chat",
+        yml: "services:\n  channel-chat:\n    image: chat:latest\n",
+        caddy: "handle_path /chat/* {\n\treverse_proxy channel-chat:8080\n}\n"
+      }
+    ]);
+
+    const result = discoverChannels(configDir);
+    expect(result).toHaveLength(1);
+    expect(result[0].hasRoute).toBe(true);
+    expect(result[0].caddyPath).toContain("chat.caddy");
+  });
+
+  test("discovers multiple channels", () => {
+    seedConfigChannels(configDir, [
+      { name: "chat", yml: "services:\n  channel-chat:\n    image: chat:latest\n" },
+      { name: "discord", yml: "services:\n  channel-discord:\n    image: discord:latest\n" },
+      { name: "api", yml: "services:\n  channel-api:\n    image: api:latest\n" }
+    ]);
+
+    const result = discoverChannels(configDir);
+    expect(result).toHaveLength(3);
+    const names = result.map((c) => c.name).sort();
+    expect(names).toEqual(["api", "chat", "discord"]);
+  });
+
+  test("filters out invalid channel names", () => {
+    const channelsDir = join(configDir, "channels");
+    mkdirSync(channelsDir, { recursive: true });
+    // Invalid names: uppercase, starts with hyphen, too long, special chars
+    writeFileSync(join(channelsDir, "UPPER.yml"), "services: {}");
+    writeFileSync(join(channelsDir, "-leading-hyphen.yml"), "services: {}");
+    writeFileSync(join(channelsDir, "has spaces.yml"), "services: {}");
+    writeFileSync(join(channelsDir, "valid-name.yml"), "services: {}");
+
+    const result = discoverChannels(configDir);
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe("valid-name");
+  });
+
+  test("ignores non-.yml files in channels directory", () => {
+    const channelsDir = join(configDir, "channels");
+    mkdirSync(channelsDir, { recursive: true });
+    writeFileSync(join(channelsDir, "readme.md"), "# Notes");
+    writeFileSync(join(channelsDir, "chat.yml"), "services: {}");
+    writeFileSync(join(channelsDir, "backup.yml.bak"), "old");
+
+    const result = discoverChannels(configDir);
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe("chat");
+  });
+});
+
+// ── Allowlist & Validation Functions ────────────────────────────────────
+
+describe("isAllowedService", () => {
+  test("allows all core services", () => {
+    for (const service of CORE_SERVICES) {
+      expect(isAllowedService(service)).toBe(true);
+    }
+  });
+
+  test("rejects empty string", () => {
+    expect(isAllowedService("")).toBe(false);
+  });
+
+  test("rejects whitespace-only string", () => {
+    expect(isAllowedService("   ")).toBe(false);
+  });
+
+  test("rejects uppercase service names (case-sensitive per doc)", () => {
+    expect(isAllowedService("Admin")).toBe(false);
+    expect(isAllowedService("GUARDIAN")).toBe(false);
+  });
+
+  test("allows channel-* when staged yml exists", () => {
+    const stateDir = trackDir(makeTempDir());
+    const channelsDir = join(stateDir, "channels");
+    mkdirSync(channelsDir, { recursive: true });
+    writeFileSync(join(channelsDir, "chat.yml"), "services: {}");
+
+    expect(isAllowedService("channel-chat", stateDir)).toBe(true);
+  });
+
+  test("rejects channel-* when staged yml does not exist", () => {
+    const stateDir = trackDir(makeTempDir());
+    expect(isAllowedService("channel-chat", stateDir)).toBe(false);
+  });
+
+  test("rejects channel- with invalid channel name", () => {
+    const stateDir = trackDir(makeTempDir());
+    expect(isAllowedService("channel-UPPER", stateDir)).toBe(false);
+    expect(isAllowedService("channel--double", stateDir)).toBe(false);
+  });
+
+  test("rejects non-core, non-channel services", () => {
+    expect(isAllowedService("unknown-service")).toBe(false);
+    expect(isAllowedService("nginx")).toBe(false);
+  });
+});
+
+describe("isAllowedAction", () => {
+  test("allows documented actions from api-spec.md", () => {
+    const validActions = [
+      "install", "update", "uninstall",
+      "containers.list", "containers.pull", "containers.up",
+      "containers.down", "containers.restart",
+      "channels.list", "channels.install", "channels.uninstall",
+      "extensions.list", "extensions.install", "extensions.uninstall",
+      "gallery.refresh",
+      "artifacts.list", "artifacts.get", "artifacts.manifest",
+      "audit.list",
+      "accessScope.get", "accessScope.set",
+      "connections.get", "connections.patch", "connections.status"
+    ];
+    for (const action of validActions) {
+      expect(isAllowedAction(action)).toBe(true);
+    }
+  });
+
+  test("rejects invalid actions", () => {
+    expect(isAllowedAction("")).toBe(false);
+    expect(isAllowedAction("destroy")).toBe(false);
+    expect(isAllowedAction("INSTALL")).toBe(false);
+    expect(isAllowedAction("admin.delete")).toBe(false);
+  });
+});
+
+describe("isValidChannel", () => {
+  test("validates channel name format (lowercase alnum + hyphens)", () => {
+    const stateDir = trackDir(makeTempDir());
+    const channelsDir = join(stateDir, "channels");
+    mkdirSync(channelsDir, { recursive: true });
+    writeFileSync(join(channelsDir, "my-channel.yml"), "services: {}");
+
+    expect(isValidChannel("my-channel", stateDir)).toBe(true);
+  });
+
+  test("rejects empty and whitespace", () => {
+    expect(isValidChannel("")).toBe(false);
+    expect(isValidChannel("  ")).toBe(false);
+  });
+
+  test("rejects invalid names even without stateDir", () => {
+    expect(isValidChannel("UPPER")).toBe(false);
+    expect(isValidChannel("-leading")).toBe(false);
+    expect(isValidChannel("has space")).toBe(false);
+  });
+
+  test("requires stateDir to confirm staging", () => {
+    // Without stateDir: format-valid but returns false (no staged file check)
+    expect(isValidChannel("chat")).toBe(false);
+  });
+
+  test("rejects valid-format name if not staged", () => {
+    const stateDir = trackDir(makeTempDir());
+    mkdirSync(join(stateDir, "channels"), { recursive: true });
+    expect(isValidChannel("unstaged", stateDir)).toBe(false);
+  });
+});
+
+// ── Caller Normalization ────────────────────────────────────────────────
+
+describe("normalizeCaller", () => {
+  test("normalizes valid caller types", () => {
+    expect(normalizeCaller("assistant")).toBe("assistant");
+    expect(normalizeCaller("cli")).toBe("cli");
+    expect(normalizeCaller("ui")).toBe("ui");
+    expect(normalizeCaller("system")).toBe("system");
+    expect(normalizeCaller("test")).toBe("test");
+  });
+
+  test("handles case-insensitive input", () => {
+    expect(normalizeCaller("UI")).toBe("ui");
+    expect(normalizeCaller("CLI")).toBe("cli");
+    expect(normalizeCaller("System")).toBe("system");
+  });
+
+  test("trims whitespace", () => {
+    expect(normalizeCaller("  ui  ")).toBe("ui");
+  });
+
+  test("returns 'unknown' for invalid callers", () => {
+    expect(normalizeCaller("")).toBe("unknown");
+    expect(normalizeCaller("browser")).toBe("unknown");
+    expect(normalizeCaller("api")).toBe("unknown");
+    expect(normalizeCaller("admin")).toBe("unknown");
+  });
+
+  test("returns 'unknown' for null", () => {
+    expect(normalizeCaller(null)).toBe("unknown");
+  });
+});
+
+// ── Access Scope Detection ──────────────────────────────────────────────
+
+describe("detectAccessScope", () => {
+  test("detects host-only scope", () => {
+    const caddyfile = `
+:8080 {
+  @denied not remote_ip 127.0.0.0/8 ::1
+  respond @denied 403
+}`;
+    expect(detectAccessScope(caddyfile)).toBe("host");
+  });
+
+  test("detects LAN scope", () => {
+    const caddyfile = `
+:8080 {
+  @denied not remote_ip 10.0.0.0/8 172.16.0.0/12 192.168.0.0/16 127.0.0.0/8 ::1 fc00::/7 fe80::/10
+  respond @denied 403
+}`;
+    expect(detectAccessScope(caddyfile)).toBe("lan");
+  });
+
+  test("returns custom for unknown IP ranges", () => {
+    const caddyfile = `
+:8080 {
+  @denied not remote_ip 192.168.1.0/24
+  respond @denied 403
+}`;
+    expect(detectAccessScope(caddyfile)).toBe("custom");
+  });
+
+  test("returns custom when @denied line is missing", () => {
+    const caddyfile = `:8080 {\n  respond "OK"\n}`;
+    expect(detectAccessScope(caddyfile)).toBe("custom");
+  });
+});
+
+// ── Artifact Metadata ───────────────────────────────────────────────────
+
+describe("buildArtifactMeta", () => {
+  test("generates metadata for compose and caddyfile", () => {
+    const artifacts = {
+      compose: "services:\n  admin:\n    image: admin:latest\n",
+      caddyfile: ":8080 {\n  respond 200\n}"
+    };
+    const meta = buildArtifactMeta(artifacts);
+    expect(meta).toHaveLength(2);
+    expect(meta[0].name).toBe("compose");
+    expect(meta[1].name).toBe("caddyfile");
+  });
+
+  test("sha256 matches content hash", () => {
+    const content = "test content";
+    const artifacts = { compose: content, caddyfile: "" };
+    const meta = buildArtifactMeta(artifacts);
+    expect(meta[0].sha256).toBe(sha256(content));
+    expect(meta[1].sha256).toBe(sha256(""));
+  });
+
+  test("bytes reflects buffer byte length (handles multibyte)", () => {
+    const artifacts = { compose: "hello", caddyfile: "\u00e9" }; // é = 2 bytes UTF-8
+    const meta = buildArtifactMeta(artifacts);
+    expect(meta[0].bytes).toBe(5);
+    expect(meta[1].bytes).toBe(2);
+  });
+
+  test("generatedAt is ISO timestamp", () => {
+    const meta = buildArtifactMeta({ compose: "", caddyfile: "" });
+    expect(meta[0].generatedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+});
+
+// ── Staged Channel Discovery ────────────────────────────────────────────
+
+describe("discoverStagedChannelYmls", () => {
+  let stateDir: string;
+
+  beforeEach(() => {
+    stateDir = trackDir(makeTempDir());
+  });
+
+  test("returns empty when channels dir does not exist", () => {
+    expect(discoverStagedChannelYmls(stateDir)).toEqual([]);
+  });
+
+  test("discovers staged .yml files", () => {
+    const channelsDir = join(stateDir, "channels");
+    mkdirSync(channelsDir, { recursive: true });
+    writeFileSync(join(channelsDir, "chat.yml"), "services: {}");
+    writeFileSync(join(channelsDir, "discord.yml"), "services: {}");
+
+    const result = discoverStagedChannelYmls(stateDir);
+    expect(result).toHaveLength(2);
+    expect(result.every((f) => f.startsWith(stateDir))).toBe(true);
+  });
+
+  test("ignores non-.yml files", () => {
+    const channelsDir = join(stateDir, "channels");
+    mkdirSync(channelsDir, { recursive: true });
+    writeFileSync(join(channelsDir, "chat.yml"), "services: {}");
+    writeFileSync(join(channelsDir, "chat.caddy"), "handle /chat {}");
+
+    const result = discoverStagedChannelYmls(stateDir);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatch(/chat\.yml$/);
+  });
+
+  test("ignores subdirectories (only files)", () => {
+    const channelsDir = join(stateDir, "channels");
+    mkdirSync(channelsDir, { recursive: true });
+    mkdirSync(join(channelsDir, "public"), { recursive: true });
+    mkdirSync(join(channelsDir, "lan"), { recursive: true });
+    writeFileSync(join(channelsDir, "chat.yml"), "services: {}");
+
+    const result = discoverStagedChannelYmls(stateDir);
+    expect(result).toHaveLength(1);
+  });
+});
+
+// ── Build Compose File List ─────────────────────────────────────────────
+
+describe("buildComposeFileList", () => {
+  test("starts with core compose from artifacts dir", () => {
+    const state = makeTestState();
+    trackDir(state.stateDir);
+    trackDir(state.configDir);
+    trackDir(state.dataDir);
+
+    const files = buildComposeFileList(state);
+    expect(files[0]).toBe(`${state.stateDir}/artifacts/docker-compose.yml`);
+  });
+
+  test("includes staged channel overlays", () => {
+    const state = makeTestState();
+    trackDir(state.stateDir);
+    trackDir(state.configDir);
+    trackDir(state.dataDir);
+
+    const channelsDir = join(state.stateDir, "channels");
+    mkdirSync(channelsDir, { recursive: true });
+    writeFileSync(join(channelsDir, "chat.yml"), "services: {}");
+
+    const files = buildComposeFileList(state);
+    expect(files).toHaveLength(2);
+    expect(files[1]).toContain("chat.yml");
+  });
+});
+
+// ── Path Helpers ────────────────────────────────────────────────────────
+
+describe("stagedEnvFile", () => {
+  test("returns STATE_HOME/artifacts/secrets.env", () => {
+    const state = makeTestState();
+    trackDir(state.stateDir);
+    trackDir(state.configDir);
+    trackDir(state.dataDir);
+    expect(stagedEnvFile(state)).toBe(`${state.stateDir}/artifacts/secrets.env`);
+  });
+});
+
+describe("stagedStackEnvFile", () => {
+  test("returns STATE_HOME/artifacts/stack.env", () => {
+    const state = makeTestState();
+    trackDir(state.stateDir);
+    trackDir(state.configDir);
+    trackDir(state.dataDir);
+    expect(stagedStackEnvFile(state)).toBe(`${state.stateDir}/artifacts/stack.env`);
+  });
+});
+
+describe("buildEnvFiles", () => {
+  test("only returns files that exist", () => {
+    const state = makeTestState();
+    trackDir(state.stateDir);
+    trackDir(state.configDir);
+    trackDir(state.dataDir);
+
+    // Neither file exists yet
+    expect(buildEnvFiles(state)).toEqual([]);
+  });
+
+  test("returns both files when they exist", () => {
+    const state = makeTestState();
+    trackDir(state.stateDir);
+    trackDir(state.configDir);
+    trackDir(state.dataDir);
+
+    const artifactDir = join(state.stateDir, "artifacts");
+    mkdirSync(artifactDir, { recursive: true });
+    writeFileSync(join(artifactDir, "stack.env"), "KEY=val");
+    writeFileSync(join(artifactDir, "secrets.env"), "SECRET=val");
+
+    const files = buildEnvFiles(state);
+    expect(files).toHaveLength(2);
+    expect(files[0]).toContain("stack.env");
+    expect(files[1]).toContain("secrets.env");
+  });
+});
+
+// ── Secrets Management ──────────────────────────────────────────────────
+
+describe("ensureSecrets", () => {
+  let configDir: string;
+
+  beforeEach(() => {
+    configDir = trackDir(makeTempDir());
+  });
+
+  test("seeds secrets.env with empty ADMIN_TOKEN on first run", () => {
+    const state = { configDir, adminToken: "preconfigured-token" } as ControlPlaneState;
+
+    ensureSecrets(state);
+
+    const secrets = readFileSync(join(configDir, "secrets.env"), "utf-8");
+    expect(secrets).toContain("ADMIN_TOKEN=\n");
+    expect(secrets).not.toContain("ADMIN_TOKEN=preconfigured-token");
+  });
+
+  test("is idempotent — does not overwrite existing secrets.env", () => {
+    const state = { configDir } as ControlPlaneState;
+    const existingContent = "ADMIN_TOKEN=my-token\nOPENAI_API_KEY=sk-test\n";
+    seedSecretsEnv(configDir, existingContent);
+
+    ensureSecrets(state);
+
+    const result = readFileSync(join(configDir, "secrets.env"), "utf-8");
+    expect(result).toBe(existingContent);
+  });
+
+  test("includes LLM provider key placeholders", () => {
+    const state = { configDir } as ControlPlaneState;
+    ensureSecrets(state);
+
+    const secrets = readFileSync(join(configDir, "secrets.env"), "utf-8");
+    expect(secrets).toContain("OPENAI_API_KEY=");
+    expect(secrets).toContain("GROQ_API_KEY=");
+    expect(secrets).toContain("MISTRAL_API_KEY=");
+    expect(secrets).toContain("GOOGLE_API_KEY=");
+  });
+
+  test("creates config directory if missing", () => {
+    const nestedDir = join(configDir, "deep", "nested");
+    const state = { configDir: nestedDir } as ControlPlaneState;
+
+    ensureSecrets(state);
+
+    expect(existsSync(join(nestedDir, "secrets.env"))).toBe(true);
+  });
+});
+
+describe("updateSecretsEnv", () => {
+  let configDir: string;
+
+  beforeEach(() => {
+    configDir = trackDir(makeTempDir());
+  });
+
+  test("throws when secrets.env does not exist", () => {
+    const state = { configDir } as ControlPlaneState;
+    expect(() => updateSecretsEnv(state, { KEY: "val" })).toThrow(
+      "secrets.env does not exist"
+    );
+  });
+
+  test("updates existing key in-place", () => {
+    seedSecretsEnv(configDir, "ADMIN_TOKEN=token\nOPENAI_API_KEY=old\n");
+    const state = { configDir } as ControlPlaneState;
+
+    updateSecretsEnv(state, { OPENAI_API_KEY: "sk-new" });
+
+    const result = readFileSync(join(configDir, "secrets.env"), "utf-8");
+    expect(result).toContain("OPENAI_API_KEY=sk-new");
+    expect(result).not.toContain("old");
+    expect(result).toContain("ADMIN_TOKEN=token");
+  });
+
+  test("uncomments and updates commented-out keys", () => {
+    seedSecretsEnv(configDir, "ADMIN_TOKEN=token\n# OPENAI_API_KEY=\n");
+    const state = { configDir } as ControlPlaneState;
+
+    updateSecretsEnv(state, { OPENAI_API_KEY: "sk-uncommented" });
+
+    const result = readFileSync(join(configDir, "secrets.env"), "utf-8");
+    expect(result).toContain("OPENAI_API_KEY=sk-uncommented");
+    expect(result).not.toContain("# OPENAI_API_KEY");
+  });
+
+  test("appends keys not found in file", () => {
+    seedSecretsEnv(configDir, "ADMIN_TOKEN=token\n");
+    const state = { configDir } as ControlPlaneState;
+
+    updateSecretsEnv(state, { NEW_KEY: "new-value" });
+
+    const result = readFileSync(join(configDir, "secrets.env"), "utf-8");
+    expect(result).toContain("NEW_KEY=new-value");
+    expect(result).toContain("ADMIN_TOKEN=token");
+  });
+
+  test("empty updates leave file unchanged", () => {
+    const original = "ADMIN_TOKEN=token\n";
+    seedSecretsEnv(configDir, original);
+    const state = { configDir } as ControlPlaneState;
+
+    updateSecretsEnv(state, {});
+
+    expect(readFileSync(join(configDir, "secrets.env"), "utf-8")).toBe(original);
+  });
+});
+
+// ── Connection Key Management ───────────────────────────────────────────
+
+describe("readSecretsEnvFile", () => {
+  let configDir: string;
+
+  beforeEach(() => {
+    configDir = trackDir(makeTempDir());
+  });
+
+  test("returns empty object when file does not exist", () => {
+    expect(readSecretsEnvFile(configDir)).toEqual({});
+  });
+
+  test("reads only ALLOWED_CONNECTION_KEYS", () => {
+    seedSecretsEnv(
+      configDir,
+      "ADMIN_TOKEN=secret\nOPENAI_API_KEY=sk-test\nRANDOM_KEY=val\n"
+    );
+
+    const result = readSecretsEnvFile(configDir);
+    expect(result.OPENAI_API_KEY).toBe("sk-test");
+    expect(result.ADMIN_TOKEN).toBeUndefined(); // ADMIN_TOKEN is not in ALLOWED_CONNECTION_KEYS
+    expect(result.RANDOM_KEY).toBeUndefined();
+  });
+
+  test("skips comments and blank lines", () => {
+    seedSecretsEnv(configDir, "# A comment\n\nOPENAI_API_KEY=sk-test\n# another\n");
+    const result = readSecretsEnvFile(configDir);
+    expect(result.OPENAI_API_KEY).toBe("sk-test");
+  });
+
+  test("strips inline comments from values", () => {
+    seedSecretsEnv(configDir, "OPENAI_API_KEY=sk-test # my key\n");
+    const result = readSecretsEnvFile(configDir);
+    expect(result.OPENAI_API_KEY).toBe("sk-test");
+  });
+
+  test("unquotes single and double quoted values", () => {
+    seedSecretsEnv(
+      configDir,
+      'OPENAI_API_KEY="sk-double"\nGROQ_API_KEY=\'sk-single\'\n'
+    );
+    const result = readSecretsEnvFile(configDir);
+    expect(result.OPENAI_API_KEY).toBe("sk-double");
+    expect(result.GROQ_API_KEY).toBe("sk-single");
+  });
+
+  test("returns empty string for keys with no value", () => {
+    seedSecretsEnv(configDir, "OPENAI_API_KEY=\n");
+    const result = readSecretsEnvFile(configDir);
+    expect(result.OPENAI_API_KEY).toBe("");
+  });
+});
+
+describe("patchSecretsEnvFile", () => {
+  let configDir: string;
+
+  beforeEach(() => {
+    configDir = trackDir(makeTempDir());
+  });
+
+  test("only patches ALLOWED_CONNECTION_KEYS", () => {
+    seedSecretsEnv(configDir, "ADMIN_TOKEN=token\nOPENAI_API_KEY=old\n");
+    patchSecretsEnvFile(configDir, {
+      OPENAI_API_KEY: "sk-new",
+      ADMIN_TOKEN: "hacked", // NOT in ALLOWED_CONNECTION_KEYS
+      RANDOM_KEY: "injected" // NOT in ALLOWED_CONNECTION_KEYS
+    });
+
+    const result = readFileSync(join(configDir, "secrets.env"), "utf-8");
+    expect(result).toContain("OPENAI_API_KEY=sk-new");
+    expect(result).toContain("ADMIN_TOKEN=token"); // unchanged
+    expect(result).not.toContain("RANDOM_KEY");
+    expect(result).not.toContain("hacked");
+  });
+
+  test("appends new allowed keys when not in file", () => {
+    seedSecretsEnv(configDir, "OPENAI_API_KEY=existing\n");
+    patchSecretsEnvFile(configDir, { GROQ_API_KEY: "gsk-new" });
+
+    const result = readFileSync(join(configDir, "secrets.env"), "utf-8");
+    expect(result).toContain("OPENAI_API_KEY=existing");
+    expect(result).toContain("GROQ_API_KEY=gsk-new");
+  });
+
+  test("creates file if it does not exist", () => {
+    patchSecretsEnvFile(configDir, { OPENAI_API_KEY: "sk-created" });
+    const result = readFileSync(join(configDir, "secrets.env"), "utf-8");
+    expect(result).toContain("OPENAI_API_KEY=sk-created");
+  });
+
+  test("no-op when patches contain only disallowed keys", () => {
+    const original = "ADMIN_TOKEN=keep\n";
+    seedSecretsEnv(configDir, original);
+    patchSecretsEnvFile(configDir, { ADMIN_TOKEN: "nope", RANDOM: "nope" });
+    expect(readFileSync(join(configDir, "secrets.env"), "utf-8")).toBe(original);
+  });
+
+  test("preserves comments and non-allowed keys", () => {
+    seedSecretsEnv(
+      configDir,
+      "# Config\nADMIN_TOKEN=secret\nOPENAI_API_KEY=old\nCUSTOM=val\n"
+    );
+    patchSecretsEnvFile(configDir, { OPENAI_API_KEY: "sk-updated" });
+
+    const result = readFileSync(join(configDir, "secrets.env"), "utf-8");
+    expect(result).toContain("# Config");
+    expect(result).toContain("ADMIN_TOKEN=secret");
+    expect(result).toContain("CUSTOM=val");
+    expect(result).toContain("OPENAI_API_KEY=sk-updated");
+  });
+});
+
+describe("maskConnectionValue", () => {
+  test("returns empty string for empty value", () => {
+    expect(maskConnectionValue("OPENAI_API_KEY", "")).toBe("");
+  });
+
+  test("masks secret keys, showing last 4 chars", () => {
+    expect(maskConnectionValue("OPENAI_API_KEY", "sk-test-1234abcd")).toBe(
+      "*".repeat("sk-test-1234abcd".length - 4) + "abcd"
+    );
+  });
+
+  test("fully masks short values (<=4 chars)", () => {
+    expect(maskConnectionValue("OPENAI_API_KEY", "abcd")).toBe("****");
+    expect(maskConnectionValue("OPENAI_API_KEY", "ab")).toBe("****");
+  });
+
+  test("returns plain config keys unmasked (per api-spec.md)", () => {
+    for (const key of PLAIN_CONFIG_KEYS) {
+      expect(maskConnectionValue(key, "some-value")).toBe("some-value");
+    }
+  });
+
+  test("GUARDIAN_LLM_PROVIDER is returned unmasked", () => {
+    expect(maskConnectionValue("GUARDIAN_LLM_PROVIDER", "anthropic")).toBe("anthropic");
+  });
+
+  test("OPENMEMORY_OPENAI_BASE_URL is returned unmasked", () => {
+    expect(maskConnectionValue("OPENMEMORY_OPENAI_BASE_URL", "http://localhost:11434")).toBe(
+      "http://localhost:11434"
+    );
+  });
+});
+
+// ── Connection Key Sets ─────────────────────────────────────────────────
+
+describe("ALLOWED_CONNECTION_KEYS", () => {
+  test("includes all keys from api-spec.md", () => {
+    const expectedKeys = [
+      "OPENAI_API_KEY",
+      "ANTHROPIC_API_KEY",
+      "GROQ_API_KEY",
+      "MISTRAL_API_KEY",
+      "GOOGLE_API_KEY",
+      "GUARDIAN_LLM_PROVIDER",
+      "GUARDIAN_LLM_MODEL",
+      "OPENMEMORY_OPENAI_BASE_URL",
+      "OPENMEMORY_OPENAI_API_KEY"
+    ];
+    for (const key of expectedKeys) {
+      expect(ALLOWED_CONNECTION_KEYS.has(key)).toBe(true);
+    }
+  });
+
+  test("does not include ADMIN_TOKEN (security: separate from connection keys)", () => {
+    expect(ALLOWED_CONNECTION_KEYS.has("ADMIN_TOKEN")).toBe(false);
+  });
+});
+
+describe("REQUIRED_LLM_PROVIDER_KEYS", () => {
+  test("includes all LLM provider API key names from api-spec.md", () => {
+    expect(REQUIRED_LLM_PROVIDER_KEYS).toContain("OPENAI_API_KEY");
+    expect(REQUIRED_LLM_PROVIDER_KEYS).toContain("ANTHROPIC_API_KEY");
+    expect(REQUIRED_LLM_PROVIDER_KEYS).toContain("GROQ_API_KEY");
+    expect(REQUIRED_LLM_PROVIDER_KEYS).toContain("MISTRAL_API_KEY");
+    expect(REQUIRED_LLM_PROVIDER_KEYS).toContain("GOOGLE_API_KEY");
+  });
+
+  test("all required keys are subset of allowed connection keys", () => {
+    for (const key of REQUIRED_LLM_PROVIDER_KEYS) {
+      expect(ALLOWED_CONNECTION_KEYS.has(key)).toBe(true);
+    }
+  });
+});
+
+// ── Audit Logging ───────────────────────────────────────────────────────
+
+describe("appendAudit", () => {
+  let state: ControlPlaneState;
+
+  beforeEach(() => {
+    state = makeTestState();
+    trackDir(state.stateDir);
+    trackDir(state.configDir);
+    trackDir(state.dataDir);
+  });
+
+  test("appends entry to in-memory audit array", () => {
+    appendAudit(state, "admin", "install", { target: "stack" }, true, "req-1", "ui");
+    expect(state.audit).toHaveLength(1);
+    expect(state.audit[0].actor).toBe("admin");
+    expect(state.audit[0].action).toBe("install");
+    expect(state.audit[0].ok).toBe(true);
+    expect(state.audit[0].requestId).toBe("req-1");
+    expect(state.audit[0].callerType).toBe("ui");
+  });
+
+  test("includes ISO timestamp", () => {
+    appendAudit(state, "admin", "test", {}, true);
+    expect(state.audit[0].at).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  test("persists to JSONL file on disk", () => {
+    appendAudit(state, "admin", "install", {}, true, "req-1");
+    const auditFile = join(state.stateDir, "audit", "admin-audit.jsonl");
+    expect(existsSync(auditFile)).toBe(true);
+    const content = readFileSync(auditFile, "utf-8");
+    const entry = JSON.parse(content.trim());
+    expect(entry.action).toBe("install");
+  });
+
+  test("caps in-memory audit at 1000 entries (per MAX_AUDIT_MEMORY)", () => {
+    for (let i = 0; i < 1050; i++) {
+      appendAudit(state, "admin", `action-${i}`, {}, true);
+    }
+    expect(state.audit.length).toBe(1000);
+    // Oldest entries should be trimmed; newest kept
+    expect(state.audit[0].action).toBe("action-50");
+    expect(state.audit[999].action).toBe("action-1049");
+  });
+
+  test("defaults requestId to empty string and callerType to unknown", () => {
+    appendAudit(state, "admin", "test", {}, true);
+    expect(state.audit[0].requestId).toBe("");
+    expect(state.audit[0].callerType).toBe("unknown");
+  });
+});
+
+// ── Channel Install / Uninstall ─────────────────────────────────────────
+
+describe("installChannelFromRegistry", () => {
+  let configDir: string;
+
+  beforeEach(() => {
+    configDir = trackDir(makeTempDir());
+  });
+
+  test("rejects invalid channel name", () => {
+    const result = installChannelFromRegistry("INVALID", configDir);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toContain("Invalid channel name");
+  });
+
+  test("rejects channel not in registry", () => {
+    const result = installChannelFromRegistry("nonexistent-channel", configDir);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toContain("not found in registry");
+  });
+
+  test("rejects already installed channel", () => {
+    // Only test if there are registry channels available
+    if (REGISTRY_CHANNEL_NAMES.length === 0) return;
+    const name = REGISTRY_CHANNEL_NAMES[0];
+    const channelsDir = join(configDir, "channels");
+    mkdirSync(channelsDir, { recursive: true });
+    writeFileSync(join(channelsDir, `${name}.yml`), "existing");
+
+    const result = installChannelFromRegistry(name, configDir);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toContain("already installed");
+  });
+
+  test("installs registry channel successfully", () => {
+    if (REGISTRY_CHANNEL_NAMES.length === 0) return;
+    const name = REGISTRY_CHANNEL_NAMES[0];
+
+    const result = installChannelFromRegistry(name, configDir);
+    expect(result.ok).toBe(true);
+    expect(existsSync(join(configDir, "channels", `${name}.yml`))).toBe(true);
+  });
+});
+
+describe("uninstallChannel", () => {
+  let configDir: string;
+
+  beforeEach(() => {
+    configDir = trackDir(makeTempDir());
+  });
+
+  test("rejects invalid channel name", () => {
+    const result = uninstallChannel("INVALID", configDir);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toContain("Invalid channel name");
+  });
+
+  test("rejects when channel is not installed", () => {
+    mkdirSync(join(configDir, "channels"), { recursive: true });
+    const result = uninstallChannel("chat", configDir);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toContain("not installed");
+  });
+
+  test("removes .yml file on uninstall", () => {
+    seedConfigChannels(configDir, [
+      { name: "chat", yml: "services: {}" }
+    ]);
+
+    const result = uninstallChannel("chat", configDir);
+    expect(result.ok).toBe(true);
+    expect(existsSync(join(configDir, "channels", "chat.yml"))).toBe(false);
+  });
+
+  test("removes both .yml and .caddy files", () => {
+    seedConfigChannels(configDir, [
+      {
+        name: "chat",
+        yml: "services: {}",
+        caddy: "handle_path /chat/* { reverse_proxy channel-chat:8080 }"
+      }
+    ]);
+
+    const result = uninstallChannel("chat", configDir);
+    expect(result.ok).toBe(true);
+    expect(existsSync(join(configDir, "channels", "chat.yml"))).toBe(false);
+    expect(existsSync(join(configDir, "channels", "chat.caddy"))).toBe(false);
+  });
+});
+
+// ── Lifecycle State Transitions ─────────────────────────────────────────
+
+describe("applyInstall", () => {
+  test("marks all core services as running", () => {
+    const state = makeTestState();
+    trackDir(state.stateDir);
+    trackDir(state.configDir);
+    trackDir(state.dataDir);
+
+    // Initialize services as stopped
+    for (const service of CORE_SERVICES) {
+      state.services[service] = "stopped";
+    }
+
+    // Create required dirs for persistArtifacts
+    mkdirSync(join(state.configDir, "channels"), { recursive: true });
+    mkdirSync(join(state.stateDir, "artifacts"), { recursive: true });
+    mkdirSync(join(state.stateDir, "channels"), { recursive: true });
+    mkdirSync(join(state.stateDir, "secrets"), { recursive: true });
+    mkdirSync(join(state.dataDir, "caddy"), { recursive: true });
+
+    applyInstall(state);
+
+    for (const service of CORE_SERVICES) {
+      expect(state.services[service]).toBe("running");
+    }
+  });
+});
+
+describe("applyUpdate", () => {
+  test("returns list of running services that were restarted", () => {
+    const state = makeTestState();
+    trackDir(state.stateDir);
+    trackDir(state.configDir);
+    trackDir(state.dataDir);
+    state.services = { admin: "running", guardian: "running", postgres: "stopped" };
+
+    mkdirSync(join(state.configDir, "channels"), { recursive: true });
+    mkdirSync(join(state.stateDir, "artifacts"), { recursive: true });
+    mkdirSync(join(state.stateDir, "channels"), { recursive: true });
+    mkdirSync(join(state.stateDir, "secrets"), { recursive: true });
+    mkdirSync(join(state.dataDir, "caddy"), { recursive: true });
+
+    const result = applyUpdate(state);
+    expect(result.restarted).toContain("admin");
+    expect(result.restarted).toContain("guardian");
+    expect(result.restarted).not.toContain("postgres");
+  });
+});
+
+describe("applyUninstall", () => {
+  test("stops all services and clears extensions", () => {
+    const state = makeTestState();
+    trackDir(state.stateDir);
+    trackDir(state.configDir);
+    trackDir(state.dataDir);
+    state.services = { admin: "running", guardian: "running" };
+    state.installedExtensions.add("plugin-a");
+
+    mkdirSync(join(state.configDir, "channels"), { recursive: true });
+    mkdirSync(join(state.stateDir, "artifacts"), { recursive: true });
+    mkdirSync(join(state.stateDir, "channels"), { recursive: true });
+    mkdirSync(join(state.stateDir, "secrets"), { recursive: true });
+    mkdirSync(join(state.dataDir, "caddy"), { recursive: true });
+
+    const result = applyUninstall(state);
+    expect(result.stopped).toContain("admin");
+    expect(result.stopped).toContain("guardian");
+
+    for (const status of Object.values(state.services)) {
+      expect(status).toBe("stopped");
+    }
+    expect(state.installedExtensions.size).toBe(0);
+  });
+});
+
+// ── XDG Directory Setup ─────────────────────────────────────────────────
+
+describe("ensureXdgDirs", () => {
+  const origEnv: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    origEnv.OPENPALM_CONFIG_HOME = process.env.OPENPALM_CONFIG_HOME;
+    origEnv.OPENPALM_STATE_HOME = process.env.OPENPALM_STATE_HOME;
+    origEnv.OPENPALM_DATA_HOME = process.env.OPENPALM_DATA_HOME;
+
+    const base = trackDir(makeTempDir());
+    process.env.OPENPALM_CONFIG_HOME = join(base, "config");
+    process.env.OPENPALM_STATE_HOME = join(base, "state");
+    process.env.OPENPALM_DATA_HOME = join(base, "data");
+  });
+
+  afterEach(() => {
+    process.env.OPENPALM_CONFIG_HOME = origEnv.OPENPALM_CONFIG_HOME;
+    process.env.OPENPALM_STATE_HOME = origEnv.OPENPALM_STATE_HOME;
+    process.env.OPENPALM_DATA_HOME = origEnv.OPENPALM_DATA_HOME;
+  });
+
+  test("creates full XDG directory tree", () => {
+    ensureXdgDirs();
+
+    const configHome = process.env.OPENPALM_CONFIG_HOME!;
+    const stateHome = process.env.OPENPALM_STATE_HOME!;
+    const dataHome = process.env.OPENPALM_DATA_HOME!;
+
+    // CONFIG subtrees
+    expect(existsSync(configHome)).toBe(true);
+    expect(existsSync(join(configHome, "channels"))).toBe(true);
+    expect(existsSync(join(configHome, "opencode"))).toBe(true);
+
+    // STATE subtrees
+    expect(existsSync(stateHome)).toBe(true);
+    expect(existsSync(join(stateHome, "artifacts"))).toBe(true);
+    expect(existsSync(join(stateHome, "audit"))).toBe(true);
+    expect(existsSync(join(stateHome, "secrets"))).toBe(true);
+    expect(existsSync(join(stateHome, "channels"))).toBe(true);
+
+    // DATA subtrees
+    expect(existsSync(dataHome)).toBe(true);
+    expect(existsSync(join(dataHome, "postgres"))).toBe(true);
+    expect(existsSync(join(dataHome, "qdrant"))).toBe(true);
+    expect(existsSync(join(dataHome, "caddy"))).toBe(true);
+    expect(existsSync(join(dataHome, "caddy", "data"))).toBe(true);
+    expect(existsSync(join(dataHome, "caddy", "config"))).toBe(true);
+  });
+
+  test("is idempotent — safe to call multiple times", () => {
+    ensureXdgDirs();
+    ensureXdgDirs(); // No error
+    expect(existsSync(process.env.OPENPALM_CONFIG_HOME!)).toBe(true);
+  });
+});
+
+// ── OpenCode Config ─────────────────────────────────────────────────────
+
+describe("ensureOpenCodeConfig", () => {
+  const origEnv: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    origEnv.OPENPALM_CONFIG_HOME = process.env.OPENPALM_CONFIG_HOME;
+    process.env.OPENPALM_CONFIG_HOME = join(trackDir(makeTempDir()), "config");
+  });
+
+  afterEach(() => {
+    process.env.OPENPALM_CONFIG_HOME = origEnv.OPENPALM_CONFIG_HOME;
+  });
+
+  test("seeds opencode.json with schema reference", () => {
+    ensureOpenCodeConfig();
+
+    const configFile = join(process.env.OPENPALM_CONFIG_HOME!, "opencode", "opencode.json");
+    expect(existsSync(configFile)).toBe(true);
+    const content = JSON.parse(readFileSync(configFile, "utf-8"));
+    expect(content.$schema).toBe("https://opencode.ai/config.json");
+  });
+
+  test("creates tools, plugins, skills subdirs", () => {
+    ensureOpenCodeConfig();
+    const base = join(process.env.OPENPALM_CONFIG_HOME!, "opencode");
+    expect(existsSync(join(base, "tools"))).toBe(true);
+    expect(existsSync(join(base, "plugins"))).toBe(true);
+    expect(existsSync(join(base, "skills"))).toBe(true);
+  });
+
+  test("does not overwrite existing opencode.json", () => {
+    const configHome = process.env.OPENPALM_CONFIG_HOME!;
+    const opencodePath = join(configHome, "opencode");
+    mkdirSync(opencodePath, { recursive: true });
+    const customConfig = '{"custom": true}\n';
+    writeFileSync(join(opencodePath, "opencode.json"), customConfig);
+
+    ensureOpenCodeConfig();
+
+    expect(readFileSync(join(opencodePath, "opencode.json"), "utf-8")).toBe(customConfig);
+  });
+});
+
+// ── createState (exercises private loaders) ─────────────────────────────
+
+describe("createState", () => {
+  const origEnv: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    origEnv.OPENPALM_CONFIG_HOME = process.env.OPENPALM_CONFIG_HOME;
+    origEnv.OPENPALM_STATE_HOME = process.env.OPENPALM_STATE_HOME;
+    origEnv.OPENPALM_DATA_HOME = process.env.OPENPALM_DATA_HOME;
+    origEnv.ADMIN_TOKEN = process.env.ADMIN_TOKEN;
+  });
+
+  afterEach(() => {
+    process.env.OPENPALM_CONFIG_HOME = origEnv.OPENPALM_CONFIG_HOME;
+    process.env.OPENPALM_STATE_HOME = origEnv.OPENPALM_STATE_HOME;
+    process.env.OPENPALM_DATA_HOME = origEnv.OPENPALM_DATA_HOME;
+    process.env.ADMIN_TOKEN = origEnv.ADMIN_TOKEN;
+  });
+
+  test("loads persisted postgres password from system-secrets.env", () => {
+    const base = trackDir(makeTempDir());
+    process.env.OPENPALM_CONFIG_HOME = join(base, "config");
+    process.env.OPENPALM_STATE_HOME = join(base, "state");
+    process.env.OPENPALM_DATA_HOME = join(base, "data");
+    delete process.env.ADMIN_TOKEN;
+
+    // Seed the system-secrets.env with a known password
+    const secretsDir = join(base, "state", "secrets");
+    mkdirSync(secretsDir, { recursive: true });
+    writeFileSync(
+      join(secretsDir, "system-secrets.env"),
+      "# System secrets\nPOSTGRES_PASSWORD=persisted-pg-pass\n"
+    );
+
+    const state = createState();
+    expect(state.postgresPassword).toBe("persisted-pg-pass");
+  });
+
+  test("loads persisted channel secrets from channel-secrets.env", () => {
+    const base = trackDir(makeTempDir());
+    process.env.OPENPALM_CONFIG_HOME = join(base, "config");
+    process.env.OPENPALM_STATE_HOME = join(base, "state");
+    process.env.OPENPALM_DATA_HOME = join(base, "data");
+    delete process.env.ADMIN_TOKEN;
+
+    const secretsDir = join(base, "state", "secrets");
+    mkdirSync(secretsDir, { recursive: true });
+    writeFileSync(
+      join(secretsDir, "channel-secrets.env"),
+      "# Channel secrets\nCHANNEL_CHAT_SECRET=abc123\nCHANNEL_DISCORD_SECRET=def456\n"
+    );
+
+    const state = createState();
+    expect(state.channelSecrets.chat).toBe("abc123");
+    expect(state.channelSecrets.discord).toBe("def456");
+  });
+
+  test("reads ADMIN_TOKEN from secrets.env file", () => {
+    const base = trackDir(makeTempDir());
+    process.env.OPENPALM_CONFIG_HOME = join(base, "config");
+    process.env.OPENPALM_STATE_HOME = join(base, "state");
+    process.env.OPENPALM_DATA_HOME = join(base, "data");
+    delete process.env.ADMIN_TOKEN;
+
+    mkdirSync(join(base, "config"), { recursive: true });
+    writeFileSync(
+      join(base, "config", "secrets.env"),
+      "ADMIN_TOKEN=file-token\nOPENAI_API_KEY=sk-test\n"
+    );
+
+    const state = createState();
+    expect(state.adminToken).toBe("file-token");
+  });
+
+  test("uses explicit adminToken parameter over file/env", () => {
+    const base = trackDir(makeTempDir());
+    process.env.OPENPALM_CONFIG_HOME = join(base, "config");
+    process.env.OPENPALM_STATE_HOME = join(base, "state");
+    process.env.OPENPALM_DATA_HOME = join(base, "data");
+    process.env.ADMIN_TOKEN = "env-token";
+
+    mkdirSync(join(base, "config"), { recursive: true });
+    writeFileSync(join(base, "config", "secrets.env"), "ADMIN_TOKEN=file-token\n");
+
+    const state = createState("explicit-token");
+    expect(state.adminToken).toBe("explicit-token");
+  });
+
+  test("generates random postgres password when not persisted", () => {
+    const base = trackDir(makeTempDir());
+    process.env.OPENPALM_CONFIG_HOME = join(base, "config");
+    process.env.OPENPALM_STATE_HOME = join(base, "state");
+    process.env.OPENPALM_DATA_HOME = join(base, "data");
+
+    const state = createState();
+    // Should be a hex string (32 chars for 16 bytes)
+    expect(state.postgresPassword).toMatch(/^[a-f0-9]{32}$/);
+  });
+
+  test("initializes all core services as stopped", () => {
+    const base = trackDir(makeTempDir());
+    process.env.OPENPALM_CONFIG_HOME = join(base, "config");
+    process.env.OPENPALM_STATE_HOME = join(base, "state");
+    process.env.OPENPALM_DATA_HOME = join(base, "data");
+
+    const state = createState();
+    for (const service of CORE_SERVICES) {
+      expect(state.services[service]).toBe("stopped");
+    }
+  });
+});
+
+// ── Core Service Constants ──────────────────────────────────────────────
+
+describe("CORE_SERVICES", () => {
+  test("includes all expected services from docs", () => {
+    expect(CORE_SERVICES).toContain("caddy");
+    expect(CORE_SERVICES).toContain("postgres");
+    expect(CORE_SERVICES).toContain("qdrant");
+    expect(CORE_SERVICES).toContain("openmemory");
+    expect(CORE_SERVICES).toContain("openmemory-ui");
+    expect(CORE_SERVICES).toContain("assistant");
+    expect(CORE_SERVICES).toContain("guardian");
+    expect(CORE_SERVICES).toContain("admin");
+  });
+
+  test("has exactly 8 core services", () => {
+    expect(CORE_SERVICES).toHaveLength(8);
+  });
+});
+
+// ── Persist Artifacts (Integration) ─────────────────────────────────────
+
+describe("persistArtifacts", () => {
+  let state: ControlPlaneState;
+
+  beforeEach(() => {
+    state = makeTestState();
+    trackDir(state.stateDir);
+    trackDir(state.configDir);
+    trackDir(state.dataDir);
+    state.artifacts = {
+      compose: "services:\n  admin:\n    image: admin:latest\n",
+      caddyfile: ":8080 {\n  respond 200\n}"
+    };
+    // Create required base dirs
+    mkdirSync(join(state.configDir, "channels"), { recursive: true });
+    mkdirSync(join(state.stateDir, "channels"), { recursive: true });
+    mkdirSync(join(state.stateDir, "secrets"), { recursive: true });
+    mkdirSync(join(state.dataDir, "caddy"), { recursive: true });
+  });
+
+  test("writes compose and caddyfile to STATE_HOME", () => {
+    persistArtifacts(state);
+
+    const composePath = join(state.stateDir, "artifacts", "docker-compose.yml");
+    const caddyPath = join(state.stateDir, "Caddyfile");
+    expect(existsSync(composePath)).toBe(true);
+    expect(readFileSync(composePath, "utf-8")).toBe(state.artifacts.compose);
+    expect(readFileSync(caddyPath, "utf-8")).toBe(state.artifacts.caddyfile);
+  });
+
+  test("writes manifest.json with artifact metadata", () => {
+    persistArtifacts(state);
+
+    const manifestPath = join(state.stateDir, "artifacts", "manifest.json");
+    expect(existsSync(manifestPath)).toBe(true);
+    const manifest = JSON.parse(readFileSync(manifestPath, "utf-8"));
+    expect(manifest).toHaveLength(2);
+    expect(manifest[0].name).toBe("compose");
+    expect(manifest[1].name).toBe("caddyfile");
+  });
+
+  test("persists system secrets (postgres password)", () => {
+    persistArtifacts(state);
+
+    const secretsPath = join(state.stateDir, "secrets", "system-secrets.env");
+    expect(existsSync(secretsPath)).toBe(true);
+    const content = readFileSync(secretsPath, "utf-8");
+    expect(content).toContain(`POSTGRES_PASSWORD=${state.postgresPassword}`);
+  });
+
+  test("generates channel secrets for discovered channels", () => {
+    seedConfigChannels(state.configDir, [
+      { name: "chat", yml: "services: {}" }
+    ]);
+
+    persistArtifacts(state);
+
+    expect(state.channelSecrets.chat).toBeDefined();
+    expect(state.channelSecrets.chat.length).toBeGreaterThan(0);
+
+    const channelSecretsPath = join(state.stateDir, "secrets", "channel-secrets.env");
+    const content = readFileSync(channelSecretsPath, "utf-8");
+    expect(content).toContain("CHANNEL_CHAT_SECRET=");
+  });
+
+  test("writes stack.env with runtime configuration", () => {
+    persistArtifacts(state);
+
+    const stackEnvPath = join(state.stateDir, "artifacts", "stack.env");
+    expect(existsSync(stackEnvPath)).toBe(true);
+    const content = readFileSync(stackEnvPath, "utf-8");
+    expect(content).toContain(`OPENPALM_CONFIG_HOME=${state.configDir}`);
+    expect(content).toContain(`OPENPALM_DATA_HOME=${state.dataDir}`);
+    expect(content).toContain(`OPENPALM_STATE_HOME=${state.stateDir}`);
+    expect(content).toContain(`POSTGRES_PASSWORD=${state.postgresPassword}`);
+  });
+
+  test("stages channel yml files from CONFIG to STATE", () => {
+    seedConfigChannels(state.configDir, [
+      { name: "chat", yml: "services:\n  channel-chat:\n    image: chat:latest\n" }
+    ]);
+
+    persistArtifacts(state);
+
+    const stagedYml = join(state.stateDir, "channels", "chat.yml");
+    expect(existsSync(stagedYml)).toBe(true);
+  });
+});
+
+// ── Access Scope Management (Filesystem) ────────────────────────────────
+
+describe("ensureCoreCaddyfile / setCoreCaddyAccessScope", () => {
+  const origEnv: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    origEnv.OPENPALM_DATA_HOME = process.env.OPENPALM_DATA_HOME;
+    process.env.OPENPALM_DATA_HOME = trackDir(makeTempDir());
+  });
+
+  afterEach(() => {
+    process.env.OPENPALM_DATA_HOME = origEnv.OPENPALM_DATA_HOME;
+  });
+
+  test("ensureCoreCaddyfile creates Caddyfile if missing", () => {
+    const path = ensureCoreCaddyfile();
+    expect(existsSync(path)).toBe(true);
+    expect(path).toContain("caddy/Caddyfile");
+  });
+
+  test("ensureCoreCaddyfile is idempotent", () => {
+    const path1 = ensureCoreCaddyfile();
+    const content1 = readFileSync(path1, "utf-8");
+    const path2 = ensureCoreCaddyfile();
+    const content2 = readFileSync(path2, "utf-8");
+    expect(content1).toBe(content2);
+  });
+
+  test("setCoreCaddyAccessScope returns error if @denied line missing", () => {
+    const dataHome = process.env.OPENPALM_DATA_HOME!;
+    const caddyDir = join(dataHome, "caddy");
+    mkdirSync(caddyDir, { recursive: true });
+    writeFileSync(join(caddyDir, "Caddyfile"), ":8080 {\n  respond 200\n}");
+
+    const result = setCoreCaddyAccessScope("host");
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toContain("@denied not remote_ip");
+  });
+});

--- a/core/admin/src/lib/server/docker.test.ts
+++ b/core/admin/src/lib/server/docker.test.ts
@@ -1,4 +1,20 @@
+/**
+ * Tests for docker.ts — Docker Compose integration layer.
+ *
+ * Verifies:
+ * 1. checkDocker handles version output, warnings, daemon errors, missing binary
+ * 2. checkDockerCompose reports availability
+ * 3. composeUp validates file existence, builds correct args with options
+ * 4. composeDown handles volumes flag
+ * 5. composeRestart, composeStop, composeStart build correct commands
+ * 6. composePs handles missing compose file fallback
+ * 7. composeLogs respects tail and service filters
+ * 8. caddyReload builds exec command correctly
+ * 9. composePull builds pull command
+ * 10. All commands use execFile (no shell injection — core security invariant)
+ */
 import { describe, test, expect, vi, beforeEach } from "vitest";
+import { existsSync } from "node:fs";
 import type { DockerResult } from "./docker.js";
 
 const execFileMock = vi.fn();
@@ -9,13 +25,47 @@ vi.mock("node:child_process", () => ({
 
 // docker.ts also imports existsSync; provide a passthrough so other
 // exports keep working without pulling in the real fs module.
+const existsSyncMock = vi.fn(() => false);
 vi.mock("node:fs", () => ({
-  existsSync: vi.fn(() => false)
+  existsSync: (...args: unknown[]) => existsSyncMock(...args)
 }));
+
+// Helper: make execFile resolve successfully
+function mockExecSuccess(stdout = "", stderr = ""): void {
+  execFileMock.mockImplementation(
+    (_cmd: string, _args: string[], _opts: unknown, cb?: Function) => {
+      // execFile can be called with 3 or 4 args depending on the function
+      const callback = cb ?? _opts;
+      if (typeof callback === "function") {
+        callback(null, stdout, stderr);
+      }
+    }
+  );
+}
+
+// Helper: make execFile resolve with error
+function mockExecError(code: number | string, stderr = ""): void {
+  execFileMock.mockImplementation(
+    (_cmd: string, _args: string[], _opts: unknown, cb?: Function) => {
+      const callback = cb ?? _opts;
+      const err = Object.assign(new Error(`exit ${code}`), { code });
+      if (typeof callback === "function") {
+        callback(err, "", stderr);
+      }
+    }
+  );
+}
+
+// Capture the args passed to execFile on each call
+function capturedArgs(): string[] {
+  const call = execFileMock.mock.calls[0];
+  return call[1]; // args array
+}
 
 describe("checkDocker", () => {
   beforeEach(() => {
     execFileMock.mockReset();
+    existsSyncMock.mockReset().mockReturnValue(false);
   });
 
   async function runCheckDocker(): Promise<DockerResult> {
@@ -74,5 +124,356 @@ describe("checkDocker", () => {
     );
     const result = await runCheckDocker();
     expect(result.ok).toBe(false);
+  });
+});
+
+describe("checkDockerCompose", () => {
+  beforeEach(() => {
+    execFileMock.mockReset();
+    existsSyncMock.mockReset().mockReturnValue(false);
+  });
+
+  test("reports ok when docker compose version succeeds", async () => {
+    execFileMock.mockImplementation(
+      (_cmd: string, _args: string[], cb: Function) => {
+        cb(null, "Docker Compose version v2.24.0\n", "");
+      }
+    );
+    const { checkDockerCompose } = await import("./docker.js");
+    const result = await checkDockerCompose();
+    expect(result.ok).toBe(true);
+    expect(result.stdout).toContain("Compose");
+  });
+
+  test("reports not ok when compose is unavailable", async () => {
+    const err = Object.assign(new Error("exit 1"), { code: 1 });
+    execFileMock.mockImplementation(
+      (_cmd: string, _args: string[], cb: Function) => {
+        cb(err, "", "docker: 'compose' is not a docker command.\n");
+      }
+    );
+    const { checkDockerCompose } = await import("./docker.js");
+    const result = await checkDockerCompose();
+    expect(result.ok).toBe(false);
+  });
+});
+
+describe("composeUp", () => {
+  beforeEach(() => {
+    execFileMock.mockReset();
+    existsSyncMock.mockReset();
+  });
+
+  test("returns error when compose file not found", async () => {
+    existsSyncMock.mockReturnValue(false);
+    const { composeUp } = await import("./docker.js");
+    const result = await composeUp("/state");
+    expect(result.ok).toBe(false);
+    expect(result.stderr).toContain("Compose file not found");
+  });
+
+  test("builds correct args with default options", async () => {
+    existsSyncMock.mockReturnValue(true);
+    mockExecSuccess("Creating containers...");
+
+    const { composeUp } = await import("./docker.js");
+    const result = await composeUp("/state");
+    expect(result.ok).toBe(true);
+
+    const args = capturedArgs();
+    expect(args).toContain("compose");
+    expect(args).toContain("-f");
+    expect(args).toContain("--project-name");
+    expect(args).toContain("openpalm");
+    expect(args).toContain("up");
+    expect(args).toContain("-d");
+  });
+
+  test("includes profile flags when specified", async () => {
+    existsSyncMock.mockReturnValue(true);
+    mockExecSuccess();
+
+    const { composeUp } = await import("./docker.js");
+    await composeUp("/state", { profiles: ["dev", "debug"] });
+
+    const args = capturedArgs();
+    expect(args).toContain("--profile");
+    // Should have both profiles
+    const profileIndices = args.reduce<number[]>((acc, a, i) => {
+      if (a === "--profile") acc.push(i);
+      return acc;
+    }, []);
+    expect(profileIndices).toHaveLength(2);
+  });
+
+  test("appends specific services when provided", async () => {
+    existsSyncMock.mockReturnValue(true);
+    mockExecSuccess();
+
+    const { composeUp } = await import("./docker.js");
+    await composeUp("/state", { services: ["admin", "guardian"] });
+
+    const args = capturedArgs();
+    const upIdx = args.indexOf("up");
+    // Services should come after "up" and "-d"
+    expect(args.slice(upIdx + 2)).toEqual(expect.arrayContaining(["admin", "guardian"]));
+  });
+
+  test("uses custom files when provided", async () => {
+    existsSyncMock.mockReturnValue(true);
+    mockExecSuccess();
+
+    const { composeUp } = await import("./docker.js");
+    await composeUp("/state", { files: ["/a/compose.yml", "/b/overlay.yml"] });
+
+    const args = capturedArgs();
+    expect(args).toContain("/a/compose.yml");
+    expect(args).toContain("/b/overlay.yml");
+  });
+});
+
+describe("composeDown", () => {
+  beforeEach(() => {
+    execFileMock.mockReset();
+    existsSyncMock.mockReset();
+  });
+
+  test("returns error when compose file not found", async () => {
+    existsSyncMock.mockReturnValue(false);
+    const { composeDown } = await import("./docker.js");
+    const result = await composeDown("/state");
+    expect(result.ok).toBe(false);
+  });
+
+  test("includes -v flag when removeVolumes is true", async () => {
+    existsSyncMock.mockReturnValue(true);
+    mockExecSuccess();
+
+    const { composeDown } = await import("./docker.js");
+    await composeDown("/state", { removeVolumes: true });
+
+    const args = capturedArgs();
+    expect(args).toContain("-v");
+    expect(args).toContain("down");
+  });
+
+  test("omits -v flag by default", async () => {
+    existsSyncMock.mockReturnValue(true);
+    mockExecSuccess();
+
+    const { composeDown } = await import("./docker.js");
+    await composeDown("/state");
+
+    const args = capturedArgs();
+    expect(args).not.toContain("-v");
+  });
+});
+
+describe("composeRestart", () => {
+  beforeEach(() => {
+    execFileMock.mockReset();
+    existsSyncMock.mockReset();
+  });
+
+  test("returns error when compose file not found", async () => {
+    existsSyncMock.mockReturnValue(false);
+    const { composeRestart } = await import("./docker.js");
+    const result = await composeRestart("/state", ["admin"]);
+    expect(result.ok).toBe(false);
+  });
+
+  test("includes service names in restart command", async () => {
+    existsSyncMock.mockReturnValue(true);
+    mockExecSuccess();
+
+    const { composeRestart } = await import("./docker.js");
+    await composeRestart("/state", ["admin", "guardian"]);
+
+    const args = capturedArgs();
+    expect(args).toContain("restart");
+    expect(args).toContain("admin");
+    expect(args).toContain("guardian");
+  });
+});
+
+describe("composeStop", () => {
+  beforeEach(() => {
+    execFileMock.mockReset();
+    existsSyncMock.mockReset();
+  });
+
+  test("builds stop command with service names", async () => {
+    existsSyncMock.mockReturnValue(true);
+    mockExecSuccess();
+
+    const { composeStop } = await import("./docker.js");
+    await composeStop("/state", ["postgres"]);
+
+    const args = capturedArgs();
+    expect(args).toContain("stop");
+    expect(args).toContain("postgres");
+  });
+});
+
+describe("composeStart", () => {
+  beforeEach(() => {
+    execFileMock.mockReset();
+    existsSyncMock.mockReset();
+  });
+
+  test("uses 'up -d' for specific services (ensures creation)", async () => {
+    existsSyncMock.mockReturnValue(true);
+    mockExecSuccess();
+
+    const { composeStart } = await import("./docker.js");
+    await composeStart("/state", ["admin"]);
+
+    const args = capturedArgs();
+    expect(args).toContain("up");
+    expect(args).toContain("-d");
+    expect(args).toContain("admin");
+  });
+});
+
+describe("composePs", () => {
+  beforeEach(() => {
+    execFileMock.mockReset();
+    existsSyncMock.mockReset();
+  });
+
+  test("falls back to docker ps with project label when compose file missing", async () => {
+    existsSyncMock.mockReturnValue(false);
+    mockExecSuccess('[{"Name": "admin"}]');
+
+    const { composePs } = await import("./docker.js");
+    await composePs("/state");
+
+    const args = capturedArgs();
+    expect(args).toContain("ps");
+    expect(args).toContain("--filter");
+    expect(args).toContain("label=com.docker.compose.project=openpalm");
+  });
+
+  test("uses compose ps with --format json when file exists", async () => {
+    existsSyncMock.mockReturnValue(true);
+    mockExecSuccess('[{"Service": "admin"}]');
+
+    const { composePs } = await import("./docker.js");
+    await composePs("/state");
+
+    const args = capturedArgs();
+    expect(args).toContain("compose");
+    expect(args).toContain("ps");
+    expect(args).toContain("--format");
+    expect(args).toContain("json");
+  });
+});
+
+describe("composeLogs", () => {
+  beforeEach(() => {
+    execFileMock.mockReset();
+    existsSyncMock.mockReset();
+  });
+
+  test("includes --tail flag with default 100", async () => {
+    existsSyncMock.mockReturnValue(true);
+    mockExecSuccess("log output...");
+
+    const { composeLogs } = await import("./docker.js");
+    await composeLogs("/state");
+
+    const args = capturedArgs();
+    expect(args).toContain("logs");
+    expect(args).toContain("--tail");
+    expect(args).toContain("100");
+  });
+
+  test("respects custom tail value", async () => {
+    existsSyncMock.mockReturnValue(true);
+    mockExecSuccess();
+
+    const { composeLogs } = await import("./docker.js");
+    await composeLogs("/state", undefined, 50);
+
+    const args = capturedArgs();
+    expect(args).toContain("--tail");
+    expect(args).toContain("50");
+  });
+
+  test("appends service names when specified", async () => {
+    existsSyncMock.mockReturnValue(true);
+    mockExecSuccess();
+
+    const { composeLogs } = await import("./docker.js");
+    await composeLogs("/state", ["admin", "guardian"]);
+
+    const args = capturedArgs();
+    expect(args).toContain("admin");
+    expect(args).toContain("guardian");
+  });
+});
+
+describe("caddyReload", () => {
+  beforeEach(() => {
+    execFileMock.mockReset();
+    existsSyncMock.mockReset();
+  });
+
+  test("executes caddy reload via docker compose exec", async () => {
+    existsSyncMock.mockReturnValue(true);
+    mockExecSuccess();
+
+    const { caddyReload } = await import("./docker.js");
+    await caddyReload("/state");
+
+    const args = capturedArgs();
+    expect(args).toContain("exec");
+    expect(args).toContain("-T");
+    expect(args).toContain("caddy");
+    expect(args).toContain("reload");
+    expect(args).toContain("--config");
+    expect(args).toContain("/etc/caddy/Caddyfile");
+    expect(args).toContain("--adapter");
+    expect(args).toContain("caddyfile");
+  });
+});
+
+describe("composePull", () => {
+  beforeEach(() => {
+    execFileMock.mockReset();
+    existsSyncMock.mockReset();
+  });
+
+  test("builds pull command", async () => {
+    existsSyncMock.mockReturnValue(true);
+    mockExecSuccess("Pulling images...");
+
+    const { composePull } = await import("./docker.js");
+    await composePull("/state");
+
+    const args = capturedArgs();
+    expect(args).toContain("compose");
+    expect(args).toContain("pull");
+    expect(args).toContain("--project-name");
+    expect(args).toContain("openpalm");
+  });
+});
+
+describe("security: no shell injection", () => {
+  beforeEach(() => {
+    execFileMock.mockReset();
+    existsSyncMock.mockReset().mockReturnValue(true);
+  });
+
+  test("all compose operations use execFile (not exec/spawn shell)", async () => {
+    mockExecSuccess();
+
+    const docker = await import("./docker.js");
+    await docker.composeUp("/state");
+
+    // Verify execFile is called with "docker" as first arg (not a shell string)
+    expect(execFileMock).toHaveBeenCalled();
+    const firstArg = execFileMock.mock.calls[0][0];
+    expect(firstArg).toBe("docker");
   });
 });

--- a/core/admin/src/lib/server/helpers.test.ts
+++ b/core/admin/src/lib/server/helpers.test.ts
@@ -1,0 +1,248 @@
+/**
+ * Tests for helpers.ts — shared API response helpers and auth middleware.
+ *
+ * Verifies:
+ * 1. jsonResponse builds correct Response objects with headers
+ * 2. errorResponse builds structured error envelopes per api-spec.md
+ * 3. getRequestId extracts from header or generates UUID
+ * 4. requireAdmin enforces timing-safe token comparison (security invariant)
+ * 5. getActor derives actor from auth state, not caller-controlled headers
+ * 6. getCallerType normalizes x-requested-by header
+ * 7. parseJsonBody returns parsed JSON or empty object on failure
+ */
+import { describe, test, expect, vi, beforeEach } from "vitest";
+import {
+  jsonResponse,
+  errorResponse,
+  getRequestId,
+  requireAdmin,
+  getActor,
+  getCallerType,
+  parseJsonBody
+} from "./helpers.js";
+import { resetState } from "./state.js";
+
+// ── Mock RequestEvent ───────────────────────────────────────────────────
+
+function makeEvent(headers: Record<string, string> = {}): {
+  request: Request;
+} {
+  const h = new Headers(headers);
+  return {
+    request: new Request("http://localhost:8100/admin/test", { headers: h })
+  };
+}
+
+// ── jsonResponse ────────────────────────────────────────────────────────
+
+describe("jsonResponse", () => {
+  test("returns Response with correct status and JSON body", async () => {
+    const res = jsonResponse(200, { ok: true, data: "test" });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({ ok: true, data: "test" });
+  });
+
+  test("sets content-type header to application/json", () => {
+    const res = jsonResponse(200, {});
+    expect(res.headers.get("content-type")).toBe("application/json");
+  });
+
+  test("includes x-request-id when provided", () => {
+    const res = jsonResponse(200, {}, "req-123");
+    expect(res.headers.get("x-request-id")).toBe("req-123");
+  });
+
+  test("omits x-request-id when not provided", () => {
+    const res = jsonResponse(200, {});
+    expect(res.headers.get("x-request-id")).toBeNull();
+  });
+
+  test("supports error status codes", async () => {
+    const res = jsonResponse(500, { error: "fail" });
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe("fail");
+  });
+});
+
+// ── errorResponse ───────────────────────────────────────────────────────
+
+describe("errorResponse", () => {
+  test("builds structured error envelope per api-spec.md", async () => {
+    const res = errorResponse(401, "unauthorized", "Missing token", {}, "req-1");
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toBe("unauthorized");
+    expect(body.message).toBe("Missing token");
+    expect(body.details).toEqual({});
+    expect(body.requestId).toBe("req-1");
+  });
+
+  test("includes details when provided", async () => {
+    const res = errorResponse(
+      400, "bad_request", "Invalid input",
+      { field: "name", reason: "too long" }, "req-2"
+    );
+    const body = await res.json();
+    expect(body.details.field).toBe("name");
+    expect(body.details.reason).toBe("too long");
+  });
+
+  test("sets x-request-id header", () => {
+    const res = errorResponse(500, "internal", "Something broke", {}, "req-3");
+    expect(res.headers.get("x-request-id")).toBe("req-3");
+  });
+
+  test("defaults details to empty object", async () => {
+    const res = errorResponse(400, "bad", "msg");
+    const body = await res.json();
+    expect(body.details).toEqual({});
+  });
+});
+
+// ── getRequestId ────────────────────────────────────────────────────────
+
+describe("getRequestId", () => {
+  test("extracts x-request-id from header", () => {
+    const event = makeEvent({ "x-request-id": "custom-id-123" });
+    expect(getRequestId(event as never)).toBe("custom-id-123");
+  });
+
+  test("generates UUID when header not present", () => {
+    const event = makeEvent({});
+    const id = getRequestId(event as never);
+    // UUID v4 format check
+    expect(id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
+  });
+
+  test("generates UUID for empty header value", () => {
+    const event = makeEvent({ "x-request-id": "" });
+    const id = getRequestId(event as never);
+    expect(id).toMatch(/^[0-9a-f]{8}-/);
+  });
+});
+
+// ── requireAdmin ────────────────────────────────────────────────────────
+
+describe("requireAdmin", () => {
+  beforeEach(() => {
+    resetState("test-admin-token-12345");
+  });
+
+  test("returns null (pass) for valid admin token", () => {
+    const event = makeEvent({ "x-admin-token": "test-admin-token-12345" });
+    const result = requireAdmin(event as never, "req-1");
+    expect(result).toBeNull();
+  });
+
+  test("returns 401 for missing token", async () => {
+    const event = makeEvent({});
+    const result = requireAdmin(event as never, "req-2");
+    expect(result).not.toBeNull();
+    expect(result!.status).toBe(401);
+    const body = await result!.json();
+    expect(body.error).toBe("unauthorized");
+  });
+
+  test("returns 401 for wrong token", async () => {
+    const event = makeEvent({ "x-admin-token": "wrong-token" });
+    const result = requireAdmin(event as never, "req-3");
+    expect(result).not.toBeNull();
+    expect(result!.status).toBe(401);
+  });
+
+  test("returns 401 for empty token", async () => {
+    const event = makeEvent({ "x-admin-token": "" });
+    const result = requireAdmin(event as never, "req-4");
+    expect(result).not.toBeNull();
+    expect(result!.status).toBe(401);
+  });
+
+  test("rejects token that differs only in length (timing-safe)", async () => {
+    const event = makeEvent({ "x-admin-token": "test-admin-token-1234" }); // one char shorter
+    const result = requireAdmin(event as never, "req-5");
+    expect(result).not.toBeNull();
+    expect(result!.status).toBe(401);
+  });
+
+  test("includes requestId in error response", async () => {
+    const event = makeEvent({});
+    const result = requireAdmin(event as never, "my-request-id");
+    const body = await result!.json();
+    expect(body.requestId).toBe("my-request-id");
+  });
+});
+
+// ── getActor ────────────────────────────────────────────────────────────
+
+describe("getActor", () => {
+  test("returns 'admin' when x-admin-token is present", () => {
+    const event = makeEvent({ "x-admin-token": "any-token" });
+    expect(getActor(event as never)).toBe("admin");
+  });
+
+  test("returns 'unauthenticated' when no token", () => {
+    const event = makeEvent({});
+    expect(getActor(event as never)).toBe("unauthenticated");
+  });
+
+  test("actor is derived from auth state, not caller-controlled (security)", () => {
+    // Even if x-requested-by claims "admin", actor is based on token presence
+    const event = makeEvent({ "x-requested-by": "admin" });
+    expect(getActor(event as never)).toBe("unauthenticated");
+  });
+});
+
+// ── getCallerType ───────────────────────────────────────────────────────
+
+describe("getCallerType", () => {
+  test("normalizes valid x-requested-by header values", () => {
+    expect(getCallerType(makeEvent({ "x-requested-by": "ui" }) as never)).toBe("ui");
+    expect(getCallerType(makeEvent({ "x-requested-by": "cli" }) as never)).toBe("cli");
+    expect(getCallerType(makeEvent({ "x-requested-by": "assistant" }) as never)).toBe("assistant");
+    expect(getCallerType(makeEvent({ "x-requested-by": "system" }) as never)).toBe("system");
+    expect(getCallerType(makeEvent({ "x-requested-by": "test" }) as never)).toBe("test");
+  });
+
+  test("returns 'unknown' for missing header", () => {
+    expect(getCallerType(makeEvent({}) as never)).toBe("unknown");
+  });
+
+  test("returns 'unknown' for invalid value", () => {
+    expect(getCallerType(makeEvent({ "x-requested-by": "hacker" }) as never)).toBe("unknown");
+  });
+});
+
+// ── parseJsonBody ───────────────────────────────────────────────────────
+
+describe("parseJsonBody", () => {
+  test("parses valid JSON body", async () => {
+    const req = new Request("http://localhost", {
+      method: "POST",
+      body: JSON.stringify({ key: "value" }),
+      headers: { "content-type": "application/json" }
+    });
+    const result = await parseJsonBody(req);
+    expect(result).toEqual({ key: "value" });
+  });
+
+  test("returns empty object for invalid JSON", async () => {
+    const req = new Request("http://localhost", {
+      method: "POST",
+      body: "not json",
+      headers: { "content-type": "text/plain" }
+    });
+    const result = await parseJsonBody(req);
+    expect(result).toEqual({});
+  });
+
+  test("returns empty object for empty body", async () => {
+    const req = new Request("http://localhost", {
+      method: "POST",
+      body: ""
+    });
+    const result = await parseJsonBody(req);
+    expect(result).toEqual({});
+  });
+});

--- a/core/admin/src/lib/server/setup-status.test.ts
+++ b/core/admin/src/lib/server/setup-status.test.ts
@@ -1,0 +1,254 @@
+/**
+ * Tests for setup-status.ts — setup detection utilities.
+ *
+ * Verifies:
+ * 1. readSecretsKeys parses .env files correctly (key presence and emptiness)
+ * 2. detectUserId prefers env vars, falls back to os.userInfo, then "default_user"
+ * 3. isSetupComplete checks staged stack.env first, falls back to secrets.env
+ */
+import { describe, test, expect, beforeEach, afterEach } from "vitest";
+import {
+  mkdirSync,
+  writeFileSync,
+  readFileSync,
+  existsSync,
+  rmSync
+} from "node:fs";
+import { randomBytes } from "node:crypto";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { readSecretsKeys, detectUserId, isSetupComplete } from "./setup-status.js";
+
+// ── Test helpers ────────────────────────────────────────────────────────
+
+function makeTempDir(): string {
+  const dir = join(tmpdir(), `openpalm-test-${randomBytes(4).toString("hex")}`);
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+let tempDirs: string[] = [];
+function trackDir(dir: string): string {
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  for (const dir of tempDirs) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+  tempDirs = [];
+});
+
+// ── readSecretsKeys ─────────────────────────────────────────────────────
+
+describe("readSecretsKeys", () => {
+  let configDir: string;
+
+  beforeEach(() => {
+    configDir = trackDir(makeTempDir());
+  });
+
+  test("returns empty object when secrets.env does not exist", () => {
+    expect(readSecretsKeys(configDir)).toEqual({});
+  });
+
+  test("detects key presence with non-empty value as true", () => {
+    writeFileSync(join(configDir, "secrets.env"), "ADMIN_TOKEN=my-token\n");
+    const result = readSecretsKeys(configDir);
+    expect(result.ADMIN_TOKEN).toBe(true);
+  });
+
+  test("detects empty value as false", () => {
+    writeFileSync(join(configDir, "secrets.env"), "ADMIN_TOKEN=\n");
+    const result = readSecretsKeys(configDir);
+    expect(result.ADMIN_TOKEN).toBe(false);
+  });
+
+  test("skips comment lines", () => {
+    writeFileSync(
+      join(configDir, "secrets.env"),
+      "# This is a comment\nADMIN_TOKEN=token\n# Another comment\n"
+    );
+    const result = readSecretsKeys(configDir);
+    expect(result.ADMIN_TOKEN).toBe(true);
+    expect(Object.keys(result)).toHaveLength(1);
+  });
+
+  test("skips blank lines", () => {
+    writeFileSync(
+      join(configDir, "secrets.env"),
+      "\n\nADMIN_TOKEN=token\n\n"
+    );
+    const result = readSecretsKeys(configDir);
+    expect(result.ADMIN_TOKEN).toBe(true);
+  });
+
+  test("handles multiple keys", () => {
+    writeFileSync(
+      join(configDir, "secrets.env"),
+      "ADMIN_TOKEN=token\nOPENAI_API_KEY=sk-test\nGROQ_API_KEY=\n"
+    );
+    const result = readSecretsKeys(configDir);
+    expect(result.ADMIN_TOKEN).toBe(true);
+    expect(result.OPENAI_API_KEY).toBe(true);
+    expect(result.GROQ_API_KEY).toBe(false);
+  });
+
+  test("handles lines without = sign", () => {
+    writeFileSync(
+      join(configDir, "secrets.env"),
+      "invalid_line_no_equals\nADMIN_TOKEN=token\n"
+    );
+    const result = readSecretsKeys(configDir);
+    expect(result.ADMIN_TOKEN).toBe(true);
+    expect(Object.keys(result)).toHaveLength(1);
+  });
+
+  test("handles value with = in it", () => {
+    writeFileSync(
+      join(configDir, "secrets.env"),
+      "OPENAI_BASE_URL=http://localhost:11434/v1?key=abc\n"
+    );
+    const result = readSecretsKeys(configDir);
+    expect(result.OPENAI_BASE_URL).toBe(true);
+  });
+});
+
+// ── detectUserId ────────────────────────────────────────────────────────
+
+describe("detectUserId", () => {
+  const origEnv: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    origEnv.USER = process.env.USER;
+    origEnv.LOGNAME = process.env.LOGNAME;
+  });
+
+  afterEach(() => {
+    process.env.USER = origEnv.USER;
+    process.env.LOGNAME = origEnv.LOGNAME;
+  });
+
+  test("prefers USER env var", () => {
+    process.env.USER = "testuser";
+    process.env.LOGNAME = "loguser";
+    expect(detectUserId()).toBe("testuser");
+  });
+
+  test("falls back to LOGNAME when USER is undefined", () => {
+    delete process.env.USER;
+    process.env.LOGNAME = "loguser";
+    expect(detectUserId()).toBe("loguser");
+  });
+
+  test("skips empty USER to os.userInfo (not LOGNAME) due to ?? semantics", () => {
+    // When USER is "" (not undefined), ?? does NOT fall through to LOGNAME.
+    // The "" is falsy, so the `if (envUser)` check skips to os.userInfo().
+    process.env.USER = "";
+    process.env.LOGNAME = "loguser";
+    const result = detectUserId();
+    // Result should come from os.userInfo(), not LOGNAME
+    expect(result).not.toBe("loguser");
+    expect(result.length).toBeGreaterThan(0);
+  });
+
+  test("falls back to os.userInfo when both env vars are empty", () => {
+    process.env.USER = "";
+    process.env.LOGNAME = "";
+    const result = detectUserId();
+    // Should return a non-empty string (either from userInfo or "default_user")
+    expect(result.length).toBeGreaterThan(0);
+  });
+
+  test("returns non-empty string in all cases", () => {
+    // Whatever the environment, we always get a user id
+    const result = detectUserId();
+    expect(typeof result).toBe("string");
+    expect(result.length).toBeGreaterThan(0);
+  });
+});
+
+// ── isSetupComplete ─────────────────────────────────────────────────────
+
+describe("isSetupComplete", () => {
+  let stateDir: string;
+  let configDir: string;
+
+  beforeEach(() => {
+    stateDir = trackDir(makeTempDir());
+    configDir = trackDir(makeTempDir());
+  });
+
+  test("returns true when stack.env has OPENPALM_SETUP_COMPLETE=true", () => {
+    const artifactDir = join(stateDir, "artifacts");
+    mkdirSync(artifactDir, { recursive: true });
+    writeFileSync(
+      join(artifactDir, "stack.env"),
+      "# Config\nOPENPALM_SETUP_COMPLETE=true\n"
+    );
+
+    expect(isSetupComplete(stateDir, configDir)).toBe(true);
+  });
+
+  test("returns false when stack.env has OPENPALM_SETUP_COMPLETE=false", () => {
+    const artifactDir = join(stateDir, "artifacts");
+    mkdirSync(artifactDir, { recursive: true });
+    writeFileSync(
+      join(artifactDir, "stack.env"),
+      "OPENPALM_SETUP_COMPLETE=false\n"
+    );
+
+    expect(isSetupComplete(stateDir, configDir)).toBe(false);
+  });
+
+  test("falls back to secrets.env ADMIN_TOKEN when stack.env missing", () => {
+    writeFileSync(join(configDir, "secrets.env"), "ADMIN_TOKEN=my-token\n");
+    expect(isSetupComplete(stateDir, configDir)).toBe(true);
+  });
+
+  test("returns false when no stack.env and ADMIN_TOKEN is empty", () => {
+    writeFileSync(join(configDir, "secrets.env"), "ADMIN_TOKEN=\n");
+    expect(isSetupComplete(stateDir, configDir)).toBe(false);
+  });
+
+  test("returns false when neither file exists", () => {
+    expect(isSetupComplete(stateDir, configDir)).toBe(false);
+  });
+
+  test("stack.env takes precedence over secrets.env", () => {
+    // stack.env says setup incomplete, but ADMIN_TOKEN is set
+    const artifactDir = join(stateDir, "artifacts");
+    mkdirSync(artifactDir, { recursive: true });
+    writeFileSync(
+      join(artifactDir, "stack.env"),
+      "OPENPALM_SETUP_COMPLETE=false\n"
+    );
+    writeFileSync(join(configDir, "secrets.env"), "ADMIN_TOKEN=my-token\n");
+
+    expect(isSetupComplete(stateDir, configDir)).toBe(false);
+  });
+
+  test("handles case-insensitive 'true' value", () => {
+    const artifactDir = join(stateDir, "artifacts");
+    mkdirSync(artifactDir, { recursive: true });
+    writeFileSync(
+      join(artifactDir, "stack.env"),
+      "OPENPALM_SETUP_COMPLETE=True\n"
+    );
+
+    expect(isSetupComplete(stateDir, configDir)).toBe(true);
+  });
+
+  test("skips comments in stack.env", () => {
+    const artifactDir = join(stateDir, "artifacts");
+    mkdirSync(artifactDir, { recursive: true });
+    writeFileSync(
+      join(artifactDir, "stack.env"),
+      "# OPENPALM_SETUP_COMPLETE=false\nOPENPALM_SETUP_COMPLETE=true\n"
+    );
+
+    expect(isSetupComplete(stateDir, configDir)).toBe(true);
+  });
+});

--- a/core/admin/src/lib/server/state.test.ts
+++ b/core/admin/src/lib/server/state.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Tests for state.ts — singleton control plane state.
+ *
+ * Verifies:
+ * 1. getState returns a valid ControlPlaneState object
+ * 2. getState returns the same instance on repeated calls (singleton)
+ * 3. resetState creates a fresh state instance
+ * 4. resetState accepts optional admin token
+ */
+import { describe, test, expect } from "vitest";
+import { getState, resetState } from "./state.js";
+
+describe("getState", () => {
+  test("returns a ControlPlaneState with expected shape", () => {
+    const state = resetState("test-token");
+    expect(state).toBeDefined();
+    expect(state.adminToken).toBe("test-token");
+    expect(state.stateDir).toBeDefined();
+    expect(state.configDir).toBeDefined();
+    expect(state.dataDir).toBeDefined();
+    expect(state.services).toBeDefined();
+    expect(state.artifacts).toBeDefined();
+    expect(state.audit).toEqual([]);
+  });
+
+  test("returns same instance on repeated calls (singleton pattern)", () => {
+    resetState("singleton-test");
+    const a = getState();
+    const b = getState();
+    expect(a).toBe(b);
+  });
+});
+
+describe("resetState", () => {
+  test("creates fresh state with new token", () => {
+    const state1 = resetState("token-a");
+    expect(state1.adminToken).toBe("token-a");
+
+    const state2 = resetState("token-b");
+    expect(state2.adminToken).toBe("token-b");
+    expect(state2).not.toBe(state1);
+  });
+
+  test("getState returns the reset state", () => {
+    resetState("reset-verify");
+    expect(getState().adminToken).toBe("reset-verify");
+  });
+
+  test("generates setupToken on each reset", () => {
+    const state1 = resetState();
+    const state2 = resetState();
+    // setupTokens should be random and different
+    expect(state1.setupToken).not.toBe(state2.setupToken);
+  });
+
+  test("initializes core services as stopped", () => {
+    const state = resetState();
+    for (const status of Object.values(state.services)) {
+      expect(status).toBe("stopped");
+    }
+  });
+});

--- a/package.json
+++ b/package.json
@@ -28,5 +28,8 @@
     "dev:stack": "docker compose -f .dev/state/artifacts/docker-compose.yml --env-file .dev/state/artifacts/stack.env --env-file .dev/state/artifacts/secrets.env up -d",
     "test": "bun test packages/ channels/ core/guardian/",
     "check": "bun run admin:check && bun run lib:test"
+  },
+  "devDependencies": {
+    "@vitest/coverage-v8": "^4.0.18"
   }
 }


### PR DESCRIPTION
Add thorough unit test coverage for all admin lib server and client modules:

- control-plane.test.ts (119 tests): validation, channel discovery, access scope,
  secrets management, audit logging, connection keys, lifecycle state transitions,
  artifact staging, XDG directory setup, channel install/uninstall
- helpers.test.ts (27 tests): JSON response helpers, error envelopes, request ID
  extraction, admin token auth (timing-safe), actor derivation, caller normalization
- setup-status.test.ts (21 tests): secrets key parsing, user detection fallback
  chain, setup completion detection via stack.env and secrets.env
- state.test.ts (6 tests): singleton pattern, reset behavior, initialization
- docker.test.ts (26 tests): all compose operations (up/down/restart/stop/start/
  ps/logs/pull), caddy reload, file existence checks, arg construction
- client.server.test.ts (6 tests): OpenCode provider fetching with graceful
  degradation on errors

All test expectations verified against docs/core-principles.md and docs/api-spec.md.
Coverage: 93.8% statements, 95.6% lines, 99% functions across all lib modules.

https://claude.ai/code/session_01VBTy5yLTJas76ow6zTfKQL