### PR TITLE
Refactor cron job system to automation scheduling

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Most AI assistants live on someone else's servers. OpenPalm runs on yours. Your 
 - **Connect your channels** — web chat and Discord are built in. Add more by dropping files — no code changes.
 - **Long-term memory** — your assistant remembers context across conversations via OpenMemory. Secrets are never stored.
 - **Admin dashboard** — manage everything from a browser: services, channels, access control.
+- **Automations** — schedule recurring tasks like updates, health checks, and assistant prompts by dropping a file.
 - **Built for safety** — defense-in-depth security: HMAC-signed messages, guardian validation, assistant isolation, LAN-first by default.
 
 ## Prerequisites
@@ -70,6 +71,10 @@ All admin operations require an admin token (`x-admin-token` header). The admin 
 ### Add channels by file-drop
 
 Adding a channel requires no code changes — just drop a Docker Compose overlay (`.yml`) and an optional Caddy route (`.caddy`) into the registry. The admin stages these into the runtime automatically. Built-in channels include web chat and Discord, with community channels documented in [`docs/community-channels.md`](docs/community-channels.md).
+
+### Automations
+
+Schedule recurring tasks by dropping a file into `~/.config/openpalm/automations/`. OpenPalm ships ready-to-use examples for auto-updating containers, health checks, sending prompts to the assistant, and log cleanup. Copy any example from `assets/automations/` to get started. See [`docs/managing-openpalm.md`](docs/managing-openpalm.md#automations) for details.
 
 <div>
 

--- a/assets/automations/cleanup-logs
+++ b/assets/automations/cleanup-logs
@@ -1,0 +1,11 @@
+# cleanup-logs — Trim old audit log entries
+#
+# Runs every Sunday at 4 AM. Keeps only the last 10,000 lines of each
+# audit log file to prevent unbounded disk growth.
+#
+# To use: copy this file to ~/.config/openpalm/automations/cleanup-logs
+# then restart admin:  docker compose restart admin
+
+SHELL=/bin/bash
+
+0 4 * * 0 node bash -c '. /etc/openpalm-env && for f in "$OPENPALM_STATE_HOME"/audit/*.jsonl "$OPENPALM_STATE_HOME"/audit/*.log; do [ -f "$f" ] || continue; tail -n 10000 "$f" > "$f.tmp" && mv "$f.tmp" "$f"; done'

--- a/assets/automations/health-check
+++ b/assets/automations/health-check
@@ -1,0 +1,11 @@
+# health-check — Monitor that all services are running
+#
+# Runs every 5 minutes. Checks the admin health endpoint and logs
+# any failures to the audit directory for review.
+#
+# To use: copy this file to ~/.config/openpalm/automations/health-check
+# then restart admin:  docker compose restart admin
+
+SHELL=/bin/bash
+
+*/5 * * * * node bash -c '. /etc/openpalm-env && STATUS=$(curl -sf http://localhost:8100/health) || echo "{\"ts\":\"$(date -Iseconds)\",\"automation\":\"health-check\",\"error\":\"admin health check failed\"}" >> "$OPENPALM_STATE_HOME/audit/automation.log"'

--- a/assets/automations/prompt-assistant
+++ b/assets/automations/prompt-assistant
@@ -1,0 +1,14 @@
+# prompt-assistant — Send a scheduled message to the assistant
+#
+# Runs daily at 8 AM. Sends a prompt through the chat channel's
+# OpenAI-compatible API. Requires the chat channel to be installed.
+#
+# Customize the prompt in the curl -d body below to suit your needs.
+# Common uses: daily briefing, system report, recurring task reminders.
+#
+# To use: copy this file to ~/.config/openpalm/automations/prompt-assistant
+# then restart admin:  docker compose restart admin
+
+SHELL=/bin/bash
+
+0 8 * * * node bash -c '. /etc/openpalm-env && curl -sf -X POST http://channel-chat:8181/v1/chat/completions -H "Content-Type: application/json" -d "{\"model\":\"default\",\"messages\":[{\"role\":\"user\",\"content\":\"Good morning. Give me a brief summary of system health and any open tasks.\"}]}" -o /dev/null'

--- a/assets/automations/update-containers
+++ b/assets/automations/update-containers
@@ -1,0 +1,10 @@
+# update-containers — Pull latest images and recreate containers
+#
+# Runs every Sunday at 3 AM. Keeps your stack up to date automatically.
+#
+# To use: copy this file to ~/.config/openpalm/automations/update-containers
+# then restart admin:  docker compose restart admin
+
+SHELL=/bin/bash
+
+0 3 * * 0 node bash -c '. /etc/openpalm-env && curl -sf -X POST http://localhost:8100/admin/containers/pull -H "x-admin-token: $ADMIN_TOKEN" -H "x-requested-by: automation" -o /dev/null'

--- a/assets/docker-compose.yml
+++ b/assets/docker-compose.yml
@@ -198,10 +198,10 @@ services:
       start_period: 5s
 
   # ── Admin ──────────────────────────────────────────────────────────
-  # Container starts as root for crond setup, then drops to target
-  # user via gosu before running the SvelteKit app. Cron files are
-  # staged to STATE_HOME/cron/ by the control plane and loaded by
-  # the entrypoint on startup.
+  # Container starts as root for scheduled automation setup, then
+  # drops to target user via gosu before running the SvelteKit app.
+  # Automation files are staged to STATE_HOME/automations/ by the
+  # control plane and loaded by the entrypoint on startup.
   admin:
     image: ${OPENPALM_IMAGE_NAMESPACE:-openpalm}/admin:${OPENPALM_IMAGE_TAG:-latest}
     restart: unless-stopped

--- a/core/admin/entrypoint.sh
+++ b/core/admin/entrypoint.sh
@@ -1,28 +1,39 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# ── Cron setup ─────────────────────────────────────────────────────────
-# Staged cron files live in STATE_HOME/cron/ (already bind-mounted).
-# Copy them to /etc/cron.d/ with required ownership (root:root, 644)
-# so crond will accept them. Filenames in /etc/cron.d/ must not contain
-# dots, so the .cron extension is stripped and files are prefixed.
-CRON_DIR="${OPENPALM_STATE_HOME:-}/cron"
-CRON_ACTIVE=0
-if [ -n "$CRON_DIR" ] && [ -d "$CRON_DIR" ]; then
+# ── Automation environment ────────────────────────────────────────────
+# Scheduled jobs run under crond which does not inherit the container's
+# environment. Write key variables to a sourceable file so automation
+# scripts can access the admin API and resolve paths.
+cat > /etc/openpalm-env <<EOF
+ADMIN_TOKEN=${ADMIN_TOKEN:-}
+OPENPALM_STATE_HOME=${OPENPALM_STATE_HOME:-}
+OPENPALM_CONFIG_HOME=${OPENPALM_CONFIG_HOME:-}
+OPENPALM_DATA_HOME=${OPENPALM_DATA_HOME:-}
+EOF
+chmod 600 /etc/openpalm-env
+
+# ── Automation setup ─────────────────────────────────────────────────
+# Staged automation files live in STATE_HOME/automations/ (already
+# bind-mounted). Copy them to /etc/cron.d/ with required ownership
+# (root:root, 644) so the scheduler will accept them.
+AUTOMATIONS_DIR="${OPENPALM_STATE_HOME:-}/automations"
+AUTOMATIONS_ACTIVE=0
+if [ -n "$AUTOMATIONS_DIR" ] && [ -d "$AUTOMATIONS_DIR" ]; then
 	rm -f /etc/cron.d/openpalm-*
 
-	for f in "$CRON_DIR"/*.cron; do
+	for f in "$AUTOMATIONS_DIR"/*; do
 		[ -f "$f" ] || continue
-		base=$(basename "$f" .cron)
+		base=$(basename "$f")
 		safe_name=$(echo "$base" | tr '.' '-')
 		dest="/etc/cron.d/openpalm-${safe_name}"
 		cp "$f" "$dest"
 		chown root:root "$dest"
 		chmod 644 "$dest"
-		CRON_ACTIVE=1
+		AUTOMATIONS_ACTIVE=1
 	done
 
-	if [ "$CRON_ACTIVE" = "1" ]; then
+	if [ "$AUTOMATIONS_ACTIVE" = "1" ]; then
 		cron
 	fi
 fi

--- a/docs/environment-and-mounts.md
+++ b/docs/environment-and-mounts.md
@@ -133,12 +133,12 @@ The admin is the sole orchestrator. It connects to Docker via the socket proxy
 STATE_HOME. The DATA_HOME mount allows the admin to pre-create subdirectories
 with correct ownership before other services start.
 
-The admin container starts as root for crond setup, then drops privileges
-to the target UID/GID (`$OPENPALM_UID:$OPENPALM_GID`, default `1000:1000`)
-via gosu before running the SvelteKit app. Staged cron files from
-`STATE_HOME/cron/` are copied to `/etc/cron.d/` with correct ownership
-on startup. See [directory-structure.md](./directory-structure.md) for cron
-file format and configuration.
+The admin container starts as root for scheduled automation setup, then
+drops privileges to the target UID/GID (`$OPENPALM_UID:$OPENPALM_GID`,
+default `1000:1000`) via gosu before running the SvelteKit app. Staged
+automation files from `STATE_HOME/automations/` are installed on startup.
+See [directory-structure.md](./directory-structure.md) for format and
+configuration details.
 
 ---
 

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -65,6 +65,7 @@ Responsibilities:
 - Runs `docker compose` for all lifecycle operations (install, update, up, down,
   restart)
 - Exposes an authenticated API used by the CLI, the browser UI, and the assistant
+- Runs scheduled automations — user-defined files from CONFIG_HOME/automations/
 - Writes the audit log
 - Discovers installed channels by scanning `CONFIG_HOME/channels/`, then stages
   overlays/snippets into `STATE_HOME/artifacts/channels/` for runtime

--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -121,6 +121,7 @@ All user-editable files live under `CONFIG_HOME` (default `~/.config/openpalm`):
 |---|---|
 | `secrets.env` | Admin token and LLM provider API keys |
 | `channels/` | Channel compose overlays (`.yml`) and Caddy routes (`.caddy`) |
+| `automations/` | Scheduled automations — see [Managing OpenPalm](managing-openpalm.md#automations) |
 | `opencode/` | OpenCode extensions — tools, plugins, skills, and config |
 
 You never need to touch the other two directories (`DATA_HOME` for service data, `STATE_HOME` for assembled runtime). See [directory-structure.md](directory-structure.md) for the complete layout.

--- a/scripts/dev-setup.sh
+++ b/scripts/dev-setup.sh
@@ -52,12 +52,12 @@ STACK_ENV_DATA="$DATA_DIR/stack.env"
 STACK_ENV_DEST="$STATE_DIR/artifacts/stack.env"
 ADMIN_ENV_DEST="$ROOT_DIR/core/admin/.env"
 
-mkdir -p "$CONFIG_DIR" "$CHANNELS_DIR" "$DEV_ROOT/config/cron" \
-	"$STATE_DIR/artifacts" "$STATE_DIR/audit" "$STATE_DIR/cron" \
+mkdir -p "$CONFIG_DIR" "$CHANNELS_DIR" "$DEV_ROOT/config/automations" \
+	"$STATE_DIR/artifacts" "$STATE_DIR/audit" "$STATE_DIR/automations" \
 	"$DATA_DIR/postgres" "$DATA_DIR/qdrant" "$DATA_DIR/openmemory" \
 	"$DATA_DIR/assistant" "$DATA_DIR/guardian" \
 	"$DATA_DIR/caddy/data" "$DATA_DIR/caddy/config" \
-	"$DATA_DIR/cron"
+	"$DATA_DIR/automations"
 
 # Seed core assets to DATA_HOME (source of truth) — write-once unless --force
 if [[ ! -f "$CADDY_CORE_DEST" || $force -eq 1 ]]; then

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -244,7 +244,7 @@ create_directories() {
 		"$CONFIG_HOME"
 		"$CONFIG_HOME/channels"
 		"$CONFIG_HOME/opencode"
-		"$CONFIG_HOME/cron"
+		"$CONFIG_HOME/automations"
 
 		# DATA_HOME — persistent service data
 		"$DATA_HOME"
@@ -256,14 +256,14 @@ create_directories() {
 		"$DATA_HOME/caddy"
 		"$DATA_HOME/caddy/data"
 		"$DATA_HOME/caddy/config"
-		"$DATA_HOME/cron"
+		"$DATA_HOME/automations"
 
 		# STATE_HOME — assembled runtime
 		"$STATE_HOME"
 		"$STATE_HOME/artifacts"
 		"$STATE_HOME/audit"
 		"$STATE_HOME/artifacts/channels"
-		"$STATE_HOME/cron"
+		"$STATE_HOME/automations"
 
 		# WORK_DIR — assistant working directory
 		"$WORK_DIR"


### PR DESCRIPTION
- Updated docker-compose.yml to reflect changes from cron to automation.
- Modified entrypoint.sh to set up automation files instead of cron jobs.
- Refactored control-plane.ts to handle automation file validation and staging.
- Updated staging tests to accommodate new automation structure.
- Revised documentation to replace references from cron jobs to automations.
- Added example automation scripts for cleanup, health checks, and updates.