### PR TITLE
fix: start full stack on update in setup scripts

### DIFF
--- a/scripts/setup.ps1
+++ b/scripts/setup.ps1
@@ -584,9 +584,20 @@ function Compose-UpAdmin {
     return
   }
 
-  Info 'Starting admin container...'
-  Compose-Cmd @('up', '-d', 'docker-socket-proxy', 'admin')
-  Ok 'Admin service started'
+  if ($IsUpdate) {
+    Info 'Starting all services...'
+    # Update: API keys are already configured, restart the full stack
+    # so all services pick up the latest compose file and images.
+    Compose-Cmd @('up', '-d')
+  }
+  else {
+    Info 'Starting admin container...'
+    # Fresh install: start only admin and its Docker socket proxy;
+    # the setup wizard will configure API keys and start remaining services.
+    Compose-Cmd @('up', '-d', 'docker-socket-proxy', 'admin')
+  }
+
+  Ok 'Services started'
 }
 
 function Wait-Healthy {

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -643,12 +643,19 @@ compose_up_admin() {
 		return 0
 	fi
 
-	info "Starting admin container..."
-	# Start only the admin and its Docker socket proxy; skip other services
-	# since the setup wizard hasn't configured API keys yet.
-	compose_cmd up -d docker-socket-proxy admin
+	if [[ $IS_UPDATE -eq 1 ]]; then
+		info "Starting all services..."
+		# Update: API keys are already configured, restart the full stack
+		# so all services pick up the latest compose file and images.
+		compose_cmd up -d
+	else
+		info "Starting admin container..."
+		# Fresh install: start only admin and its Docker socket proxy;
+		# the setup wizard will configure API keys and start remaining services.
+		compose_cmd up -d docker-socket-proxy admin
+	fi
 
-	ok "Admin service started"
+	ok "Services started"
 }
 
 # ── Health check ──────────────────────────────────────────────────────


### PR DESCRIPTION
The setup scripts only started admin and docker-socket-proxy, even
during updates where API keys are already configured. This meant
other services (memory, assistant, guardian, caddy) were not
restarted with updated compose config or images.

Now for updates (secrets.env exists), the scripts run
`docker compose up -d` for all services. Fresh installs still
start only admin so the setup wizard can configure API keys first.

https://claude.ai/code/session_011ofZydQejkFVb6DbAutFcA