### PR TITLE
Support runtime UID/GID mapping for assistant and pre-provision OpenMemory user

### DIFF
--- a/core/assets/docker-compose.yml
+++ b/core/assets/docker-compose.yml
@@ -86,6 +86,8 @@ services:
       OPENPALM_ADMIN_TOKEN: ${ADMIN_TOKEN:-}
       OPENMEMORY_API_URL: http://openmemory:8765
       OPENMEMORY_USER_ID: ${OPENMEMORY_USER_ID:-default_user}
+      OPENPALM_UID: ${OPENPALM_UID:-1000}
+      OPENPALM_GID: ${OPENPALM_GID:-1000}
       OPENAI_API_KEY: ${OPENAI_API_KEY:-}
       OPENAI_BASE_URL: ${OPENAI_BASE_URL:-}
       ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
@@ -102,7 +104,6 @@ services:
       - ${OPENPALM_DATA_HOME:-${HOME}/.local/share/openpalm}/opencode:/home/opencode/.local/share/opencode
       - ${OPENPALM_WORK_DIR:-${HOME}/openpalm}:/work
     working_dir: /work
-    user: "${OPENPALM_UID:-1000}:${OPENPALM_GID:-1000}"
     networks: [assistant_net]
     depends_on:
       openmemory:

--- a/core/assistant/Dockerfile
+++ b/core/assistant/Dockerfile
@@ -6,7 +6,7 @@
 FROM node:lts-trixie
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends tini curl git ca-certificates bash openssh-server \
+    && apt-get install -y --no-install-recommends tini curl git ca-certificates bash openssh-server gosu \
         python3 python3-pip \
     && curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
         -o /usr/share/keyrings/githubcli-archive-keyring.gpg \

--- a/core/assistant/entrypoint.sh
+++ b/core/assistant/entrypoint.sh
@@ -3,36 +3,133 @@ set -euo pipefail
 
 PORT="${OPENCODE_PORT:-4096}"
 ENABLE_SSH="${OPENCODE_ENABLE_SSH:-0}"
+TARGET_UID="${OPENPALM_UID:-1000}"
+TARGET_GID="${OPENPALM_GID:-1000}"
+TARGET_USER="opencode"
+TARGET_GROUP="opencode"
 
-# Ensure cache directory exists and is writable by the current UID
-# (the container may run as an arbitrary UID via OPENPALM_UID)
-mkdir -p /home/opencode/.cache 2>/dev/null || true
+ensure_user_mapping() {
+  if ! command -v getent >/dev/null 2>&1; then
+    return 0
+  fi
 
-if [ "$ENABLE_SSH" = "1" ] || [ "$ENABLE_SSH" = "true" ]; then
-	mkdir -p /var/run/sshd /home/opencode/.ssh
-	chown -R node:node /home/opencode/.ssh
-	chmod 755 /home/opencode
-	chmod 700 /home/opencode/.ssh
-	touch /home/opencode/.ssh/authorized_keys
-	chown node:node /home/opencode/.ssh/authorized_keys
-	chmod 600 /home/opencode/.ssh/authorized_keys
-	if command -v openssl >/dev/null 2>&1; then
-		usermod -p "$(openssl passwd -6 "$(openssl rand -hex 16)")" node 2>/dev/null || true
-	fi
-	if [ ! -f /etc/ssh/ssh_host_ed25519_key ]; then
-		ssh-keygen -A
-	fi
-	/usr/sbin/sshd \
-		-o PasswordAuthentication=no \
-		-o PermitRootLogin=no \
-		-o AuthorizedKeysFile=/home/opencode/.ssh/authorized_keys \
-		-o AllowTcpForwarding=no \
-		-o X11Forwarding=no \
-		-o PermitTunnel=no \
-		-o UsePAM=no \
-		-o PubkeyAuthentication=yes \
-		-o StrictModes=yes
-fi
+  local existing_group
+  existing_group="$(getent group "$TARGET_GID" | cut -d: -f1 || true)"
+  if [ -n "$existing_group" ]; then
+    TARGET_GROUP="$existing_group"
+  elif [ "$(id -u)" = "0" ]; then
+    groupadd --gid "$TARGET_GID" "$TARGET_GROUP" >/dev/null 2>&1 || true
+  fi
 
-cd /work
-exec opencode web --hostname 0.0.0.0 --port "$PORT" --print-logs
+  local existing_user
+  existing_user="$(getent passwd "$TARGET_UID" | cut -d: -f1 || true)"
+  if [ -n "$existing_user" ]; then
+    TARGET_USER="$existing_user"
+  elif [ "$(id -u)" = "0" ]; then
+    useradd \
+      --uid "$TARGET_UID" \
+      --gid "$TARGET_GID" \
+      --home-dir /home/opencode \
+      --shell /bin/bash \
+      --no-create-home \
+      "$TARGET_USER" >/dev/null 2>&1 || true
+  fi
+}
+
+ensure_home_layout() {
+  mkdir -p \
+    /home/opencode \
+    /home/opencode/.cache \
+    /home/opencode/.config/opencode \
+    /home/opencode/.local/state/opencode \
+    /home/opencode/.local/share/opencode \
+    /work \
+    /etc/opencode
+
+  if [ "$(id -u)" = "0" ]; then
+    chown -R "$TARGET_UID:$TARGET_GID" \
+      /home/opencode \
+      /work \
+      /etc/opencode \
+      /var/run/sshd 2>/dev/null || true
+  fi
+}
+
+maybe_set_openmemory_user_id() {
+  if [ -n "${OPENMEMORY_USER_ID:-}" ] && [ "${OPENMEMORY_USER_ID}" != "default_user" ]; then
+    return 0
+  fi
+
+  local inferred_user
+  inferred_user=""
+
+  if command -v getent >/dev/null 2>&1; then
+    inferred_user="$(getent passwd "$TARGET_UID" | cut -d: -f1 || true)"
+  fi
+
+  if [ -z "$inferred_user" ] && command -v whoami >/dev/null 2>&1; then
+    inferred_user="$(whoami 2>/dev/null || true)"
+  fi
+
+  if [ -z "$inferred_user" ]; then
+    inferred_user="opencode"
+  fi
+
+  export OPENMEMORY_USER_ID="$inferred_user"
+}
+
+maybe_enable_ssh() {
+  if [ "$ENABLE_SSH" != "1" ] && [ "$ENABLE_SSH" != "true" ]; then
+    return 0
+  fi
+
+  mkdir -p /var/run/sshd /home/opencode/.ssh
+
+  if [ "$(id -u)" = "0" ]; then
+    chown -R "$TARGET_UID:$TARGET_GID" /home/opencode/.ssh
+    chmod 755 /home/opencode
+    chmod 700 /home/opencode/.ssh
+  fi
+
+  touch /home/opencode/.ssh/authorized_keys
+
+  if [ "$(id -u)" = "0" ]; then
+    chown "$TARGET_UID:$TARGET_GID" /home/opencode/.ssh/authorized_keys
+    chmod 600 /home/opencode/.ssh/authorized_keys
+  fi
+
+  if command -v openssl >/dev/null 2>&1; then
+    usermod -p "$(openssl passwd -6 "$(openssl rand -hex 16)")" "$TARGET_USER" 2>/dev/null || true
+  fi
+
+  if [ ! -f /etc/ssh/ssh_host_ed25519_key ]; then
+    ssh-keygen -A
+  fi
+
+  /usr/sbin/sshd \
+    -o PasswordAuthentication=no \
+    -o PermitRootLogin=no \
+    -o AuthorizedKeysFile=/home/opencode/.ssh/authorized_keys \
+    -o AllowTcpForwarding=no \
+    -o X11Forwarding=no \
+    -o PermitTunnel=no \
+    -o UsePAM=no \
+    -o PubkeyAuthentication=yes \
+    -o StrictModes=yes
+}
+
+start_opencode() {
+  cd /work
+
+  if [ "$(id -u)" = "0" ]; then
+    exec gosu "$TARGET_UID:$TARGET_GID" opencode web --hostname 0.0.0.0 --port "$PORT" --print-logs
+  fi
+
+  exec opencode web --hostname 0.0.0.0 --port "$PORT" --print-logs
+}
+
+ensure_user_mapping
+ensure_home_layout
+maybe_set_openmemory_user_id
+maybe_enable_ssh
+start_opencode

