### PR TITLE
Add cache directory support for arbitrary container UIDs

### DIFF
--- a/core/assistant/Dockerfile
+++ b/core/assistant/Dockerfile
@@ -21,8 +21,9 @@ RUN apt-get update \
 RUN HOME=/usr/local curl -fsSL https://opencode.ai/install | HOME=/usr/local bash -s -- --no-modify-path
 ENV PATH="/usr/local/.opencode/bin:$PATH"
 
-RUN mkdir -p /home/opencode /work \
-    && chown node:node /home/opencode /work \
+RUN mkdir -p /home/opencode/.cache /work \
+    && chmod 777 /home/opencode /home/opencode/.cache \
+    && chown node:node /home/opencode /home/opencode/.cache /work \
     && sed -i 's@^#\?PasswordAuthentication .*@PasswordAuthentication no@' /etc/ssh/sshd_config \
     && sed -i 's@^#\?UsePAM .*@UsePAM no@' /etc/ssh/sshd_config \
     && sed -i 's@^#\?PermitRootLogin .*@PermitRootLogin no@' /etc/ssh/sshd_config

--- a/core/assistant/entrypoint.sh
+++ b/core/assistant/entrypoint.sh
@@ -4,6 +4,10 @@ set -euo pipefail
 PORT="${OPENCODE_PORT:-4096}"
 ENABLE_SSH="${OPENCODE_ENABLE_SSH:-0}"
 
+# Ensure cache directory exists and is writable by the current UID
+# (the container may run as an arbitrary UID via OPENPALM_UID)
+mkdir -p /home/opencode/.cache 2>/dev/null || true
+
 if [ "$ENABLE_SSH" = "1" ] || [ "$ENABLE_SSH" = "true" ]; then
 	mkdir -p /var/run/sshd /home/opencode/.ssh
 	chown -R node:node /home/opencode/.ssh


### PR DESCRIPTION
## Summary
This change adds proper cache directory initialization and permission handling to support running the assistant container with arbitrary UIDs (via `OPENPALM_UID`), which is necessary for certain deployment scenarios.

## Key Changes
- **Dockerfile**: 
  - Create `/home/opencode/.cache` directory during image build
  - Set world-writable permissions (777) on cache directories to support arbitrary UIDs
  - Ensure proper ownership by the `node` user for standard execution paths
  
- **entrypoint.sh**:
  - Add runtime cache directory initialization that gracefully handles permission errors
  - Ensures the cache directory exists even when the container runs as a non-standard UID

## Implementation Details
The changes address a limitation where containers running with arbitrary UIDs (not the `node` user) would fail to access or create the cache directory. By:
1. Pre-creating the cache directory with world-writable permissions in the image
2. Attempting to ensure it exists at runtime (with error suppression for permission issues)

This allows the container to function correctly in both standard deployments (running as `node` user) and arbitrary UID scenarios (e.g., Kubernetes with `runAsNonRoot` security policies).

https://claude.ai/code/session_01RfJLP6VJjin6cPHfnFehnd