### PR TITLE
feat: split release into build-then-push to prevent partial Docker Hu…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,15 +102,63 @@ jobs:
           POSTGRES_PASSWORD: ci-placeholder
         run: docker compose -f assets/docker-compose.yml -f docker-compose.override.yml config -q
 
-  publish-images:
-    name: Publish Docker images
+  build-images:
+    name: Build Docker images
     runs-on: ubuntu-latest
     timeout-minutes: 45
     needs:
       - prepare-tag
       - quality-gates
     strategy:
-      fail-fast: false
+      fail-fast: true
+      matrix:
+        include:
+          - dockerfile: core/admin/Dockerfile
+            image: openpalm/admin
+          - dockerfile: core/guardian/Dockerfile
+            image: openpalm/guardian
+          - dockerfile: channels/chat/Dockerfile
+            image: openpalm/channel-chat
+          - dockerfile: channels/api/Dockerfile
+            image: openpalm/channel-api
+          - dockerfile: channels/discord/Dockerfile
+            image: openpalm/channel-discord
+          - dockerfile: channels/base/Dockerfile
+            image: openpalm/channel-base
+          - dockerfile: core/assistant/Dockerfile
+            image: openpalm/assistant
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.prepare-tag.outputs.tag }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          platforms: linux/amd64,linux/arm64
+          push: false
+          cache-from: type=gha,scope=${{ matrix.image }}
+          cache-to: type=gha,scope=${{ matrix.image }},mode=max
+
+  push-images:
+    name: Push Docker images
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    needs:
+      - prepare-tag
+      - build-images
+    strategy:
+      fail-fast: true
       matrix:
         include:
           - dockerfile: core/admin/Dockerfile
@@ -155,7 +203,7 @@ jobs:
             type=raw,value=latest
             type=raw,value=v${{ needs.prepare-tag.outputs.version }}
 
-      - name: Build and push
+      - name: Push image
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -164,6 +212,7 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=${{ matrix.image }}
 
   release:
     name: Publish GitHub release
@@ -171,7 +220,7 @@ jobs:
     timeout-minutes: 15
     needs:
       - prepare-tag
-      - publish-images
+      - push-images
 
     steps:
       - name: Checkout


### PR DESCRIPTION
…b pushes

Split the single publish-images job into two sequential jobs:

- build-images: validates all 7 Dockerfiles build for both platforms with fail-fast: true, so any build failure cancels everything before anything reaches Docker Hub
- push-images: only runs after all builds succeed, rebuilds from GHA cache (near-instant) and pushes tagged images

Also adds GitHub Actions layer caching (type=gha) scoped per image, which reduces Docker Hub base image pulls on subsequent releases.

https://claude.ai/code/session_01Ng492ne2d5ZVZcayP7LFsw