--- a/docs/environment-and-mounts.md
+++ b/docs/environment-and-mounts.md
@@ -73,8 +73,7 @@ Users add tools, plugins, or skills to `CONFIG_HOME/assistant/` without
 rebuilding the image. OpenCode merges config from `/etc/opencode/` (system)
 and `~/.config/opencode/` (user).
 
-The assistant runs as `$OPENPALM_UID:$OPENPALM_GID` (default `1000:1000`)
-with `working_dir: /work`. It has **no Docker socket access**.
+The assistant container starts as root only to normalize runtime user mapping, then drops privileges to `$OPENPALM_UID:$OPENPALM_GID` (default `1000:1000`) before launching OpenCode. This ensures bind-mounted files are writable across Linux/macOS runtimes while preserving non-root execution for the app process. It uses `working_dir: /work` and has **no Docker socket access**.
 
 ### 2.4 Guardian
 
@@ -215,7 +214,9 @@ They are written into `DATA_HOME/stack.env` and staged to `STATE_HOME/artifacts/
 | `OPENPALM_ADMIN_API_URL` | `http://admin:8100` | Admin API URL for admin tools |
 | `OPENPALM_ADMIN_TOKEN` | from secrets.env | Bearer token for Admin API |
 | `OPENMEMORY_API_URL` | `http://openmemory:8765` | OpenMemory service URL |
-| `OPENMEMORY_USER_ID` | `default_user` | User identifier for memory |
+| `OPENMEMORY_USER_ID` | `default_user` | User identifier for memory (entrypoint auto-falls back to runtime username when left as default) |
+| `OPENPALM_UID` | `${OPENPALM_UID:-1000}` | Target runtime UID used by assistant entrypoint before dropping privileges |
+| `OPENPALM_GID` | `${OPENPALM_GID:-1000}` | Target runtime GID used by assistant entrypoint before dropping privileges |
 | `OPENAI_API_KEY` | pass-through | OpenAI provider key |
 | `ANTHROPIC_API_KEY` | pass-through | Anthropic provider key |
 | `GROQ_API_KEY` | pass-through | Groq provider key |

--- a/packages/assistant-tools/dist/index.js
+++ b/packages/assistant-tools/dist/index.js
@@ -420,7 +420,7 @@ var MemoryContextPlugin = async (ctx) => {
   };
 };
 
