### PR TITLE
docs: add architecture diagram for README

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ Schedule recurring tasks by dropping a `.yml` file into `~/.config/openpalm/auto
 <p>OpenPalm has defense built into its core. It has many layers working together to protect your system and your secrets from malicious activity, destructive actions, and other common disasters that can occur with unattended AI assistants.</p>
 </div>
 
+![Architecture](docs/architecture.svg)
+
 - **Admin** (`core/admin/`) — SvelteKit app: operator UI + API + control plane. Only component with Docker socket access.
 - **Guardian** (`core/guardian/`) — Bun HTTP server: HMAC verification, replay detection, rate limiting for all channel traffic.
 - **Assistant** (`core/assistant/`) — OpenCode runtime. No Docker socket. Calls Admin API for stack operations.

--- a/docs/architecture.svg
+++ b/docs/architecture.svg
@@ -1,0 +1,198 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1020 720" font-family="'Segoe UI', system-ui, -apple-system, sans-serif" font-size="13">
+  <defs>
+    <marker id="arrow" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+      <path d="M0,0 L8,3 L0,6 Z" fill="#555"/>
+    </marker>
+    <marker id="arrow-blue" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+      <path d="M0,0 L8,3 L0,6 Z" fill="#3b82f6"/>
+    </marker>
+    <marker id="arrow-green" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+      <path d="M0,0 L8,3 L0,6 Z" fill="#22c55e"/>
+    </marker>
+    <marker id="arrow-orange" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+      <path d="M0,0 L8,3 L0,6 Z" fill="#f97316"/>
+    </marker>
+    <marker id="arrow-red" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+      <path d="M0,0 L8,3 L0,6 Z" fill="#ef4444"/>
+    </marker>
+  </defs>
+
+  <!-- Background -->
+  <rect width="1020" height="720" rx="8" fill="#fafafa"/>
+
+  <!-- Title -->
+  <text x="510" y="32" text-anchor="middle" font-size="20" font-weight="700" fill="#1e293b">OpenPalm Container Topology</text>
+
+  <!-- ═══════════════════════════════════════════════════════════════ -->
+  <!-- NETWORK BOUNDARIES (dashed rectangles)                        -->
+  <!-- ═══════════════════════════════════════════════════════════════ -->
+
+  <!-- channel_public network -->
+  <rect x="30" y="130" width="310" height="295" rx="10" fill="none" stroke="#ef4444" stroke-width="1.5" stroke-dasharray="7,4"/>
+  <text x="45" y="152" font-size="11" fill="#ef4444" font-weight="600">channel_public</text>
+
+  <!-- channel_lan network -->
+  <rect x="20" y="120" width="490" height="315" rx="12" fill="none" stroke="#f97316" stroke-width="1.5" stroke-dasharray="7,4"/>
+  <text x="355" y="142" font-size="11" fill="#f97316" font-weight="600">channel_lan</text>
+
+  <!-- assistant_net network -->
+  <rect x="350" y="110" width="650" height="470" rx="12" fill="none" stroke="#3b82f6" stroke-width="1.5" stroke-dasharray="7,4"/>
+  <text x="830" y="132" font-size="11" fill="#3b82f6" font-weight="600">assistant_net</text>
+
+  <!-- admin_docker_net network -->
+  <rect x="530" y="465" width="460" height="120" rx="10" fill="none" stroke="#8b5cf6" stroke-width="1.5" stroke-dasharray="7,4"/>
+  <text x="545" y="487" font-size="11" fill="#8b5cf6" font-weight="600">admin_docker_net</text>
+
+  <!-- ═══════════════════════════════════════════════════════════════ -->
+  <!-- EXTERNAL ACTORS                                                -->
+  <!-- ═══════════════════════════════════════════════════════════════ -->
+
+  <!-- User browser -->
+  <rect x="40" y="52" width="130" height="40" rx="8" fill="#f1f5f9" stroke="#94a3b8" stroke-width="1.2"/>
+  <text x="105" y="77" text-anchor="middle" font-size="12" fill="#334155" font-weight="600">User Browser</text>
+
+  <!-- External clients -->
+  <rect x="220" y="52" width="150" height="40" rx="8" fill="#f1f5f9" stroke="#94a3b8" stroke-width="1.2"/>
+  <text x="295" y="77" text-anchor="middle" font-size="12" fill="#334155" font-weight="600">External Clients</text>
+
+  <!-- ═══════════════════════════════════════════════════════════════ -->
+  <!-- CONTAINERS                                                     -->
+  <!-- ═══════════════════════════════════════════════════════════════ -->
+
+  <!-- Caddy (infrastructure / gray-blue) -->
+  <rect x="50" y="168" width="160" height="56" rx="10" fill="#e0e7ff" stroke="#6366f1" stroke-width="1.5"/>
+  <text x="130" y="192" text-anchor="middle" font-size="14" font-weight="700" fill="#3730a3">Caddy</text>
+  <text x="130" y="213" text-anchor="middle" font-size="10" fill="#6366f1">reverse proxy :80</text>
+
+  <!-- Guardian (core / blue) -->
+  <rect x="370" y="245" width="160" height="70" rx="10" fill="#dbeafe" stroke="#3b82f6" stroke-width="1.5"/>
+  <text x="450" y="271" text-anchor="middle" font-size="14" font-weight="700" fill="#1e40af">Guardian</text>
+  <text x="450" y="288" text-anchor="middle" font-size="10" fill="#3b82f6">HMAC verify :8080</text>
+  <text x="450" y="304" text-anchor="middle" font-size="10" fill="#3b82f6">replay + rate limit</text>
+
+  <!-- Channel: Chat (green) -->
+  <rect x="60" y="265" width="145" height="50" rx="10" fill="#dcfce7" stroke="#22c55e" stroke-width="1.5"/>
+  <text x="132" y="288" text-anchor="middle" font-size="13" font-weight="600" fill="#166534">channel-chat</text>
+  <text x="132" y="304" text-anchor="middle" font-size="10" fill="#22c55e">:8181</text>
+
+  <!-- Channel: API (green) -->
+  <rect x="60" y="330" width="145" height="50" rx="10" fill="#dcfce7" stroke="#22c55e" stroke-width="1.5"/>
+  <text x="132" y="353" text-anchor="middle" font-size="13" font-weight="600" fill="#166534">channel-api</text>
+  <text x="132" y="369" text-anchor="middle" font-size="10" fill="#22c55e">:8282</text>
+
+  <!-- Channel: Discord (green) -->
+  <rect x="230" y="330" width="145" height="50" rx="10" fill="#dcfce7" stroke="#22c55e" stroke-width="1.5"/>
+  <text x="302" y="353" text-anchor="middle" font-size="13" font-weight="600" fill="#166534">channel-discord</text>
+  <text x="302" y="369" text-anchor="middle" font-size="10" fill="#22c55e">:8383</text>
+
+  <!-- Assistant (core / blue) -->
+  <rect x="620" y="245" width="180" height="70" rx="10" fill="#dbeafe" stroke="#3b82f6" stroke-width="1.5"/>
+  <text x="710" y="271" text-anchor="middle" font-size="14" font-weight="700" fill="#1e40af">Assistant</text>
+  <text x="710" y="288" text-anchor="middle" font-size="10" fill="#3b82f6">OpenCode :4096</text>
+  <text x="710" y="304" text-anchor="middle" font-size="10" fill="#3b82f6">no Docker socket</text>
+
+  <!-- Memory (core / blue) -->
+  <rect x="830" y="245" width="150" height="56" rx="10" fill="#dbeafe" stroke="#3b82f6" stroke-width="1.5"/>
+  <text x="905" y="271" text-anchor="middle" font-size="14" font-weight="700" fill="#1e40af">Memory</text>
+  <text x="905" y="289" text-anchor="middle" font-size="10" fill="#3b82f6">sqlite-vec :8765</text>
+
+  <!-- Admin (core / blue) -->
+  <rect x="550" y="390" width="180" height="70" rx="10" fill="#dbeafe" stroke="#3b82f6" stroke-width="1.5"/>
+  <text x="640" y="416" text-anchor="middle" font-size="14" font-weight="700" fill="#1e40af">Admin</text>
+  <text x="640" y="433" text-anchor="middle" font-size="10" fill="#3b82f6">SvelteKit :8100</text>
+  <text x="640" y="449" text-anchor="middle" font-size="10" fill="#3b82f6">control plane</text>
+
+  <!-- Docker Socket Proxy (infrastructure / gray) -->
+  <rect x="800" y="497" width="175" height="70" rx="10" fill="#f3f4f6" stroke="#6b7280" stroke-width="1.5"/>
+  <text x="887" y="520" text-anchor="middle" font-size="12" font-weight="700" fill="#374151">Docker Socket</text>
+  <text x="887" y="536" text-anchor="middle" font-size="12" font-weight="700" fill="#374151">Proxy</text>
+  <text x="887" y="554" text-anchor="middle" font-size="10" fill="#6b7280">filtered :2375</text>
+
+  <!-- Docker Daemon (external) -->
+  <rect x="810" y="620" width="155" height="42" rx="8" fill="#f1f5f9" stroke="#94a3b8" stroke-width="1.2"/>
+  <text x="887" y="645" text-anchor="middle" font-size="12" fill="#334155" font-weight="600">Docker Daemon</text>
+
+  <!-- ═══════════════════════════════════════════════════════════════ -->
+  <!-- MESSAGE FLOW ARROWS                                            -->
+  <!-- ═══════════════════════════════════════════════════════════════ -->
+
+  <!-- User browser -> Caddy -->
+  <line x1="105" y1="92" x2="120" y2="165" stroke="#555" stroke-width="1.5" marker-end="url(#arrow)"/>
+
+  <!-- External clients -> Caddy (via channels) -->
+  <line x1="270" y1="92" x2="145" y2="165" stroke="#555" stroke-width="1.5" marker-end="url(#arrow)"/>
+
+  <!-- Caddy -> Admin (UI/API route) -->
+  <path d="M 180 224 Q 250 320, 548 420" fill="none" stroke="#3b82f6" stroke-width="1.5" marker-end="url(#arrow-blue)"/>
+  <text x="300" y="330" font-size="10" fill="#3b82f6" font-style="italic">/admin/*</text>
+
+  <!-- Caddy -> channel-chat -->
+  <line x1="115" y1="224" x2="122" y2="262" stroke="#555" stroke-width="1.2" marker-end="url(#arrow)"/>
+
+  <!-- Caddy -> Guardian route -->
+  <path d="M 210 210 Q 290 230, 368 270" fill="none" stroke="#f97316" stroke-width="1.3" marker-end="url(#arrow-orange)"/>
+  <text x="265" y="228" font-size="10" fill="#f97316" font-style="italic">/guardian/*</text>
+
+  <!-- channel-chat -> Guardian (HMAC signed) -->
+  <path d="M 205 280 L 367 275" fill="none" stroke="#22c55e" stroke-width="1.5" marker-end="url(#arrow-green)"/>
+  <text x="270" y="267" font-size="10" fill="#22c55e" font-weight="600">HMAC signed</text>
+
+  <!-- channel-api -> Guardian -->
+  <path d="M 205 352 Q 300 330, 375 300" fill="none" stroke="#22c55e" stroke-width="1.3" marker-end="url(#arrow-green)"/>
+
+  <!-- channel-discord -> Guardian -->
+  <path d="M 375 348 Q 400 330, 420 318" fill="none" stroke="#22c55e" stroke-width="1.3" marker-end="url(#arrow-green)"/>
+
+  <!-- Guardian -> Assistant (validated message) -->
+  <line x1="530" y1="280" x2="617" y2="280" stroke="#3b82f6" stroke-width="1.8" marker-end="url(#arrow-blue)"/>
+  <text x="555" y="270" font-size="10" fill="#3b82f6" font-weight="600">validated</text>
+
+  <!-- Assistant -> Memory -->
+  <line x1="800" y1="273" x2="828" y2="273" stroke="#3b82f6" stroke-width="1.5" marker-end="url(#arrow-blue)"/>
+
+  <!-- Assistant -> Admin API (stack ops) -->
+  <path d="M 680 315 L 660 388" fill="none" stroke="#3b82f6" stroke-width="1.3" stroke-dasharray="5,3" marker-end="url(#arrow-blue)"/>
+  <text x="685" y="355" font-size="10" fill="#3b82f6" font-style="italic">API calls</text>
+
+  <!-- Admin -> Docker Socket Proxy -->
+  <path d="M 730 440 L 798 515" fill="none" stroke="#8b5cf6" stroke-width="1.5" marker-end="url(#arrow)"/>
+  <text x="740" y="480" font-size="10" fill="#8b5cf6" font-style="italic">DOCKER_HOST</text>
+
+  <!-- Docker Socket Proxy -> Docker Daemon -->
+  <line x1="887" y1="567" x2="887" y2="617" stroke="#6b7280" stroke-width="1.5" marker-end="url(#arrow)"/>
+  <text x="905" y="598" font-size="10" fill="#6b7280" font-style="italic">/var/run/docker.sock</text>
+
+  <!-- ═══════════════════════════════════════════════════════════════ -->
+  <!-- LEGEND                                                         -->
+  <!-- ═══════════════════════════════════════════════════════════════ -->
+
+  <rect x="30" y="640" width="500" height="70" rx="8" fill="#fff" stroke="#e2e8f0" stroke-width="1"/>
+
+  <!-- Core services -->
+  <rect x="45" y="653" width="16" height="12" rx="3" fill="#dbeafe" stroke="#3b82f6" stroke-width="1"/>
+  <text x="67" y="664" font-size="11" fill="#334155">Core service</text>
+
+  <!-- Channel adapters -->
+  <rect x="160" y="653" width="16" height="12" rx="3" fill="#dcfce7" stroke="#22c55e" stroke-width="1"/>
+  <text x="182" y="664" font-size="11" fill="#334155">Channel adapter</text>
+
+  <!-- Infrastructure -->
+  <rect x="300" y="653" width="16" height="12" rx="3" fill="#f3f4f6" stroke="#6b7280" stroke-width="1"/>
+  <text x="322" y="664" font-size="11" fill="#334155">Infrastructure</text>
+
+  <!-- External -->
+  <rect x="418" y="653" width="16" height="12" rx="3" fill="#f1f5f9" stroke="#94a3b8" stroke-width="1"/>
+  <text x="440" y="664" font-size="11" fill="#334155">External</text>
+
+  <!-- Network boundary -->
+  <line x1="45" y1="685" x2="80" y2="685" stroke="#555" stroke-width="1.2" stroke-dasharray="6,3"/>
+  <text x="86" y="689" font-size="11" fill="#334155">Network boundary</text>
+
+  <!-- Message flow -->
+  <line x1="210" y1="685" x2="240" y2="685" stroke="#555" stroke-width="1.5" marker-end="url(#arrow)"/>
+  <text x="247" y="689" font-size="11" fill="#334155">Message flow</text>
+
+  <!-- API call -->
+  <line x1="345" y1="685" x2="375" y2="685" stroke="#555" stroke-width="1.2" stroke-dasharray="5,3" marker-end="url(#arrow)"/>
+  <text x="382" y="689" font-size="11" fill="#334155">Internal API call</text>
+</svg>


### PR DESCRIPTION
## Summary
- Adds an SVG architecture diagram (`docs/architecture.svg`) showing the full OpenPalm container topology, network boundaries, and message flow
- Embeds the diagram in `README.md` under the "How It Works" section

The diagram covers:
- All 7 core containers: Caddy, Admin, Guardian, Assistant, Memory, Docker Socket Proxy, plus channel adapters (chat, api, discord)
- All 4 Docker networks: `admin_docker_net`, `assistant_net`, `channel_lan`, `channel_public`
- Message flow: External client -> Channel -> Guardian (HMAC verify) -> Assistant -> Memory
- Admin flow: Browser -> Caddy -> Admin -> Docker Socket Proxy -> Docker Daemon
- Color coding: blue for core services, green for channels, gray for infrastructure
- Legend explaining all visual elements

Closes #277

## Test plan
- [ ] Verify SVG renders correctly on GitHub (view `docs/architecture.svg` directly and in README.md)
- [ ] Confirm diagram accuracy against `core/assets/docker-compose.yml` network/service definitions
- [ ] Check rendering on both light and dark GitHub themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)