### PR TITLE
Fix build dependencies for @openpalm/lib in admin Docker image

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -48,6 +48,7 @@
         "@sveltejs/vite-plugin-svelte": "^6.2.4",
         "@types/node": "^24",
         "@vitest/browser-playwright": "^4.0.18",
+        "dotenv": "^16.4.7",
         "eslint": "^9.39.2",
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-svelte": "^3.14.0",

--- a/core/admin/Dockerfile
+++ b/core/admin/Dockerfile
@@ -11,7 +11,9 @@ COPY core/admin/ .
 COPY assets/ ../assets/
 COPY registry/ ../registry/
 # @openpalm/lib is resolved via vite alias: ../../packages/lib/src → /packages/lib/src
+# Its dependencies (e.g. dotenv) must be available at build time — install them.
 COPY packages/lib /packages/lib
+RUN cd /packages/lib && npm install --omit=dev
 RUN npm run build
 
 # ── Runtime ───────────────────────────────────────────────────────────────────

--- a/core/admin/package.json
+++ b/core/admin/package.json
@@ -23,6 +23,7 @@
     "@sveltejs/vite-plugin-svelte": "^6.2.4",
     "@types/node": "^24",
     "@vitest/browser-playwright": "^4.0.18",
+    "dotenv": "^16.4.7",
     "eslint": "^9.39.2",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-svelte": "^3.14.0",


### PR DESCRIPTION
## Summary
Ensures that dependencies required by `@openpalm/lib` (such as `dotenv`) are available during the Docker build process for the admin service.

## Key Changes
- Added `npm install --omit=dev` step in the Dockerfile after copying `/packages/lib` to install its production dependencies at build time
- Added `dotenv` as a dev dependency in `core/admin/package.json` to support environment variable loading during the build process
- Added clarifying comment in Dockerfile explaining why `/packages/lib` dependencies must be installed

## Implementation Details
The `@openpalm/lib` package is resolved via a Vite alias during the admin build, but its own dependencies were not being installed in the Docker image. This caused build failures when the library code attempted to use packages like `dotenv`. The fix installs only production dependencies (`--omit=dev`) to keep the build image lean while ensuring all required runtime dependencies are available.

https://claude.ai/code/session_01Nknq9q8GJwGEXTuN5AJKLM