-// ../../node_modules/.bun/zod@4.1.8/node_modules/zod/v4/classic/external.js
+// ../../node_modules/zod/v4/classic/external.js
 var exports_external = {};
 __export(exports_external, {
   xid: () => xid2,
@@ -650,7 +650,7 @@ __export(exports_external, {
   $brand: () => $brand
 });
 
-// ../../node_modules/.bun/zod@4.1.8/node_modules/zod/v4/core/index.js
+// ../../node_modules/zod/v4/core/index.js
 var exports_core2 = {};
 __export(exports_core2, {
   version: () => version,
@@ -914,7 +914,7 @@ __export(exports_core2, {
   $ZodAny: () => $ZodAny
 });
 
-// ../../node_modules/.bun/zod@4.1.8/node_modules/zod/v4/core/core.js
+// ../../node_modules/zod/v4/core/core.js
 var NEVER = Object.freeze({
   status: "aborted"
 });
@@ -981,7 +981,7 @@ function config(newConfig) {
     Object.assign(globalConfig, newConfig);
   return globalConfig;
 }
-// ../../node_modules/.bun/zod@4.1.8/node_modules/zod/v4/core/util.js
+// ../../node_modules/zod/v4/core/util.js
 var exports_util = {};
 __export(exports_util, {
   unwrapMessage: () => unwrapMessage,
@@ -1610,7 +1610,7 @@ class Class {
   constructor(..._args) {}
 }
 
-// ../../node_modules/.bun/zod@4.1.8/node_modules/zod/v4/core/errors.js
+// ../../node_modules/zod/v4/core/errors.js
 var initializer = (inst, def) => {
   inst.name = "$ZodError";
   Object.defineProperty(inst, "_zod", {
@@ -1753,7 +1753,7 @@ function prettifyError(error) {
 `);
 }
 
-// ../../node_modules/.bun/zod@4.1.8/node_modules/zod/v4/core/parse.js
+// ../../node_modules/zod/v4/core/parse.js
 var _parse = (_Err) => (schema, value, _ctx, _params) => {
   const ctx = _ctx ? Object.assign(_ctx, { async: false }) : { async: false };
   const result = schema._zod.run({ value, issues: [] }, ctx);
@@ -1840,7 +1840,7 @@ var _safeDecodeAsync = (_Err) => async (schema, value, _ctx) => {
   return _safeParseAsync(_Err)(schema, value, _ctx);
 };
 var safeDecodeAsync = /* @__PURE__ */ _safeDecodeAsync($ZodRealError);
-// ../../node_modules/.bun/zod@4.1.8/node_modules/zod/v4/core/regexes.js
+// ../../node_modules/zod/v4/core/regexes.js
 var exports_regexes = {};
 __export(exports_regexes, {
   xid: () => xid,
@@ -1992,7 +1992,7 @@ var sha512_hex = /^[0-9a-fA-F]{128}$/;
 var sha512_base64 = /* @__PURE__ */ fixedBase64(86, "==");
 var sha512_base64url = /* @__PURE__ */ fixedBase64url(86);
 
-// ../../node_modules/.bun/zod@4.1.8/node_modules/zod/v4/core/checks.js
+// ../../node_modules/zod/v4/core/checks.js
 var $ZodCheck = /* @__PURE__ */ $constructor("$ZodCheck", (inst, def) => {
   var _a;
   inst._zod ?? (inst._zod = {});
@@ -2533,7 +2533,7 @@ var $ZodCheckOverwrite = /* @__PURE__ */ $constructor("$ZodCheckOverwrite", (ins
   };
 });
 
-// ../../node_modules/.bun/zod@4.1.8/node_modules/zod/v4/core/doc.js
+// ../../node_modules/zod/v4/core/doc.js
 class Doc {
   constructor(args = []) {
     this.content = [];
@@ -2571,14 +2571,14 @@ class Doc {
   }
 }
 
-// ../../node_modules/.bun/zod@4.1.8/node_modules/zod/v4/core/versions.js
+// ../../node_modules/zod/v4/core/versions.js
 var version = {
   major: 4,
   minor: 1,
   patch: 8
 };
 
-// ../../node_modules/.bun/zod@4.1.8/node_modules/zod/v4/core/schemas.js
+// ../../node_modules/zod/v4/core/schemas.js
 var $ZodType = /* @__PURE__ */ $constructor("$ZodType", (inst, def) => {
   var _a;
   inst ?? (inst = {});
@@ -4401,7 +4401,7 @@ function handleRefineResult(result, payload, input, inst) {
     payload.issues.push(issue(_iss));
   }
 }
-// ../../node_modules/.bun/zod@4.1.8/node_modules/zod/v4/locales/index.js
+// ../../node_modules/zod/v4/locales/index.js
 var exports_locales = {};
 __export(exports_locales, {
   zhTW: () => zh_TW_default,
@@ -4452,7 +4452,7 @@ __export(exports_locales, {
   ar: () => ar_default
 });
 
-// ../../node_modules/.bun/zod@4.1.8/node_modules/zod/v4/locales/ar.js
+// ../../node_modules/zod/v4/locales/ar.js
 var error = () => {
   const Sizable = {
     string: { unit: "حرف", verb: "أن يحوي" },
@@ -4568,7 +4568,7 @@ function ar_default() {
     localeError: error()
   };
 }
-// ../../node_modules/.bun/zod@4.1.8/node_modules/zod/v4/locales/az.js
+// ../../node_modules/zod/v4/locales/az.js
 var error2 = () => {
   const Sizable = {
     string: { unit: "simvol", verb: "olmalıdır" },
@@ -4683,7 +4683,7 @@ function az_default() {
     localeError: error2()
   };
 }
-// ../../node_modules/.bun/zod@4.1.8/node_modules/zod/v4/locales/be.js
+// ../../node_modules/zod/v4/locales/be.js
 function getBelarusianPlural(count, one, few, many) {
   const absCount = Math.abs(count);
   const lastDigit = absCount % 10;
@@ -4847,7 +4847,7 @@ function be_default() {
     localeError: error3()
   };
 }
-// ../../node_modules/.bun/zod@4.1.8/node_modules/zod/v4/locales/ca.js
+// ../../node_modules/zod/v4/locales/ca.js
 var error4 = () => {
   const Sizable = {
     string: { unit: "caràcters", verb: "contenir" },
@@ -4964,7 +4964,7 @@ function ca_default() {
     localeError: error4()
   };
 }
-// ../../node_modules/.bun/zod@4.1.8/node_modules/zod/v4/locales/cs.js
+// ../../node_modules/zod/v4/locales/cs.js
 var error5 = () => {
   const Sizable = {
     string: { unit: "znaků", verb: "mít" },
@@ -5099,7 +5099,7 @@ function cs_default() {
     localeError: error5()
   };
 }
-// ../../node_modules/.bun/zod@4.1.8/node_modules/zod/v4/locales/da.js
+// ../../node_modules/zod/v4/locales/da.js
 var error6 = () => {
   const Sizable = {
     string: { unit: "tegn", verb: "havde" },
@@ -5230,7 +5230,7 @@ function da_default() {
     localeError: error6()
   };
 }
-// ../../node_modules/.bun/zod@4.1.8/node_modules/zod/v4/locales/de.js
+// ../../node_modules/zod/v4/locales/de.js
 var error7 = () => {
   const Sizable = {
     string: { unit: "Zeichen", verb: "zu haben" },
@@ -5346,7 +5346,7 @@ function de_default() {
     localeError: error7()
   };
 }
-// ../../node_modules/.bun/zod@4.1.8/node_modules/zod/v4/locales/en.js
+// ../../node_modules/zod/v4/locales/en.js
 var parsedType = (data) => {
   const t = typeof data;
   switch (t) {
@@ -5463,7 +5463,7 @@ function en_default() {
     localeError: error8()
   };
 }
-// ../../node_modules/.bun/zod@4.1.8/node_modules/zod/v4/locales/eo.js
+// ../../node_modules/zod/v4/locales/eo.js
 var parsedType2 = (data) => {
   const t = typeof data;
   switch (t) {
@@ -5579,7 +5579,7 @@ function eo_default() {
     localeError: error9()
   };
 }
-// ../../node_modules/.bun/zod@4.1.8/node_modules/zod/v4/locales/es.js
+// ../../node_modules/zod/v4/locales/es.js
 var error10 = () => {
   const Sizable = {
     string: { unit: "caracteres", verb: "tener" },
@@ -5727,7 +5727,7 @@ function es_default() {
     localeError: error10()
   };
 }
-// ../../node_modules/.bun/zod@4.1.8/node_modules/zod/v4/locales/fa.js
+// ../../node_modules/zod/v4/locales/fa.js
 var error11 = () => {
   const Sizable = {
     string: { unit: "کاراکتر", verb: "داشته باشد" },
@@ -5849,7 +5849,7 @@ function fa_default() {
     localeError: error11()
   };
 }
-// ../../node_modules/.bun/zod@4.1.8/node_modules/zod/v4/locales/fi.js
+// ../../node_modules/zod/v4/locales/fi.js
 var error12 = () => {
   const Sizable = {
     string: { unit: "merkkiä", subject: "merkkijonon" },
@@ -5971,7 +5971,7 @@ function fi_default() {
     localeError: error12()
   };
 }
-// ../../node_modules/.bun/zod@4.1.8/node_modules/zod/v4/locales/fr.js
+// ../../node_modules/zod/v4/locales/fr.js
 var error13 = () => {
   const Sizable = {
     string: { unit: "caractères", verb: "avoir" },
@@ -6087,7 +6087,7 @@ function fr_default() {
     localeError: error13()
   };
 }
-// ../../node_modules/.bun/zod@4.1.8/node_modules/zod/v4/locales/fr-CA.js
+// ../../node_modules/zod/v4/locales/fr-CA.js
 var error14 = () => {
   const Sizable = {
     string: { unit: "caractères", verb: "avoir" },
@@ -6204,7 +6204,7 @@ function fr_CA_default() {
     localeError: error14()
   };
 }
-// ../../node_modules/.bun/zod@4.1.8/node_modules/zod/v4/locales/he.js
+// ../../node_modules/zod/v4/locales/he.js
 var error15 = () => {
   const Sizable = {
     string: { unit: "אותיות", verb: "לכלול" },
@@ -6320,7 +6320,7 @@ function he_default() {
     localeError: error15()
   };
 }
-// ../../node_modules/.bun/zod@4.1.8/node_modules/zod/v4/locales/hu.js
+// ../../node_modules/zod/v4/locales/hu.js
 var error16 = () => {
   const Sizable = {
     string: { unit: "karakter", verb: "legyen" },
@@ -6436,7 +6436,7 @@ function hu_default() {
     localeError: error16()
   };
 }
-// ../../node_modules/.bun/zod@4.1.8/node_modules/zod/v4/locales/id.js
+// ../../node_modules/zod/v4/locales/id.js
 var error17 = () => {
   const Sizable = {
     string: { unit: "karakter", verb: "memiliki" },
@@ -6552,7 +6552,7 @@ function id_default() {
     localeError: error17()
   };
 }
-// ../../node_modules/.bun/zod@4.1.8/node_modules/zod/v4/locales/is.js
+// ../../node_modules/zod/v4/locales/is.js
 var parsedType3 = (data) => {
   const t = typeof data;
   switch (t) {
@@ -6669,7 +6669,7 @@ function is_default() {
     localeError: error18()
   };
 }
-// ../../node_modules/.bun/zod@4.1.8/node_modules/zod/v4/locales/it.js
+// ../../node_modules/zod/v4/locales/it.js
 var error19 = () => {
   const Sizable = {
     string: { unit: "caratteri", verb: "avere" },
@@ -6785,7 +6785,7 @@ function it_default() {
     localeError: error19()
   };
 }
-// ../../node_modules/.bun/zod@4.1.8/node_modules/zod/v4/locales/ja.js
+// ../../node_modules/zod/v4/locales/ja.js
 var error20 = () => {
   const Sizable = {
     string: { unit: "文字", verb: "である" },
@@ -6900,7 +6900,7 @@ function ja_default() {
     localeError: error20()
   };
 }
-// ../../node_modules/.bun/zod@4.1.8/node_modules/zod/v4/locales/ka.js
+// ../../node_modules/zod/v4/locales/ka.js
 var parsedType4 = (data) => {
   const t = typeof data;
   switch (t) {
@@ -7025,7 +7025,7 @@ function ka_default() {
     localeError: error21()
   };
 }
-// ../../node_modules/.bun/zod@4.1.8/node_modules/zod/v4/locales/km.js
+// ../../node_modules/zod/v4/locales/km.js
 var error22 = () => {
   const Sizable = {
     string: { unit: "តួអក្សរ", verb: "គួរមាន" },
@@ -7143,11 +7143,11 @@ function km_default() {
   };
 }
 
-// ../../node_modules/.bun/zod@4.1.8/node_modules/zod/v4/locales/kh.js
+// ../../node_modules/zod/v4/locales/kh.js
 function kh_default() {
   return km_default();
 }
-// ../../node_modules/.bun/zod@4.1.8/node_modules/zod/v4/locales/ko.js
+// ../../node_modules/zod/v4/locales/ko.js
 var error23 = () => {
   const Sizable = {
     string: { unit: "문자", verb: "to have" },
@@ -7268,7 +7268,7 @@ function ko_default() {
     localeError: error23()
   };
 }
-// ../../node_modules/.bun/zod@4.1.8/node_modules/zod/v4/locales/lt.js
+// ../../node_modules/zod/v4/locales/lt.js
 var parsedType5 = (data) => {
   const t = typeof data;
   return parsedTypeFromType(t, data);
@@ -7497,7 +7497,7 @@ function lt_default() {
     localeError: error24()
   };
 }
-// ../../node_modules/.bun/zod@4.1.8/node_modules/zod/v4/locales/mk.js
+// ../../node_modules/zod/v4/locales/mk.js
 var error25 = () => {
   const Sizable = {
     string: { unit: "знаци", verb: "да имаат" },
@@ -7614,7 +7614,7 @@ function mk_default() {
     localeError: error25()
   };
 }
-// ../../node_modules/.bun/zod@4.1.8/node_modules/zod/v4/locales/ms.js
+// ../../node_modules/zod/v4/locales/ms.js
 var error26 = () => {
   const Sizable = {
     string: { unit: "aksara", verb: "mempunyai" },
@@ -7730,7 +7730,7 @@ function ms_default() {
     localeError: error26()
   };
 }
-// ../../node_modules/.bun/zod@4.1.8/node_modules/zod/v4/locales/nl.js
+// ../../node_modules/zod/v4/locales/nl.js
 var error27 = () => {
   const Sizable = {
     string: { unit: "tekens" },
@@ -7847,7 +7847,7 @@ function nl_default() {
     localeError: error27()
   };
 }
-// ../../node_modules/.bun/zod@4.1.8/node_modules/zod/v4/locales/no.js
+// ../../node_modules/zod/v4/locales/no.js
 var error28 = () => {
   const Sizable = {
     string: { unit: "tegn", verb: "å ha" },
@@ -7963,7 +7963,7 @@ function no_default() {
     localeError: error28()
   };
 }
-// ../../node_modules/.bun/zod@4.1.8/node_modules/zod/v4/locales/ota.js
+// ../../node_modules/zod/v4/locales/ota.js
 var error29 = () => {
   const Sizable = {
     string: { unit: "harf", verb: "olmalıdır" },
@@ -8079,7 +8079,7 @@ function ota_default() {
     localeError: error29()
   };
 }
-// ../../node_modules/.bun/zod@4.1.8/node_modules/zod/v4/locales/ps.js
+// ../../node_modules/zod/v4/locales/ps.js
 var error30 = () => {
   const Sizable = {
     string: { unit: "توکي", verb: "ولري" },
@@ -8201,7 +8201,7 @@ function ps_default() {
     localeError: error30()
   };
 }
-// ../../node_modules/.bun/zod@4.1.8/node_modules/zod/v4/locales/pl.js
+// ../../node_modules/zod/v4/locales/pl.js
 var error31 = () => {
   const Sizable = {
     string: { unit: "znaków", verb: "mieć" },
@@ -8318,7 +8318,7 @@ function pl_default() {
     localeError: error31()
   };
 }
-// ../../node_modules/.bun/zod@4.1.8/node_modules/zod/v4/locales/pt.js
+// ../../node_modules/zod/v4/locales/pt.js
 var error32 = () => {
   const Sizable = {
     string: { unit: "caracteres", verb: "ter" },
@@ -8434,7 +8434,7 @@ function pt_default() {
     localeError: error32()
   };
 }
-// ../../node_modules/.bun/zod@4.1.8/node_modules/zod/v4/locales/ru.js
+// ../../node_modules/zod/v4/locales/ru.js
 function getRussianPlural(count, one, few, many) {
   const absCount = Math.abs(count);
   const lastDigit = absCount % 10;
@@ -8598,7 +8598,7 @@ function ru_default() {
     localeError: error33()
   };
 }
-// ../../node_modules/.bun/zod@4.1.8/node_modules/zod/v4/locales/sl.js
+// ../../node_modules/zod/v4/locales/sl.js
 var error34 = () => {
   const Sizable = {
     string: { unit: "znakov", verb: "imeti" },
@@ -8715,7 +8715,7 @@ function sl_default() {
     localeError: error34()
   };
 }
-// ../../node_modules/.bun/zod@4.1.8/node_modules/zod/v4/locales/sv.js
+// ../../node_modules/zod/v4/locales/sv.js
 var error35 = () => {
   const Sizable = {
     string: { unit: "tecken", verb: "att ha" },
@@ -8833,7 +8833,7 @@ function sv_default() {
     localeError: error35()
   };
 }
-// ../../node_modules/.bun/zod@4.1.8/node_modules/zod/v4/locales/ta.js
+// ../../node_modules/zod/v4/locales/ta.js
 var error36 = () => {
   const Sizable = {
     string: { unit: "எழுத்துக்கள்", verb: "கொண்டிருக்க வேண்டும்" },
@@ -8950,7 +8950,7 @@ function ta_default() {
     localeError: error36()
   };
 }
-// ../../node_modules/.bun/zod@4.1.8/node_modules/zod/v4/locales/th.js
+// ../../node_modules/zod/v4/locales/th.js
 var error37 = () => {
   const Sizable = {
     string: { unit: "ตัวอักษร", verb: "ควรมี" },
@@ -9067,7 +9067,7 @@ function th_default() {
     localeError: error37()
   };
 }
-// ../../node_modules/.bun/zod@4.1.8/node_modules/zod/v4/locales/tr.js
+// ../../node_modules/zod/v4/locales/tr.js
 var parsedType6 = (data) => {
   const t = typeof data;
   switch (t) {
@@ -9182,7 +9182,7 @@ function tr_default() {
     localeError: error38()
   };
 }
-// ../../node_modules/.bun/zod@4.1.8/node_modules/zod/v4/locales/uk.js
+// ../../node_modules/zod/v4/locales/uk.js
 var error39 = () => {
   const Sizable = {
     string: { unit: "символів", verb: "матиме" },
@@ -9299,11 +9299,11 @@ function uk_default() {
   };
 }
 
-// ../../node_modules/.bun/zod@4.1.8/node_modules/zod/v4/locales/ua.js
+// ../../node_modules/zod/v4/locales/ua.js
 function ua_default() {
   return uk_default();
 }
-// ../../node_modules/.bun/zod@4.1.8/node_modules/zod/v4/locales/ur.js
+// ../../node_modules/zod/v4/locales/ur.js
 var error40 = () => {
   const Sizable = {
     string: { unit: "حروف", verb: "ہونا" },
@@ -9420,7 +9420,7 @@ function ur_default() {
     localeError: error40()
   };
 }
-// ../../node_modules/.bun/zod@4.1.8/node_modules/zod/v4/locales/vi.js
+// ../../node_modules/zod/v4/locales/vi.js
 var error41 = () => {
   const Sizable = {
     string: { unit: "ký tự", verb: "có" },
@@ -9536,7 +9536,7 @@ function vi_default() {
     localeError: error41()
   };
 }
-// ../../node_modules/.bun/zod@4.1.8/node_modules/zod/v4/locales/zh-CN.js
+// ../../node_modules/zod/v4/locales/zh-CN.js
 var error42 = () => {
   const Sizable = {
     string: { unit: "字符", verb: "包含" },
@@ -9652,7 +9652,7 @@ function zh_CN_default() {
     localeError: error42()
   };
 }
-// ../../node_modules/.bun/zod@4.1.8/node_modules/zod/v4/locales/zh-TW.js
+// ../../node_modules/zod/v4/locales/zh-TW.js
 var error43 = () => {
   const Sizable = {
     string: { unit: "字元", verb: "擁有" },
@@ -9769,7 +9769,7 @@ function zh_TW_default() {
     localeError: error43()
   };
 }
-// ../../node_modules/.bun/zod@4.1.8/node_modules/zod/v4/locales/yo.js
+// ../../node_modules/zod/v4/locales/yo.js
 var error44 = () => {
   const Sizable = {
     string: { unit: "àmi", verb: "ní" },
@@ -9884,7 +9884,7 @@ function yo_default() {
     localeError: error44()
   };
 }
-// ../../node_modules/.bun/zod@4.1.8/node_modules/zod/v4/core/registries.js
+// ../../node_modules/zod/v4/core/registries.js
 var $output = Symbol("ZodOutput");
 var $input = Symbol("ZodInput");
 
@@ -9935,7 +9935,7 @@ function registry() {
   return new $ZodRegistry;
 }
 var globalRegistry = /* @__PURE__ */ registry();
-// ../../node_modules/.bun/zod@4.1.8/node_modules/zod/v4/core/api.js
+// ../../node_modules/zod/v4/core/api.js
 function _string(Class2, params) {
   return new Class2({
     type: "string",
@@ -10813,7 +10813,7 @@ function _stringFormat(Class2, format, fnOrRegex, _params = {}) {
   const inst = new Class2(def);
   return inst;
 }
-// ../../node_modules/.bun/zod@4.1.8/node_modules/zod/v4/core/to-json-schema.js
+// ../../node_modules/zod/v4/core/to-json-schema.js
 class JSONSchemaGenerator {
   constructor(params) {
     this.counter = 0;
@@ -11617,9 +11617,9 @@ function isTransforming(_schema, _ctx) {
   }
   throw new Error(`Unknown schema type: ${def.type}`);
 }
-// ../../node_modules/.bun/zod@4.1.8/node_modules/zod/v4/core/json-schema.js
+// ../../node_modules/zod/v4/core/json-schema.js
 var exports_json_schema = {};
-// ../../node_modules/.bun/zod@4.1.8/node_modules/zod/v4/classic/iso.js
+// ../../node_modules/zod/v4/classic/iso.js
 var exports_iso = {};
 __export(exports_iso, {
   time: () => time2,
@@ -11660,7 +11660,7 @@ function duration2(params) {
   return _isoDuration(ZodISODuration, params);
 }
 
-// ../../node_modules/.bun/zod@4.1.8/node_modules/zod/v4/classic/errors.js
+// ../../node_modules/zod/v4/classic/errors.js
 var initializer2 = (inst, issues) => {
   $ZodError.init(inst, issues);
   inst.name = "ZodError";
@@ -11695,7 +11695,7 @@ var ZodRealError = $constructor("ZodError", initializer2, {
   Parent: Error
 });
 
-// ../../node_modules/.bun/zod@4.1.8/node_modules/zod/v4/classic/parse.js
+// ../../node_modules/zod/v4/classic/parse.js
 var parse3 = /* @__PURE__ */ _parse(ZodRealError);
 var parseAsync2 = /* @__PURE__ */ _parseAsync(ZodRealError);
 var safeParse2 = /* @__PURE__ */ _safeParse(ZodRealError);
@@ -11709,7 +11709,7 @@ var safeDecode2 = /* @__PURE__ */ _safeDecode(ZodRealError);
 var safeEncodeAsync2 = /* @__PURE__ */ _safeEncodeAsync(ZodRealError);
 var safeDecodeAsync2 = /* @__PURE__ */ _safeDecodeAsync(ZodRealError);
 
-// ../../node_modules/.bun/zod@4.1.8/node_modules/zod/v4/classic/schemas.js
+// ../../node_modules/zod/v4/classic/schemas.js
 var ZodType = /* @__PURE__ */ $constructor("ZodType", (inst, def) => {
   $ZodType.init(inst, def);
   inst.def = def;
@@ -12684,7 +12684,7 @@ function json(params) {
 function preprocess(fn, schema) {
   return pipe(transform(fn), schema);
 }
-// ../../node_modules/.bun/zod@4.1.8/node_modules/zod/v4/classic/compat.js
+// ../../node_modules/zod/v4/classic/compat.js
 var ZodIssueCode = {
   invalid_type: "invalid_type",
   too_big: "too_big",
@@ -12708,7 +12708,7 @@ function getErrorMap() {
 }
 var ZodFirstPartyTypeKind;
 (function(ZodFirstPartyTypeKind2) {})(ZodFirstPartyTypeKind || (ZodFirstPartyTypeKind = {}));
-// ../../node_modules/.bun/zod@4.1.8/node_modules/zod/v4/classic/coerce.js
+// ../../node_modules/zod/v4/classic/coerce.js
 var exports_coerce = {};
 __export(exports_coerce, {
   string: () => string3,
@@ -12733,9 +12733,9 @@ function date4(params) {
   return _coercedDate(ZodDate, params);
 }
 
-// ../../node_modules/.bun/zod@4.1.8/node_modules/zod/v4/classic/external.js
+// ../../node_modules/zod/v4/classic/external.js
 config(en_default());
-// ../../node_modules/.bun/@opencode-ai+plugin@1.2.15/node_modules/@opencode-ai/plugin/dist/tool.js
+// ../../node_modules/@opencode-ai/plugin/dist/tool.js
 function tool(input) {
   return input;
 }
@@ -12774,6 +12774,108 @@ var ADMIN_URL = process.env.OPENPALM_ADMIN_API_URL || "http://admin:8100";
 var ADMIN_TOKEN = process.env.OPENPALM_ADMIN_TOKEN || "";
 var OPENMEMORY_URL2 = process.env.OPENMEMORY_API_URL || "http://openmemory:8765";
 var USER_ID2 = process.env.OPENMEMORY_USER_ID || "default_user";
+var userProvisionPromise = null;
+async function provisionOpenMemoryUser(userId) {
+  const appName = "openpalm-assistant";
+  const sseController = new AbortController;
+  const timeout = setTimeout(() => sseController.abort(), 1e4);
+  try {
+    const sseRes = await fetch(`${OPENMEMORY_URL2}/mcp/${appName}/sse/${encodeURIComponent(userId)}`, { signal: sseController.signal }).catch(() => null);
+    if (!sseRes || !sseRes.ok || !sseRes.body) {
+      clearTimeout(timeout);
+      return { ok: false, error: sseRes ? `SSE HTTP ${sseRes.status}` : "SSE connection failed" };
+    }
+    const reader = sseRes.body.getReader();
+    const decoder = new TextDecoder;
+    let sseBuffer = "";
+    const readNextEvent = async (timeoutMs = 5000) => {
+      const deadline = Date.now() + timeoutMs;
+      while (Date.now() < deadline) {
+        const remaining = Math.max(deadline - Date.now(), 100);
+        const timeoutRace = new Promise((resolve) => setTimeout(() => resolve(null), remaining));
+        const chunk = await Promise.race([reader.read(), timeoutRace]);
+        if (!chunk || chunk.done)
+          return null;
+        sseBuffer += decoder.decode(chunk.value, { stream: true });
+        const eventMatch = sseBuffer.match(/event:\s*(\S+)\r?\n(?:data:\s*(.*)\r?\n)?\r?\n/);
+        if (eventMatch) {
+          sseBuffer = sseBuffer.slice((eventMatch.index ?? 0) + eventMatch[0].length);
+          return { event: eventMatch[1], data: eventMatch[2] || "" };
+        }
+      }
+      return null;
+    };
+    const endpointEvt = await readNextEvent(5000);
+    if (!endpointEvt || endpointEvt.event !== "endpoint" || !endpointEvt.data) {
+      clearTimeout(timeout);
+      sseController.abort();
+      return { ok: false, error: "No endpoint event received from SSE" };
+    }
+    const messagesUrl = `${OPENMEMORY_URL2}${endpointEvt.data}`;
+    await fetch(messagesUrl, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: {
+          protocolVersion: "2024-11-05",
+          capabilities: {},
+          clientInfo: { name: appName, version: "1.0.0" }
+        }
+      })
+    }).catch(() => null);
+    await readNextEvent(5000);
+    await fetch(messagesUrl, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        method: "notifications/initialized"
+      })
+    }).catch(() => null);
+    await new Promise((resolve) => setTimeout(resolve, 300));
+    await fetch(messagesUrl, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 2,
+        method: "tools/call",
+        params: {
+          name: "add_memories",
+          arguments: {
+            text: `User ${userId} account provisioned by assistant-tools.`
+          }
+        }
+      })
+    }).catch(() => null);
+    await readNextEvent(8000);
+    clearTimeout(timeout);
+    sseController.abort();
+    return { ok: true };
+  } catch (err) {
+    clearTimeout(timeout);
+    sseController.abort();
+    if (err instanceof Error && err.name === "AbortError") {
+      return { ok: true };
+    }
+    return { ok: false, error: String(err) };
+  }
+}
+async function ensureMemoryUserProvisioned() {
+  if (userProvisionPromise) {
+    return userProvisionPromise;
+  }
+  userProvisionPromise = (async () => {
+    const result = await provisionOpenMemoryUser(USER_ID2);
+    if (!result.ok) {
+      console.warn(`[assistant-tools] Unable to pre-provision OpenMemory user '${USER_ID2}': ${result.error}`);
+    }
+  })();
+  await userProvisionPromise;
+}
 async function adminFetch(path, options) {
   try {
     const res = await fetch(`${ADMIN_URL}${path}`, {
@@ -12796,6 +12898,7 @@ async function adminFetch(path, options) {
 }
 async function memoryFetch(path, options) {
   try {
+    await ensureMemoryUserProvisioned();
     const res = await fetch(`${OPENMEMORY_URL2}${path}`, {
       ...options,
       headers: { "content-type": "application/json", ...options?.headers },

--- a/packages/assistant-tools/opencode/tools/lib.ts
+++ b/packages/assistant-tools/opencode/tools/lib.ts
@@ -3,6 +3,132 @@ const ADMIN_TOKEN = process.env.OPENPALM_ADMIN_TOKEN || "";
 const OPENMEMORY_URL = process.env.OPENMEMORY_API_URL || "http://openmemory:8765";
 export const USER_ID = process.env.OPENMEMORY_USER_ID || "default_user";
 
+let userProvisionPromise: Promise<void> | null = null;
+
+type ProvisionResult = { ok: true } | { ok: false; error: string };
+
+async function provisionOpenMemoryUser(userId: string): Promise<ProvisionResult> {
+  const appName = 'openpalm-assistant';
+  const sseController = new AbortController();
+  const timeout = setTimeout(() => sseController.abort(), 10_000);
+
+  try {
+    const sseRes = await fetch(
+      `${OPENMEMORY_URL}/mcp/${appName}/sse/${encodeURIComponent(userId)}`,
+      { signal: sseController.signal },
+    ).catch(() => null);
+
+    if (!sseRes || !sseRes.ok || !sseRes.body) {
+      clearTimeout(timeout);
+      return { ok: false, error: sseRes ? `SSE HTTP ${sseRes.status}` : 'SSE connection failed' };
+    }
+
+    const reader = sseRes.body.getReader();
+    const decoder = new TextDecoder();
+    let sseBuffer = '';
+
+    const readNextEvent = async (timeoutMs = 5_000): Promise<{ event: string; data: string } | null> => {
+      const deadline = Date.now() + timeoutMs;
+      while (Date.now() < deadline) {
+        const remaining = Math.max(deadline - Date.now(), 100);
+        const timeoutRace = new Promise<null>((resolve) =>
+          setTimeout(() => resolve(null), remaining),
+        );
+        const chunk = await Promise.race([reader.read(), timeoutRace]);
+        if (!chunk || (chunk as { done: boolean }).done) return null;
+        sseBuffer += decoder.decode((chunk as { value: Uint8Array }).value, { stream: true });
+        const eventMatch = sseBuffer.match(/event:\s*(\S+)\r?\n(?:data:\s*(.*)\r?\n)?\r?\n/);
+        if (eventMatch) {
+          sseBuffer = sseBuffer.slice((eventMatch.index ?? 0) + eventMatch[0].length);
+          return { event: eventMatch[1], data: eventMatch[2] || '' };
+        }
+      }
+      return null;
+    };
+
+    const endpointEvt = await readNextEvent(5_000);
+    if (!endpointEvt || endpointEvt.event !== 'endpoint' || !endpointEvt.data) {
+      clearTimeout(timeout);
+      sseController.abort();
+      return { ok: false, error: 'No endpoint event received from SSE' };
+    }
+
+    const messagesUrl = `${OPENMEMORY_URL}${endpointEvt.data}`;
+
+    await fetch(messagesUrl, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'initialize',
+        params: {
+          protocolVersion: '2024-11-05',
+          capabilities: {},
+          clientInfo: { name: appName, version: '1.0.0' },
+        },
+      }),
+    }).catch(() => null);
+
+    await readNextEvent(5_000);
+
+    await fetch(messagesUrl, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        method: 'notifications/initialized',
+      }),
+    }).catch(() => null);
+
+    await new Promise((resolve) => setTimeout(resolve, 300));
+
+    await fetch(messagesUrl, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: 2,
+        method: 'tools/call',
+        params: {
+          name: 'add_memories',
+          arguments: {
+            text: `User ${userId} account provisioned by assistant-tools.`,
+          },
+        },
+      }),
+    }).catch(() => null);
+
+    await readNextEvent(8_000);
+
+    clearTimeout(timeout);
+    sseController.abort();
+    return { ok: true };
+  } catch (err) {
+    clearTimeout(timeout);
+    sseController.abort();
+    if (err instanceof Error && err.name === 'AbortError') {
+      return { ok: true };
+    }
+    return { ok: false, error: String(err) };
+  }
+}
+
+export async function ensureMemoryUserProvisioned(): Promise<void> {
+  if (userProvisionPromise) {
+    return userProvisionPromise;
+  }
+
+  userProvisionPromise = (async () => {
+    const result = await provisionOpenMemoryUser(USER_ID);
+    if (!result.ok) {
+      console.warn(`[assistant-tools] Unable to pre-provision OpenMemory user '${USER_ID}': ${result.error}`);
+    }
+  })();
+
+  await userProvisionPromise;
+}
+
 export async function adminFetch(path: string, options?: RequestInit): Promise<string> {
   try {
     const res = await fetch(`${ADMIN_URL}${path}`, {
@@ -25,6 +151,7 @@ export async function adminFetch(path: string, options?: RequestInit): Promise<s
 
 export async function memoryFetch(path: string, options?: RequestInit): Promise<string> {
   try {
+    await ensureMemoryUserProvisioned();
     const res = await fetch(`${OPENMEMORY_URL}${path}`, {
       ...options,
       headers: { "content-type": "application/json", ...options?.headers },


### PR DESCRIPTION
### Motivation
- Ensure the assistant container can run as a non-root process mapped to arbitrary host UIDs/GIDs while keeping bind-mounted files writable across platforms.
- Make OpenMemory usable out-of-the-box by pre-provisioning the assistant's memory user so memory calls do not fail when the user is still the default placeholder.

### Description
- Add `OPENPALM_UID` and `OPENPALM_GID` environment variables to `core/assets/docker-compose.yml` to configure the target runtime UID/GID for the assistant service.
- Install `gosu` in `core/assistant/Dockerfile` and replace the static `user:` compose mapping with an entrypoint that creates/uses a UID/GID mapping and drops privileges at runtime.
- Replace the assistant entrypoint with a robust script (`core/assistant/entrypoint.sh`) that: detects or creates the target user/group, normalizes home and opencode layout, chowns mounts when running as root, optionally enables SSH, sets `OPENMEMORY_USER_ID` to a sensible runtime username when left as `default_user`, and executes OpenCode using `gosu` to run as the mapped UID:GID.
- Update documentation (`docs/environment-and-mounts.md`) to explain the new startup behavior and expose the new environment variables `OPENPALM_UID` and `OPENPALM_GID` and the `OPENMEMORY_USER_ID` fallback behavior.
- Add OpenMemory user pre-provisioning in assistant tools (both built `dist` and `opencode/tools/lib.ts`) by implementing `provisionOpenMemoryUser` and `ensureMemoryUserProvisioned`, which use the OpenMemory MCP SSE/messaging flow to initialize a user and call `add_memories`; invoke `ensureMemoryUserProvisioned` before `memoryFetch` so memory endpoints are prepared.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a93185d5988327a7348e2bf6b934cb)