### PR TITLE
fix: remove hardcoded big-pickle default model

### DIFF
--- a/core/assets/opencode.jsonc
+++ b/core/assets/opencode.jsonc
@@ -1,5 +1,4 @@
 {
   "$schema": "https://opencode.ai/config.json",
-  "model": "opencode/big-pickle",
   "plugin": ["@openpalm/assistant-tools", "agentikit-opencode"]
 }

--- a/core/cli/src/main.ts
+++ b/core/cli/src/main.ts
@@ -256,7 +256,6 @@ async function ensureOpenCodeSystemConfig(dataHome: string): Promise<void> {
     JSON.stringify(
       {
         "$schema": "https://opencode.ai/config.json",
-        "model": "opencode/big-pickle",
         "plugin": ["@openpalm/assistant-tools", "@itlackey/openkit"]
       },
       null,

--- a/docs/memory-privacy.md
+++ b/docs/memory-privacy.md
@@ -66,6 +66,15 @@ Every time a fact is stored or a search query is executed, the text is sent to t
 
 **To keep all data on your local network**, configure both the LLM and embedding providers to use a local Ollama instance. When using remote providers (OpenAI, Anthropic, etc.), the fact text and search queries are sent to those external APIs.
 
+### Assistant model (chat completions)
+
+The assistant service (OpenCode) sends conversation messages to the configured chat model for inference. Which model is used depends entirely on operator configuration during setup:
+
+- **Local provider (Ollama):** All inference stays on the local network. No data leaves the host.
+- **Remote provider (OpenAI, Anthropic, Groq, etc.):** Conversation content is sent to that provider's API. Each provider has its own data retention and usage policies. Consult the provider's terms of service and privacy policy for details.
+
+OpenPalm does not default to any specific model. The setup wizard requires the operator to choose a provider and model before the stack starts. This ensures the operator makes a conscious decision about where their data is processed.
+
 ## How to view stored memories
 
 ### Admin API

--- a/docs/opencode-configuration.md
+++ b/docs/opencode-configuration.md
@@ -20,8 +20,8 @@ OpenCode supports a layered configuration model. OpenPalm uses three layers:
    This is the lowest-precedence layer.
 2. **System config** — persisted on the host at
    `$OPENPALM_DATA_HOME/assistant/` and bind-mounted into the container at
-   `/etc/opencode/` via `OPENCODE_CONFIG_DIR`. Contains the model selection,
-   plugin declarations, and persona (AGENTS.md). Overrides user config.
+   `/etc/opencode/` via `OPENCODE_CONFIG_DIR`. Contains plugin declarations
+   and persona (AGENTS.md). Overrides user config for keys it sets.
 3. **Project config** — an `opencode.json` in the `/work` directory (if present).
    Highest precedence, overrides everything.
 
@@ -122,15 +122,20 @@ and overwritten when the bundled version changes (with backup).
 
 ### opencode.jsonc
 
-Selects the default model and declares plugins for auto-install:
+Declares plugins for auto-install. The model is not set here; it comes
+from the user's connection setup (see below):
 
 ```jsonc
 {
   "$schema": "https://opencode.ai/config.json",
-  "model": "opencode/big-pickle",
   "plugin": ["@openpalm/assistant-tools", "@itlackey/openkit"]
 }
 ```
+
+The model is **not** set in the system config. It is determined by the
+user's connection setup: the setup wizard or admin UI writes the selected
+model to `CONFIG_HOME/assistant/opencode.json`, which OpenCode picks up
+as the user config layer.
 
 ### AGENTS.md
 


### PR DESCRIPTION
## Summary
- Removes the hardcoded `"model": "opencode/big-pickle"` default from the system config asset (`core/assets/opencode.jsonc`) and the CLI's `ensureOpenCodeSystemConfig()` in `core/cli/src/main.ts`
- The system config now declares only the `$schema` and `plugin` list -- no model default
- The model is determined entirely by the operator's connection setup (wizard or admin UI), which writes to `CONFIG_HOME/assistant/opencode.json` (user config layer)
- Adds assistant model data collection disclosure section to `docs/memory-privacy.md`
- Updates `docs/opencode-configuration.md` to reflect that system config no longer sets a model

## Why
The `opencode.jsonc` system config (layer 2) overrides the user config (layer 1) in OpenCode's precedence chain. This meant the hardcoded `big-pickle` default could silently override whatever model the operator selected during setup. Since `big-pickle` may send data to external services during its free period, this conflicted with OpenPalm's "nothing leaves your network" value proposition.

## Test plan
- [x] `npx vitest run src/lib/server/core-assets.test.ts` -- 25 tests pass (verifies system config seeding)
- [x] `npx vitest run src/lib/server/connection-mapping.test.ts` -- 14 tests pass (verifies opencode config writing)
- [x] `npx svelte-check` -- 0 new errors (pre-existing dotenv/croner missing in worktree)
- [x] Grep confirms zero remaining `big-pickle` references in codebase
- [ ] Manual: fresh install via setup wizard selects operator-chosen model, not big-pickle

Closes #256

🤖 Generated with [Claude Code](https://claude.com/claude-code)