### PR TITLE
Release prep batch 2: scripts, tests, docs, Windows fixes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,7 +102,12 @@ jobs:
             echo "Bumped ${pkg} to ${VERSION}"
           done
 
-          git add package.json core/*/package.json
+          # Stamp SCRIPT_VERSION into setup scripts so curl|bash defaults to this release
+          sed -i "s/^SCRIPT_VERSION=\".*\"/SCRIPT_VERSION=\"${VERSION}\"/" scripts/setup.sh
+          sed -i "s/^\\\$ScriptVersion = '.*'/\$ScriptVersion = '${VERSION}'/" scripts/setup.ps1
+          echo "Stamped SCRIPT_VERSION=${VERSION} into setup scripts"
+
+          git add package.json core/*/package.json scripts/setup.sh scripts/setup.ps1
           git commit -m "chore: bump version to ${VERSION}"
           git push origin "${BRANCH}"
 
@@ -295,7 +300,7 @@ jobs:
             ## Quick Install
 
             ```bash
-            curl -fsSL https://raw.githubusercontent.com/itlackey/openpalm/main/scripts/setup.sh | bash
+            curl -fsSL https://raw.githubusercontent.com/itlackey/openpalm/v${{ needs.prepare-tag.outputs.version }}/scripts/setup.sh | bash
             ```
 
             ## What's Changed

--- a/README.md
+++ b/README.md
@@ -36,12 +36,12 @@ Copy-paste **one** command into your terminal and the installer does the rest:
 
 **Mac or Linux** — open Terminal and paste:
 ```bash
-curl -fsSL https://raw.githubusercontent.com/itlackey/openpalm/main/scripts/setup.sh | bash
+curl -fsSL https://raw.githubusercontent.com/itlackey/openpalm/v0.9.0-rc5/scripts/setup.sh | bash
 ```
 
 **Windows (PowerShell)** — open PowerShell and paste:
 ```powershell
-irm https://raw.githubusercontent.com/itlackey/openpalm/main/scripts/setup.ps1 | iex
+irm https://raw.githubusercontent.com/itlackey/openpalm/v0.9.0-rc5/scripts/setup.ps1 | iex
 ```
 
 No config files to edit. Re-run the same command to update — your secrets are never overwritten.
@@ -83,6 +83,8 @@ Schedule recurring tasks by dropping a `.yml` file into `~/.config/openpalm/auto
 <img src="core/admin/static/fu-128.png" alt="OpenPalm" width="90" style="float: right; shape-margin: 0.25rem;" />
 <p>OpenPalm has defense built into its core. It has many layers working together to protect your system and your secrets from malicious activity, destructive actions, and other common disasters that can occur with unattended AI assistants.</p>
 </div>
+
+![Architecture](docs/architecture.svg)
 
 - **Admin** (`core/admin/`) — SvelteKit app: operator UI + API + control plane. Only component with Docker socket access.
 - **Guardian** (`core/guardian/`) — Bun HTTP server: HMAC verification, replay detection, rate limiting for all channel traffic.

--- a/core/admin/e2e/channel-guardian-pipeline.test.ts
+++ b/core/admin/e2e/channel-guardian-pipeline.test.ts
@@ -1,0 +1,336 @@
+import { expect, test } from '@playwright/test';
+import { createHmac, randomUUID } from 'node:crypto';
+import { readFileSync, writeFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * Channel -> Guardian -> Assistant Full-Chain Integration Tests
+ *
+ * Exercises the COMPLETE message flow that real channel adapters use:
+ *   1. Build a ChannelPayload (userId, channel, text, nonce, timestamp)
+ *   2. HMAC-SHA256 sign it with the channel secret
+ *   3. POST to guardian /channel/inbound (via Caddy proxy)
+ *   4. Guardian verifies HMAC, checks nonce/replay, checks rate limit
+ *   5. Guardian forwards to the assistant (OpenCode)
+ *   6. Response flows back: assistant -> guardian -> test client
+ *
+ * This closes the test coverage gap where assistant-pipeline.test.ts talks
+ * to OpenCode directly (bypassing guardian) and server.test.ts uses a mock
+ * assistant (never hitting the real one).
+ *
+ * Prerequisites:
+ *   - Running compose stack (RUN_DOCKER_STACK_TESTS=1)
+ *   - LLM provider configured for message tests (RUN_LLM_TESTS=1)
+ *
+ * Run with:
+ *   RUN_DOCKER_STACK_TESTS=1 bun run admin:test:e2e
+ *   RUN_DOCKER_STACK_TESTS=1 RUN_LLM_TESTS=1 bun run admin:test:e2e
+ */
+
+// ── Config ───────────────────────────────────────────────────────────────
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(HERE, '../../..');
+const STACK_ENV_PATH = resolve(REPO_ROOT, '.dev/state/artifacts/stack.env');
+
+/**
+ * Guardian URL: Caddy proxies /guardian/* to guardian:8080 (stripping prefix).
+ * The ingress port defaults to 8080 via OPENPALM_INGRESS_PORT in stack.env.
+ */
+const CADDY_BASE = `http://localhost:${process.env.OPENPALM_INGRESS_PORT ?? '8080'}`;
+const GUARDIAN_URL = `${CADDY_BASE}/guardian`;
+
+const TEST_CHANNEL = 'e2etest';
+const TEST_SECRET = `e2e-test-secret-${Date.now()}`;
+
+// ── HMAC helpers (pure Node.js — no Bun dependency) ─────────────────────
+
+function signPayload(secret: string, body: string): string {
+	return createHmac('sha256', secret).update(body).digest('hex');
+}
+
+function makePayload(overrides: Record<string, unknown> = {}) {
+	return {
+		userId: `e2e-user-${Date.now()}`,
+		channel: TEST_CHANNEL,
+		text: 'hello from e2e channel test',
+		nonce: randomUUID(),
+		timestamp: Date.now(),
+		...overrides
+	};
+}
+
+// ── Stack.env secret management ─────────────────────────────────────────
+
+let originalStackEnv: string | null = null;
+
+/**
+ * Seeds CHANNEL_E2ETEST_SECRET into stack.env so the guardian can verify
+ * our test messages. The guardian re-reads the file on each request
+ * (via GUARDIAN_SECRETS_PATH), so no container restart is needed.
+ */
+function seedTestSecret(): boolean {
+	try {
+		originalStackEnv = readFileSync(STACK_ENV_PATH, 'utf8');
+		const secretLine = `CHANNEL_E2ETEST_SECRET=${TEST_SECRET}`;
+		if (originalStackEnv.includes('CHANNEL_E2ETEST_SECRET=')) {
+			// Replace existing
+			const updated = originalStackEnv.replace(
+				/^CHANNEL_E2ETEST_SECRET=.*$/m,
+				secretLine
+			);
+			writeFileSync(STACK_ENV_PATH, updated);
+		} else {
+			// Append
+			writeFileSync(STACK_ENV_PATH, originalStackEnv.trimEnd() + '\n' + secretLine + '\n');
+		}
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+function restoreStackEnv(): void {
+	if (originalStackEnv !== null) {
+		try {
+			writeFileSync(STACK_ENV_PATH, originalStackEnv);
+		} catch {
+			// Best-effort restore
+		}
+	}
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────
+
+test.describe('Channel -> Guardian -> Assistant Pipeline', () => {
+	const SKIP = !process.env.RUN_DOCKER_STACK_TESTS;
+	test.skip(!!SKIP, 'Requires RUN_DOCKER_STACK_TESTS=1 and running compose stack');
+
+	let secretSeeded = false;
+
+	test.beforeAll(() => {
+		secretSeeded = seedTestSecret();
+	});
+
+	test.afterAll(() => {
+		restoreStackEnv();
+	});
+
+	// ── Group 1: Guardian reachability (no LLM needed) ──────────────
+
+	test('guardian health check responds via Caddy proxy', async ({ request }) => {
+		const res = await request.get(`${GUARDIAN_URL}/health`, { timeout: 10_000 });
+		expect(res.ok(), `Guardian health check failed: ${res.status()}`).toBeTruthy();
+		const body = await res.json();
+		expect(body.ok).toBe(true);
+		expect(body.service).toBe('guardian');
+	});
+
+	test('test channel secret is seeded in stack.env', () => {
+		expect(secretSeeded).toBe(true);
+	});
+
+	// ── Group 2: HMAC verification (no LLM needed) ──────────────────
+
+	test('valid HMAC-signed message is accepted by guardian', async ({ request }) => {
+		test.skip(!secretSeeded, 'Could not seed test secret');
+		test.setTimeout(130_000);
+
+		const payload = makePayload();
+		const body = JSON.stringify(payload);
+		const signature = signPayload(TEST_SECRET, body);
+
+		const res = await request.post(`${GUARDIAN_URL}/channel/inbound`, {
+			headers: {
+				'content-type': 'application/json',
+				'x-channel-signature': signature
+			},
+			data: body,
+			timeout: 125_000
+		});
+
+		// Guardian should accept the message. If assistant is unavailable we get 502,
+		// but the HMAC verification itself passed (would be 403 otherwise).
+		expect(
+			[200, 502].includes(res.status()),
+			`Expected 200 (success) or 502 (assistant unavailable), got ${res.status()}: ${await res.text()}`
+		).toBeTruthy();
+
+		if (res.status() === 200) {
+			const data = await res.json();
+			expect(data.userId).toBe(payload.userId);
+			expect(typeof data.sessionId).toBe('string');
+			expect(typeof data.answer).toBe('string');
+			expect(data.answer.length).toBeGreaterThan(0);
+		}
+	});
+
+	test('invalid HMAC signature is rejected with 403', async ({ request }) => {
+		test.skip(!secretSeeded, 'Could not seed test secret');
+
+		const payload = makePayload();
+		const body = JSON.stringify(payload);
+
+		const res = await request.post(`${GUARDIAN_URL}/channel/inbound`, {
+			headers: {
+				'content-type': 'application/json',
+				'x-channel-signature': 'deadbeef0000111122223333444455556666777788889999aaaabbbbccccdddd'
+			},
+			data: body,
+			timeout: 10_000
+		});
+
+		expect(res.status()).toBe(403);
+		const data = await res.json();
+		expect(data.error).toBe('invalid_signature');
+	});
+
+	test('missing signature header is rejected with 403', async ({ request }) => {
+		test.skip(!secretSeeded, 'Could not seed test secret');
+
+		const payload = makePayload();
+
+		const res = await request.post(`${GUARDIAN_URL}/channel/inbound`, {
+			headers: { 'content-type': 'application/json' },
+			data: JSON.stringify(payload),
+			timeout: 10_000
+		});
+
+		expect(res.status()).toBe(403);
+		const data = await res.json();
+		expect(data.error).toBe('invalid_signature');
+	});
+
+	// ── Group 3: Nonce replay protection (no LLM needed) ───────────
+
+	test('replayed nonce is rejected with 409', async ({ request }) => {
+		test.skip(!secretSeeded, 'Could not seed test secret');
+		test.setTimeout(130_000);
+
+		const nonce = randomUUID();
+		const payload1 = makePayload({ nonce });
+		const body1 = JSON.stringify(payload1);
+		const sig1 = signPayload(TEST_SECRET, body1);
+
+		// First request should succeed (or 502 if assistant is down)
+		const res1 = await request.post(`${GUARDIAN_URL}/channel/inbound`, {
+			headers: {
+				'content-type': 'application/json',
+				'x-channel-signature': sig1
+			},
+			data: body1,
+			timeout: 125_000
+		});
+		expect(
+			[200, 502].includes(res1.status()),
+			`First request: expected 200 or 502, got ${res1.status()}`
+		).toBeTruthy();
+
+		// Second request with same nonce should be rejected as replay
+		const payload2 = makePayload({ nonce, userId: payload1.userId });
+		const body2 = JSON.stringify(payload2);
+		const sig2 = signPayload(TEST_SECRET, body2);
+
+		const res2 = await request.post(`${GUARDIAN_URL}/channel/inbound`, {
+			headers: {
+				'content-type': 'application/json',
+				'x-channel-signature': sig2
+			},
+			data: body2,
+			timeout: 10_000
+		});
+		expect(res2.status()).toBe(409);
+		const data = await res2.json();
+		expect(data.error).toBe('replay_detected');
+	});
+
+	test('expired timestamp is rejected with 409', async ({ request }) => {
+		test.skip(!secretSeeded, 'Could not seed test secret');
+
+		const payload = makePayload({ timestamp: Date.now() - 6 * 60 * 1000 });
+		const body = JSON.stringify(payload);
+		const signature = signPayload(TEST_SECRET, body);
+
+		const res = await request.post(`${GUARDIAN_URL}/channel/inbound`, {
+			headers: {
+				'content-type': 'application/json',
+				'x-channel-signature': signature
+			},
+			data: body,
+			timeout: 10_000
+		});
+		expect(res.status()).toBe(409);
+		const data = await res.json();
+		expect(data.error).toBe('replay_detected');
+	});
+
+	// ── Group 4: Payload validation (no LLM needed) ─────────────────
+
+	test('missing required fields returns 400', async ({ request }) => {
+		test.skip(!secretSeeded, 'Could not seed test secret');
+
+		const incomplete = { userId: 'u1' };
+		const body = JSON.stringify(incomplete);
+		const signature = signPayload(TEST_SECRET, body);
+
+		const res = await request.post(`${GUARDIAN_URL}/channel/inbound`, {
+			headers: {
+				'content-type': 'application/json',
+				'x-channel-signature': signature
+			},
+			data: body,
+			timeout: 10_000
+		});
+		expect(res.status()).toBe(400);
+		const data = await res.json();
+		expect(data.error).toBe('invalid_payload');
+	});
+
+	test('invalid JSON body returns 400', async ({ request }) => {
+		const res = await request.post(`${GUARDIAN_URL}/channel/inbound`, {
+			headers: {
+				'content-type': 'application/json',
+				'x-channel-signature': 'anything'
+			},
+			data: 'not valid json{{{',
+			timeout: 10_000
+		});
+		expect(res.status()).toBe(400);
+		const data = await res.json();
+		expect(data.error).toBe('invalid_json');
+	});
+
+	// ── Group 5: Full pipeline with LLM (needs RUN_LLM_TESTS=1) ────
+
+	test('HMAC-signed message gets LLM response through full chain', async ({ request }) => {
+		const SKIP_LLM = !process.env.RUN_LLM_TESTS;
+		test.skip(!!SKIP_LLM, 'Requires RUN_LLM_TESTS=1 (LLM inference through guardian)');
+		test.skip(!secretSeeded, 'Could not seed test secret');
+		test.setTimeout(180_000);
+
+		const payload = makePayload({
+			text: 'Reply with exactly the word "channel-pipeline-ok". Nothing else.'
+		});
+		const body = JSON.stringify(payload);
+		const signature = signPayload(TEST_SECRET, body);
+
+		const res = await request.post(`${GUARDIAN_URL}/channel/inbound`, {
+			headers: {
+				'content-type': 'application/json',
+				'x-channel-signature': signature
+			},
+			data: body,
+			timeout: 175_000
+		});
+
+		expect(res.status()).toBe(200);
+		const data = await res.json();
+		expect(data.userId).toBe(payload.userId);
+		expect(typeof data.sessionId).toBe('string');
+		expect(data.sessionId.length).toBeGreaterThan(0);
+		expect(typeof data.answer).toBe('string');
+		expect(data.answer.length).toBeGreaterThan(0);
+		expect(typeof data.requestId).toBe('string');
+	});
+});

--- a/core/admin/e2e/scheduler.test.ts
+++ b/core/admin/e2e/scheduler.test.ts
@@ -1,0 +1,167 @@
+/**
+ * Automation Scheduler — Stack-dependent E2E tests
+ *
+ * Validates that the scheduler is running in the admin container and that
+ * automations are loaded and reported correctly via the admin API.
+ *
+ * These tests hit the real admin container at http://localhost:8100 and
+ * require a running compose stack. They verify:
+ *
+ *   1. GET /admin/automations returns valid structure with scheduler status
+ *   2. Automations from the state directory are loaded and listed
+ *   3. Execution logs are present for automations that have fired
+ *
+ * Run with:
+ *   RUN_DOCKER_STACK_TESTS=1 ADMIN_TOKEN=dev-admin-token bun run admin:test:e2e
+ */
+
+import { expect, test } from '@playwright/test';
+
+const ADMIN_URL = 'http://localhost:8100';
+
+/** Build admin auth headers. */
+function adminHeaders(): Record<string, string> {
+	return {
+		'x-admin-token': process.env.ADMIN_TOKEN ?? '',
+		'x-requested-by': 'test',
+		'x-request-id': crypto.randomUUID()
+	};
+}
+
+// ── Group: Scheduler API (stack-dependent) ───────────────────────────
+
+test.describe('Automation Scheduler API', () => {
+	const SKIP = !process.env.RUN_DOCKER_STACK_TESTS;
+	test.skip(!!SKIP, 'Requires RUN_DOCKER_STACK_TESTS=1 and running compose stack');
+
+	test('GET /admin/automations returns valid structure', async ({ request }) => {
+		const response = await request.get(`${ADMIN_URL}/admin/automations`, {
+			headers: adminHeaders(),
+			timeout: 10_000
+		});
+
+		expect(response.ok()).toBeTruthy();
+		const data = await response.json();
+
+		// Must have top-level automations array and scheduler status
+		expect(data).toHaveProperty('automations');
+		expect(Array.isArray(data.automations)).toBe(true);
+		expect(data).toHaveProperty('scheduler');
+		expect(typeof data.scheduler.jobCount).toBe('number');
+		expect(Array.isArray(data.scheduler.jobs)).toBe(true);
+	});
+
+	test('GET /admin/automations requires auth', async ({ request }) => {
+		const response = await request.get(`${ADMIN_URL}/admin/automations`, {
+			headers: { 'x-request-id': crypto.randomUUID() },
+			timeout: 10_000
+		});
+		expect(response.status()).toBe(401);
+	});
+
+	test('scheduler reports running jobs matching enabled automations', async ({ request }) => {
+		const response = await request.get(`${ADMIN_URL}/admin/automations`, {
+			headers: adminHeaders(),
+			timeout: 10_000
+		});
+
+		expect(response.ok()).toBeTruthy();
+		const data = await response.json();
+
+		const enabledAutomations = data.automations.filter(
+			(a: { enabled: boolean }) => a.enabled
+		);
+		const schedulerJobs = data.scheduler.jobs;
+
+		// Every enabled automation should have a corresponding scheduler job
+		for (const automation of enabledAutomations) {
+			const matchingJob = schedulerJobs.find(
+				(j: { fileName: string }) => j.fileName === automation.fileName
+			);
+			expect(
+				matchingJob,
+				`Expected scheduler job for enabled automation "${automation.name}" (${automation.fileName})`
+			).toBeDefined();
+			expect(matchingJob.running).toBe(true);
+		}
+
+		// Job count should match enabled automation count
+		expect(data.scheduler.jobCount).toBe(enabledAutomations.length);
+	});
+
+	test('automation entries have required fields', async ({ request }) => {
+		const response = await request.get(`${ADMIN_URL}/admin/automations`, {
+			headers: adminHeaders(),
+			timeout: 10_000
+		});
+
+		expect(response.ok()).toBeTruthy();
+		const data = await response.json();
+
+		for (const automation of data.automations) {
+			expect(typeof automation.name).toBe('string');
+			expect(typeof automation.schedule).toBe('string');
+			expect(typeof automation.enabled).toBe('boolean');
+			expect(typeof automation.fileName).toBe('string');
+			expect(automation.fileName).toMatch(/\.yml$/);
+
+			// Action must have a valid type
+			expect(automation.action).toBeDefined();
+			expect(['api', 'http', 'shell', 'assistant']).toContain(automation.action.type);
+
+			// Logs array must be present (may be empty if automation has not fired yet)
+			expect(Array.isArray(automation.logs)).toBe(true);
+		}
+	});
+
+	test('core automations are present and enabled', async ({ request }) => {
+		const response = await request.get(`${ADMIN_URL}/admin/automations`, {
+			headers: adminHeaders(),
+			timeout: 10_000
+		});
+
+		expect(response.ok()).toBeTruthy();
+		const data = await response.json();
+
+		// A deployed stack should have at least one automation (core automations
+		// are seeded during setup). If no automations exist, the test still passes
+		// since the scheduler structure was already validated above.
+		if (data.automations.length > 0) {
+			// At least one automation should be enabled
+			const hasEnabled = data.automations.some((a: { enabled: boolean }) => a.enabled);
+			expect(hasEnabled).toBe(true);
+		}
+	});
+
+	test('execution logs contain valid entries for fired automations', async ({ request }) => {
+		const response = await request.get(`${ADMIN_URL}/admin/automations`, {
+			headers: adminHeaders(),
+			timeout: 10_000
+		});
+
+		expect(response.ok()).toBeTruthy();
+		const data = await response.json();
+
+		// Check any automations that have execution log entries
+		for (const automation of data.automations) {
+			if (automation.logs.length > 0) {
+				for (const entry of automation.logs) {
+					expect(typeof entry.at).toBe('string');
+					expect(typeof entry.ok).toBe('boolean');
+					expect(typeof entry.durationMs).toBe('number');
+					expect(entry.durationMs).toBeGreaterThanOrEqual(0);
+
+					// Failed entries should have an error message
+					if (!entry.ok) {
+						expect(typeof entry.error).toBe('string');
+						expect(entry.error!.length).toBeGreaterThan(0);
+					}
+
+					// Timestamp should be a valid ISO date
+					const parsed = new Date(entry.at);
+					expect(parsed.getTime()).not.toBeNaN();
+				}
+			}
+		}
+	});
+});

--- a/core/admin/src/lib/server/scheduler.test.ts
+++ b/core/admin/src/lib/server/scheduler.test.ts
@@ -6,12 +6,15 @@
  * 2. Schedule preset resolution
  * 3. Automation loading from directory
  * 4. Scheduler start/stop lifecycle
+ * 5. executeAction integration (http action with real HTTP server)
+ * 6. Scheduler fires cron job and records execution log
  */
 import { describe, test, expect, beforeEach, afterEach, vi } from "vitest";
 import { mkdirSync, writeFileSync, rmSync } from "node:fs";
 import { randomBytes } from "node:crypto";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { createServer, type Server } from "node:http";
 import {
   parseAutomationYaml,
   resolveSchedule,
@@ -20,6 +23,7 @@ import {
   startScheduler,
   stopScheduler,
   getSchedulerStatus,
+  getExecutionLog,
   executeAction
 } from "./scheduler.js";
 
@@ -611,4 +615,232 @@ describe("executeAction assistant", () => {
       )
     ).rejects.toThrow("OpenCode POST /session/sess1/message 504");
   });
+});
+
+// ── executeAction integration: http action with real HTTP server ─────
+
+describe("executeAction http integration", () => {
+  let server: Server;
+  let serverPort: number;
+  let receivedRequests: { method: string; url: string; body: string; headers: Record<string, string | string[] | undefined> }[];
+
+  beforeEach(async () => {
+    receivedRequests = [];
+    server = createServer((req, res) => {
+      let body = "";
+      req.on("data", (chunk) => { body += chunk; });
+      req.on("end", () => {
+        receivedRequests.push({
+          method: req.method ?? "",
+          url: req.url ?? "",
+          body,
+          headers: req.headers as Record<string, string | string[] | undefined>
+        });
+        res.writeHead(200, { "content-type": "application/json" });
+        res.end(JSON.stringify({ ok: true }));
+      });
+    });
+
+    // Listen on a random available port
+    await new Promise<void>((resolve) => {
+      server.listen(0, "127.0.0.1", () => resolve());
+    });
+    const addr = server.address();
+    serverPort = typeof addr === "object" && addr !== null ? addr.port : 0;
+  });
+
+  afterEach(async () => {
+    await new Promise<void>((resolve) => {
+      server.close(() => resolve());
+    });
+  });
+
+  test("http GET action hits the target server", async () => {
+    await executeAction(
+      {
+        type: "http",
+        method: "GET",
+        url: `http://127.0.0.1:${serverPort}/test-endpoint`,
+        timeout: 5000
+      },
+      "unused-token"
+    );
+
+    expect(receivedRequests.length).toBe(1);
+    expect(receivedRequests[0].method).toBe("GET");
+    expect(receivedRequests[0].url).toBe("/test-endpoint");
+  });
+
+  test("http POST action sends body and custom headers", async () => {
+    await executeAction(
+      {
+        type: "http",
+        method: "POST",
+        url: `http://127.0.0.1:${serverPort}/webhook`,
+        body: { message: "hello from automation" },
+        headers: { "x-custom-header": "test-value" },
+        timeout: 5000
+      },
+      "unused-token"
+    );
+
+    expect(receivedRequests.length).toBe(1);
+    expect(receivedRequests[0].method).toBe("POST");
+    expect(receivedRequests[0].url).toBe("/webhook");
+    expect(JSON.parse(receivedRequests[0].body)).toEqual({ message: "hello from automation" });
+    expect(receivedRequests[0].headers["x-custom-header"]).toBe("test-value");
+    expect(receivedRequests[0].headers["content-type"]).toBe("application/json");
+  });
+
+  test("http action throws on non-2xx response", async () => {
+    // Replace the server with one that returns 500
+    await new Promise<void>((resolve) => {
+      server.close(() => resolve());
+    });
+
+    server = createServer((_req, res) => {
+      res.writeHead(500, { "content-type": "text/plain" });
+      res.end("Internal Server Error");
+    });
+    await new Promise<void>((resolve) => {
+      server.listen(serverPort, "127.0.0.1", () => resolve());
+    });
+
+    await expect(
+      executeAction(
+        {
+          type: "http",
+          method: "GET",
+          url: `http://127.0.0.1:${serverPort}/fail`,
+          timeout: 5000
+        },
+        "unused-token"
+      )
+    ).rejects.toThrow("HTTP 500");
+  });
+});
+
+// ── Scheduler fires cron and records execution log ───────────────────
+
+describe("scheduler cron firing", () => {
+  let stateDir: string;
+  let server: Server;
+  let serverPort: number;
+  let hitCount: number;
+
+  beforeEach(async () => {
+    stateDir = makeTempDir();
+    hitCount = 0;
+    stopScheduler();
+
+    server = createServer((_req, res) => {
+      hitCount++;
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ ok: true }));
+    });
+
+    await new Promise<void>((resolve) => {
+      server.listen(0, "127.0.0.1", () => resolve());
+    });
+    const addr = server.address();
+    serverPort = typeof addr === "object" && addr !== null ? addr.port : 0;
+  });
+
+  afterEach(async () => {
+    stopScheduler();
+    rmSync(stateDir, { recursive: true, force: true });
+    await new Promise<void>((resolve) => {
+      server.close(() => resolve());
+    });
+  });
+
+  test("scheduler fires http automation and records execution log", async () => {
+    const dir = join(stateDir, "automations");
+    mkdirSync(dir, { recursive: true });
+
+    // Use a per-second cron pattern so it fires within 2 seconds
+    writeFileSync(
+      join(dir, "e2e-probe.yml"),
+      [
+        "name: E2E Probe",
+        "description: Integration test automation",
+        "schedule: '* * * * * *'",  // every second (Croner supports seconds)
+        "action:",
+        "  type: http",
+        "  method: GET",
+        `  url: http://127.0.0.1:${serverPort}/scheduler-probe`,
+        "  timeout: 5000"
+      ].join("\n")
+    );
+
+    startScheduler(stateDir, "test-token");
+
+    const status = getSchedulerStatus();
+    expect(status.jobCount).toBe(1);
+    expect(status.jobs[0].name).toBe("E2E Probe");
+    expect(status.jobs[0].running).toBe(true);
+
+    // Wait for the cron to fire (up to 5 seconds, polling every 200ms)
+    const deadline = Date.now() + 5_000;
+    while (hitCount === 0 && Date.now() < deadline) {
+      await new Promise((r) => setTimeout(r, 200));
+    }
+
+    expect(hitCount).toBeGreaterThanOrEqual(1);
+
+    // Verify execution log was recorded
+    const logs = getExecutionLog("e2e-probe.yml");
+    expect(logs.length).toBeGreaterThanOrEqual(1);
+    expect(logs[0].ok).toBe(true);
+    expect(typeof logs[0].durationMs).toBe("number");
+    expect(typeof logs[0].at).toBe("string");
+  }, 10_000);
+
+  test("scheduler records failure in execution log when action fails", async () => {
+    // Replace server with one that returns 500
+    await new Promise<void>((resolve) => {
+      server.close(() => resolve());
+    });
+
+    server = createServer((_req, res) => {
+      hitCount++;
+      res.writeHead(500, { "content-type": "text/plain" });
+      res.end("Internal Server Error");
+    });
+    await new Promise<void>((resolve) => {
+      server.listen(serverPort, "127.0.0.1", () => resolve());
+    });
+
+    const dir = join(stateDir, "automations");
+    mkdirSync(dir, { recursive: true });
+
+    writeFileSync(
+      join(dir, "failing-probe.yml"),
+      [
+        "name: Failing Probe",
+        "schedule: '* * * * * *'",
+        "action:",
+        "  type: http",
+        "  method: GET",
+        `  url: http://127.0.0.1:${serverPort}/will-fail`,
+        "  timeout: 5000"
+      ].join("\n")
+    );
+
+    startScheduler(stateDir, "test-token");
+
+    // Wait for the cron to fire
+    const deadline = Date.now() + 5_000;
+    while (hitCount === 0 && Date.now() < deadline) {
+      await new Promise((r) => setTimeout(r, 200));
+    }
+
+    expect(hitCount).toBeGreaterThanOrEqual(1);
+
+    // Verify failure was recorded in execution log
+    const logs = getExecutionLog("failing-probe.yml");
+    expect(logs.length).toBeGreaterThanOrEqual(1);
+    expect(logs[0].ok).toBe(false);
+    expect(logs[0].error).toContain("HTTP 500");
+  }, 10_000);
 });

--- a/core/assets/opencode.jsonc
+++ b/core/assets/opencode.jsonc
@@ -1,5 +1,4 @@
 {
   "$schema": "https://opencode.ai/config.json",
-  "model": "opencode/big-pickle",
   "plugin": ["@openpalm/assistant-tools", "agentikit-opencode"]
 }

--- a/core/cli/src/main.ts
+++ b/core/cli/src/main.ts
@@ -7,6 +7,8 @@ const ADMIN_URL = process.env.OPENPALM_ADMIN_API_URL || 'http://localhost:8100';
 const REPO_OWNER = 'itlackey';
 const REPO_NAME = 'openpalm';
 
+const IS_WINDOWS = process.platform === 'win32';
+
 type Command =
   | 'install'
   | 'uninstall'
@@ -28,15 +30,32 @@ type InstallOptions = {
 };
 
 function defaultConfigHome(): string {
-  return process.env.OPENPALM_CONFIG_HOME || join(homedir(), '.config', 'openpalm');
+  if (process.env.OPENPALM_CONFIG_HOME) return process.env.OPENPALM_CONFIG_HOME;
+  if (IS_WINDOWS) {
+    return join(process.env.APPDATA || join(homedir(), 'AppData', 'Roaming'), 'openpalm');
+  }
+  return join(homedir(), '.config', 'openpalm');
 }
 
 function defaultDataHome(): string {
-  return process.env.OPENPALM_DATA_HOME || join(homedir(), '.local', 'share', 'openpalm');
+  if (process.env.OPENPALM_DATA_HOME) return process.env.OPENPALM_DATA_HOME;
+  if (IS_WINDOWS) {
+    return join(process.env.LOCALAPPDATA || join(homedir(), 'AppData', 'Local'), 'openpalm', 'data');
+  }
+  return join(homedir(), '.local', 'share', 'openpalm');
 }
 
 function defaultStateHome(): string {
-  return process.env.OPENPALM_STATE_HOME || join(homedir(), '.local', 'state', 'openpalm');
+  if (process.env.OPENPALM_STATE_HOME) return process.env.OPENPALM_STATE_HOME;
+  if (IS_WINDOWS) {
+    return join(process.env.LOCALAPPDATA || join(homedir(), 'AppData', 'Local'), 'openpalm', 'state');
+  }
+  return join(homedir(), '.local', 'state', 'openpalm');
+}
+
+function defaultDockerSock(): string {
+  if (process.env.OPENPALM_DOCKER_SOCK) return process.env.OPENPALM_DOCKER_SOCK;
+  return IS_WINDOWS ? '//./pipe/docker_engine' : '/var/run/docker.sock';
 }
 
 function defaultWorkDir(): string {
@@ -216,7 +235,7 @@ async function ensureStackEnv(configHome: string, dataHome: string, stateHome: s
   const dataStackEnv = join(dataHome, 'stack.env');
   const stagedStackEnv = join(stateHome, 'artifacts', 'stack.env');
   if (!(await Bun.file(dataStackEnv).exists())) {
-    const content = `# OpenPalm Stack Bootstrap — system-managed, do not edit\nOPENPALM_CONFIG_HOME=${configHome}\nOPENPALM_DATA_HOME=${dataHome}\nOPENPALM_STATE_HOME=${stateHome}\nOPENPALM_WORK_DIR=${workDir}\nOPENPALM_UID=${process.getuid?.() ?? 1000}\nOPENPALM_GID=${process.getgid?.() ?? 1000}\nOPENPALM_DOCKER_SOCK=/var/run/docker.sock\nOPENPALM_IMAGE_NAMESPACE=${process.env.OPENPALM_IMAGE_NAMESPACE || 'openpalm'}\nOPENPALM_IMAGE_TAG=${process.env.OPENPALM_IMAGE_TAG || 'latest'}\n`;
+    const content = `# OpenPalm Stack Bootstrap — system-managed, do not edit\nOPENPALM_CONFIG_HOME=${configHome}\nOPENPALM_DATA_HOME=${dataHome}\nOPENPALM_STATE_HOME=${stateHome}\nOPENPALM_WORK_DIR=${workDir}\nOPENPALM_UID=${process.getuid?.() ?? 1000}\nOPENPALM_GID=${process.getgid?.() ?? 1000}\nOPENPALM_DOCKER_SOCK=${defaultDockerSock()}\nOPENPALM_IMAGE_NAMESPACE=${process.env.OPENPALM_IMAGE_NAMESPACE || 'openpalm'}\nOPENPALM_IMAGE_TAG=${process.env.OPENPALM_IMAGE_TAG || 'latest'}\n`;
     await Bun.write(dataStackEnv, content);
   }
   await Bun.write(stagedStackEnv, Bun.file(dataStackEnv));

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,7 @@ Documentation index for OpenPalm.
 | [CONTRIBUTING.md](CONTRIBUTING.md) | **Dev environment cheatsheet** — clone, bootstrap, run, test |
 | [system-requirements.md](system-requirements.md) | CPU, RAM, disk, network — minimum and recommended specs |
 | [setup-guide.md](setup-guide.md) | Installation, updating, troubleshooting |
+| [setup-walkthrough.md](setup-walkthrough.md) | Visual walkthrough of every setup wizard screen |
 | [troubleshooting.md](troubleshooting.md) | Top 10 common problems and solutions |
 | [manual-setup.md](manual-setup.md) | Step-by-step manual host configuration (no scripts) |
 | [how-it-works.md](how-it-works.md) | Architecture overview and data flow |

--- a/docs/architecture.svg
+++ b/docs/architecture.svg
@@ -1,0 +1,198 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1020 720" font-family="'Segoe UI', system-ui, -apple-system, sans-serif" font-size="13">
+  <defs>
+    <marker id="arrow" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+      <path d="M0,0 L8,3 L0,6 Z" fill="#555"/>
+    </marker>
+    <marker id="arrow-blue" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+      <path d="M0,0 L8,3 L0,6 Z" fill="#3b82f6"/>
+    </marker>
+    <marker id="arrow-green" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+      <path d="M0,0 L8,3 L0,6 Z" fill="#22c55e"/>
+    </marker>
+    <marker id="arrow-orange" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+      <path d="M0,0 L8,3 L0,6 Z" fill="#f97316"/>
+    </marker>
+    <marker id="arrow-red" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+      <path d="M0,0 L8,3 L0,6 Z" fill="#ef4444"/>
+    </marker>
+  </defs>
+
+  <!-- Background -->
+  <rect width="1020" height="720" rx="8" fill="#fafafa"/>
+
+  <!-- Title -->
+  <text x="510" y="32" text-anchor="middle" font-size="20" font-weight="700" fill="#1e293b">OpenPalm Container Topology</text>
+
+  <!-- ═══════════════════════════════════════════════════════════════ -->
+  <!-- NETWORK BOUNDARIES (dashed rectangles)                        -->
+  <!-- ═══════════════════════════════════════════════════════════════ -->
+
+  <!-- channel_public network -->
+  <rect x="30" y="130" width="310" height="295" rx="10" fill="none" stroke="#ef4444" stroke-width="1.5" stroke-dasharray="7,4"/>
+  <text x="45" y="152" font-size="11" fill="#ef4444" font-weight="600">channel_public</text>
+
+  <!-- channel_lan network -->
+  <rect x="20" y="120" width="490" height="315" rx="12" fill="none" stroke="#f97316" stroke-width="1.5" stroke-dasharray="7,4"/>
+  <text x="355" y="142" font-size="11" fill="#f97316" font-weight="600">channel_lan</text>
+
+  <!-- assistant_net network -->
+  <rect x="350" y="110" width="650" height="470" rx="12" fill="none" stroke="#3b82f6" stroke-width="1.5" stroke-dasharray="7,4"/>
+  <text x="830" y="132" font-size="11" fill="#3b82f6" font-weight="600">assistant_net</text>
+
+  <!-- admin_docker_net network -->
+  <rect x="530" y="465" width="460" height="120" rx="10" fill="none" stroke="#8b5cf6" stroke-width="1.5" stroke-dasharray="7,4"/>
+  <text x="545" y="487" font-size="11" fill="#8b5cf6" font-weight="600">admin_docker_net</text>
+
+  <!-- ═══════════════════════════════════════════════════════════════ -->
+  <!-- EXTERNAL ACTORS                                                -->
+  <!-- ═══════════════════════════════════════════════════════════════ -->
+
+  <!-- User browser -->
+  <rect x="40" y="52" width="130" height="40" rx="8" fill="#f1f5f9" stroke="#94a3b8" stroke-width="1.2"/>
+  <text x="105" y="77" text-anchor="middle" font-size="12" fill="#334155" font-weight="600">User Browser</text>
+
+  <!-- External clients -->
+  <rect x="220" y="52" width="150" height="40" rx="8" fill="#f1f5f9" stroke="#94a3b8" stroke-width="1.2"/>
+  <text x="295" y="77" text-anchor="middle" font-size="12" fill="#334155" font-weight="600">External Clients</text>
+
+  <!-- ═══════════════════════════════════════════════════════════════ -->
+  <!-- CONTAINERS                                                     -->
+  <!-- ═══════════════════════════════════════════════════════════════ -->
+
+  <!-- Caddy (infrastructure / gray-blue) -->
+  <rect x="50" y="168" width="160" height="56" rx="10" fill="#e0e7ff" stroke="#6366f1" stroke-width="1.5"/>
+  <text x="130" y="192" text-anchor="middle" font-size="14" font-weight="700" fill="#3730a3">Caddy</text>
+  <text x="130" y="213" text-anchor="middle" font-size="10" fill="#6366f1">reverse proxy :80</text>
+
+  <!-- Guardian (core / blue) -->
+  <rect x="370" y="245" width="160" height="70" rx="10" fill="#dbeafe" stroke="#3b82f6" stroke-width="1.5"/>
+  <text x="450" y="271" text-anchor="middle" font-size="14" font-weight="700" fill="#1e40af">Guardian</text>
+  <text x="450" y="288" text-anchor="middle" font-size="10" fill="#3b82f6">HMAC verify :8080</text>
+  <text x="450" y="304" text-anchor="middle" font-size="10" fill="#3b82f6">replay + rate limit</text>
+
+  <!-- Channel: Chat (green) -->
+  <rect x="60" y="265" width="145" height="50" rx="10" fill="#dcfce7" stroke="#22c55e" stroke-width="1.5"/>
+  <text x="132" y="288" text-anchor="middle" font-size="13" font-weight="600" fill="#166534">channel-chat</text>
+  <text x="132" y="304" text-anchor="middle" font-size="10" fill="#22c55e">:8181</text>
+
+  <!-- Channel: API (green) -->
+  <rect x="60" y="330" width="145" height="50" rx="10" fill="#dcfce7" stroke="#22c55e" stroke-width="1.5"/>
+  <text x="132" y="353" text-anchor="middle" font-size="13" font-weight="600" fill="#166534">channel-api</text>
+  <text x="132" y="369" text-anchor="middle" font-size="10" fill="#22c55e">:8282</text>
+
+  <!-- Channel: Discord (green) -->
+  <rect x="230" y="330" width="145" height="50" rx="10" fill="#dcfce7" stroke="#22c55e" stroke-width="1.5"/>
+  <text x="302" y="353" text-anchor="middle" font-size="13" font-weight="600" fill="#166534">channel-discord</text>
+  <text x="302" y="369" text-anchor="middle" font-size="10" fill="#22c55e">:8383</text>
+
+  <!-- Assistant (core / blue) -->
+  <rect x="620" y="245" width="180" height="70" rx="10" fill="#dbeafe" stroke="#3b82f6" stroke-width="1.5"/>
+  <text x="710" y="271" text-anchor="middle" font-size="14" font-weight="700" fill="#1e40af">Assistant</text>
+  <text x="710" y="288" text-anchor="middle" font-size="10" fill="#3b82f6">OpenCode :4096</text>
+  <text x="710" y="304" text-anchor="middle" font-size="10" fill="#3b82f6">no Docker socket</text>
+
+  <!-- Memory (core / blue) -->
+  <rect x="830" y="245" width="150" height="56" rx="10" fill="#dbeafe" stroke="#3b82f6" stroke-width="1.5"/>
+  <text x="905" y="271" text-anchor="middle" font-size="14" font-weight="700" fill="#1e40af">Memory</text>
+  <text x="905" y="289" text-anchor="middle" font-size="10" fill="#3b82f6">sqlite-vec :8765</text>
+
+  <!-- Admin (core / blue) -->
+  <rect x="550" y="390" width="180" height="70" rx="10" fill="#dbeafe" stroke="#3b82f6" stroke-width="1.5"/>
+  <text x="640" y="416" text-anchor="middle" font-size="14" font-weight="700" fill="#1e40af">Admin</text>
+  <text x="640" y="433" text-anchor="middle" font-size="10" fill="#3b82f6">SvelteKit :8100</text>
+  <text x="640" y="449" text-anchor="middle" font-size="10" fill="#3b82f6">control plane</text>
+
+  <!-- Docker Socket Proxy (infrastructure / gray) -->
+  <rect x="800" y="497" width="175" height="70" rx="10" fill="#f3f4f6" stroke="#6b7280" stroke-width="1.5"/>
+  <text x="887" y="520" text-anchor="middle" font-size="12" font-weight="700" fill="#374151">Docker Socket</text>
+  <text x="887" y="536" text-anchor="middle" font-size="12" font-weight="700" fill="#374151">Proxy</text>
+  <text x="887" y="554" text-anchor="middle" font-size="10" fill="#6b7280">filtered :2375</text>
+
+  <!-- Docker Daemon (external) -->
+  <rect x="810" y="620" width="155" height="42" rx="8" fill="#f1f5f9" stroke="#94a3b8" stroke-width="1.2"/>
+  <text x="887" y="645" text-anchor="middle" font-size="12" fill="#334155" font-weight="600">Docker Daemon</text>
+
+  <!-- ═══════════════════════════════════════════════════════════════ -->
+  <!-- MESSAGE FLOW ARROWS                                            -->
+  <!-- ═══════════════════════════════════════════════════════════════ -->
+
+  <!-- User browser -> Caddy -->
+  <line x1="105" y1="92" x2="120" y2="165" stroke="#555" stroke-width="1.5" marker-end="url(#arrow)"/>
+
+  <!-- External clients -> Caddy (via channels) -->
+  <line x1="270" y1="92" x2="145" y2="165" stroke="#555" stroke-width="1.5" marker-end="url(#arrow)"/>
+
+  <!-- Caddy -> Admin (UI/API route) -->
+  <path d="M 180 224 Q 250 320, 548 420" fill="none" stroke="#3b82f6" stroke-width="1.5" marker-end="url(#arrow-blue)"/>
+  <text x="300" y="330" font-size="10" fill="#3b82f6" font-style="italic">/admin/*</text>
+
+  <!-- Caddy -> channel-chat -->
+  <line x1="115" y1="224" x2="122" y2="262" stroke="#555" stroke-width="1.2" marker-end="url(#arrow)"/>
+
+  <!-- Caddy -> Guardian route -->
+  <path d="M 210 210 Q 290 230, 368 270" fill="none" stroke="#f97316" stroke-width="1.3" marker-end="url(#arrow-orange)"/>
+  <text x="265" y="228" font-size="10" fill="#f97316" font-style="italic">/guardian/*</text>
+
+  <!-- channel-chat -> Guardian (HMAC signed) -->
+  <path d="M 205 280 L 367 275" fill="none" stroke="#22c55e" stroke-width="1.5" marker-end="url(#arrow-green)"/>
+  <text x="270" y="267" font-size="10" fill="#22c55e" font-weight="600">HMAC signed</text>
+
+  <!-- channel-api -> Guardian -->
+  <path d="M 205 352 Q 300 330, 375 300" fill="none" stroke="#22c55e" stroke-width="1.3" marker-end="url(#arrow-green)"/>
+
+  <!-- channel-discord -> Guardian -->
+  <path d="M 375 348 Q 400 330, 420 318" fill="none" stroke="#22c55e" stroke-width="1.3" marker-end="url(#arrow-green)"/>
+
+  <!-- Guardian -> Assistant (validated message) -->
+  <line x1="530" y1="280" x2="617" y2="280" stroke="#3b82f6" stroke-width="1.8" marker-end="url(#arrow-blue)"/>
+  <text x="555" y="270" font-size="10" fill="#3b82f6" font-weight="600">validated</text>
+
+  <!-- Assistant -> Memory -->
+  <line x1="800" y1="273" x2="828" y2="273" stroke="#3b82f6" stroke-width="1.5" marker-end="url(#arrow-blue)"/>
+
+  <!-- Assistant -> Admin API (stack ops) -->
+  <path d="M 680 315 L 660 388" fill="none" stroke="#3b82f6" stroke-width="1.3" stroke-dasharray="5,3" marker-end="url(#arrow-blue)"/>
+  <text x="685" y="355" font-size="10" fill="#3b82f6" font-style="italic">API calls</text>
+
+  <!-- Admin -> Docker Socket Proxy -->
+  <path d="M 730 440 L 798 515" fill="none" stroke="#8b5cf6" stroke-width="1.5" marker-end="url(#arrow)"/>
+  <text x="740" y="480" font-size="10" fill="#8b5cf6" font-style="italic">DOCKER_HOST</text>
+
+  <!-- Docker Socket Proxy -> Docker Daemon -->
+  <line x1="887" y1="567" x2="887" y2="617" stroke="#6b7280" stroke-width="1.5" marker-end="url(#arrow)"/>
+  <text x="905" y="598" font-size="10" fill="#6b7280" font-style="italic">/var/run/docker.sock</text>
+
+  <!-- ═══════════════════════════════════════════════════════════════ -->
+  <!-- LEGEND                                                         -->
+  <!-- ═══════════════════════════════════════════════════════════════ -->
+
+  <rect x="30" y="640" width="500" height="70" rx="8" fill="#fff" stroke="#e2e8f0" stroke-width="1"/>
+
+  <!-- Core services -->
+  <rect x="45" y="653" width="16" height="12" rx="3" fill="#dbeafe" stroke="#3b82f6" stroke-width="1"/>
+  <text x="67" y="664" font-size="11" fill="#334155">Core service</text>
+
+  <!-- Channel adapters -->
+  <rect x="160" y="653" width="16" height="12" rx="3" fill="#dcfce7" stroke="#22c55e" stroke-width="1"/>
+  <text x="182" y="664" font-size="11" fill="#334155">Channel adapter</text>
+
+  <!-- Infrastructure -->
+  <rect x="300" y="653" width="16" height="12" rx="3" fill="#f3f4f6" stroke="#6b7280" stroke-width="1"/>
+  <text x="322" y="664" font-size="11" fill="#334155">Infrastructure</text>
+
+  <!-- External -->
+  <rect x="418" y="653" width="16" height="12" rx="3" fill="#f1f5f9" stroke="#94a3b8" stroke-width="1"/>
+  <text x="440" y="664" font-size="11" fill="#334155">External</text>
+
+  <!-- Network boundary -->
+  <line x1="45" y1="685" x2="80" y2="685" stroke="#555" stroke-width="1.2" stroke-dasharray="6,3"/>
+  <text x="86" y="689" font-size="11" fill="#334155">Network boundary</text>
+
+  <!-- Message flow -->
+  <line x1="210" y1="685" x2="240" y2="685" stroke="#555" stroke-width="1.5" marker-end="url(#arrow)"/>
+  <text x="247" y="689" font-size="11" fill="#334155">Message flow</text>
+
+  <!-- API call -->
+  <line x1="345" y1="685" x2="375" y2="685" stroke="#555" stroke-width="1.2" stroke-dasharray="5,3" marker-end="url(#arrow)"/>
+  <text x="382" y="689" font-size="11" fill="#334155">Internal API call</text>
+</svg>

--- a/docs/backup-restore.md
+++ b/docs/backup-restore.md
@@ -114,7 +114,7 @@ pass `-f` with the path to `STATE_HOME/artifacts/docker-compose.yml`.
 4. Download the installer without starting the stack:
 
    ```bash
-   curl -fsSL https://raw.githubusercontent.com/itlackey/openpalm/main/scripts/setup.sh \
+   curl -fsSL https://raw.githubusercontent.com/itlackey/openpalm/v0.9.0-rc5/scripts/setup.sh \
      -o setup.sh
    bash setup.sh --no-start
    ```

--- a/docs/memory-privacy.md
+++ b/docs/memory-privacy.md
@@ -66,6 +66,15 @@ Every time a fact is stored or a search query is executed, the text is sent to t
 
 **To keep all data on your local network**, configure both the LLM and embedding providers to use a local Ollama instance. When using remote providers (OpenAI, Anthropic, etc.), the fact text and search queries are sent to those external APIs.
 
+### Assistant model (chat completions)
+
+The assistant service (OpenCode) sends conversation messages to the configured chat model for inference. Which model is used depends entirely on operator configuration during setup:
+
+- **Local provider (Ollama):** All inference stays on the local network. No data leaves the host.
+- **Remote provider (OpenAI, Anthropic, Groq, etc.):** Conversation content is sent to that provider's API. Each provider has its own data retention and usage policies. Consult the provider's terms of service and privacy policy for details.
+
+OpenPalm does not default to any specific model. The setup wizard requires the operator to choose a provider and model before the stack starts. This ensures the operator makes a conscious decision about where their data is processed.
+
 ## How to view stored memories
 
 ### Admin API

--- a/docs/opencode-configuration.md
+++ b/docs/opencode-configuration.md
@@ -20,8 +20,8 @@ OpenCode supports a layered configuration model. OpenPalm uses three layers:
    This is the lowest-precedence layer.
 2. **System config** — persisted on the host at
    `$OPENPALM_DATA_HOME/assistant/` and bind-mounted into the container at
-   `/etc/opencode/` via `OPENCODE_CONFIG_DIR`. Contains the model selection,
-   plugin declarations, and persona (AGENTS.md). Overrides user config.
+   `/etc/opencode/` via `OPENCODE_CONFIG_DIR`. Contains plugin declarations
+   and persona (AGENTS.md). Overrides user config for keys it sets.
 3. **Project config** — an `opencode.json` in the `/work` directory (if present).
    Highest precedence, overrides everything.
 
@@ -122,15 +122,20 @@ and overwritten when the bundled version changes (with backup).
 
 ### opencode.jsonc
 
-Selects the default model and declares plugins for auto-install:
+Declares plugins for auto-install. The model is not set here; it comes
+from the user's connection setup (see below):
 
 ```jsonc
 {
   "$schema": "https://opencode.ai/config.json",
-  "model": "opencode/big-pickle",
   "plugin": ["@openpalm/assistant-tools", "@itlackey/openkit"]
 }
 ```
+
+The model is **not** set in the system config. It is determined by the
+user's connection setup: the setup wizard or admin UI writes the selected
+model to `CONFIG_HOME/assistant/opencode.json`, which OpenCode picks up
+as the user config layer.
 
 ### AGENTS.md
 

--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -38,7 +38,7 @@ curl -fsSL https://raw.githubusercontent.com/itlackey/openpalm/main/scripts/setu
 2. Creates the XDG directory tree and downloads core assets (compose file, Caddyfile)
 3. Generates an admin token (or lets you set your own) and seeds missing default config files
 4. Pulls and starts the admin service, then opens the setup wizard in your browser
-5. The wizard walks you through connecting your AI provider and choosing channels
+5. The wizard walks you through connecting your AI provider and choosing channels (see [Setup Walkthrough](setup-walkthrough.md) for a detailed screen-by-screen guide)
 6. When you finish the wizard, the full stack starts automatically
 
 No code to clone. You can run fully from the UI if you want, and edit files directly any time. Existing user config files in `CONFIG_HOME` are never overwritten on subsequent runs; only missing defaults are seeded.
@@ -254,6 +254,7 @@ irm https://raw.githubusercontent.com/itlackey/openpalm/main/scripts/setup.ps1 |
 
 | Guide | What's inside |
 |---|---|
+| [Setup Walkthrough](setup-walkthrough.md) | Detailed screen-by-screen walkthrough of the setup wizard |
 | [Managing OpenPalm](managing-openpalm.md) | Day-to-day administration: secrets, channels, access control, extensions |
 | [How It Works](how-it-works.md) | Architecture overview and data flow |
 | [Directory Structure](directory-structure.md) | Host paths, XDG tiers, volume mounts |

--- a/docs/setup-walkthrough.md
+++ b/docs/setup-walkthrough.md
@@ -1,0 +1,828 @@
+# Setup Wizard Walkthrough
+
+A detailed, step-by-step walkthrough of every screen in the OpenPalm setup wizard. Use this alongside the [Setup Guide](setup-guide.md) for a complete picture of what to expect the first time you run OpenPalm.
+
+> **Tip:** The wizard runs at `http://localhost:8100/setup` (or `http://localhost/setup` via Caddy) the first time you start the admin container. If you have already completed setup once, the wizard redirects to the admin console.
+
+---
+
+## Wizard Layout
+
+Every screen shares the same card layout:
+
+```
++--------------------------------------------------+
+|         OpenPalm Setup Wizard                     |
+|   Configure your OpenPalm stack in a few steps.   |
++--------------------------------------------------+
+|                                                    |
+|   (1)---(2)---(3)---(4)---(5)---(6)               |
+|   Step progress dots                               |
+|                                                    |
+|   [ Current screen content ]                       |
+|                                                    |
+|                          [Back]  [Continue]         |
++--------------------------------------------------+
+```
+
+The six numbered dots across the top track your progress:
+
+| Dot | Maps to screen(s) |
+|-----|-------------------|
+| 1 | Welcome |
+| 2 | Connections Hub |
+| 3 | Connection Type + Connection Details |
+| 4 | Required Models |
+| 5 | Optional Add-ons |
+| 6 | Review and Install |
+
+Completed dots turn green with a checkmark. You can click any completed dot to jump back and edit that step. The dots disappear on the final Deploying screen.
+
+---
+
+## Step 1: Welcome
+
+**What you see:**
+
+```
++--------------------------------------------------+
+|                   Welcome                         |
+|                                                    |
+|  Start with your name and an admin token. Then     |
+|  connect your models, choose defaults for chat     |
+|  and memory, and let OpenPalm bring the stack      |
+|  online for you.                                   |
+|                                                    |
+|  Your Name                                         |
+|  +----------------------------------------------+ |
+|  | Jane Doe                                      | |
+|  +----------------------------------------------+ |
+|  Used as the default Memory user ID.               |
+|                                                    |
+|  Email (optional)                                  |
+|  +----------------------------------------------+ |
+|  | jane@example.com                              | |
+|  +----------------------------------------------+ |
+|  For account identification. Not shared externally. |
+|                                                    |
+|  Admin Token                                       |
+|  +----------------------------------------------+ |
+|  | ********                                      | |
+|  +----------------------------------------------+ |
+|  This token protects your admin console. Keep it   |
+|  safe -- you'll need it to log in.                 |
+|                                                    |
+|                                      [Start]       |
++--------------------------------------------------+
+```
+
+**Fields:**
+
+| Field | Required | Notes |
+|-------|----------|-------|
+| Your Name | Yes | Used to derive the memory user ID (e.g., "Jane Doe" becomes `jane_doe`). |
+| Email | No | Stored locally for identification. Never sent externally. |
+| Admin Token | Yes | Must be at least 8 characters. This is the password you use to access the admin console. Choose something secure and save it somewhere safe. |
+
+**What to do:** Fill in your name and a strong admin token, then click **Start**.
+
+**Validation rules:**
+- Name must not be empty.
+- Admin token must not be empty and must be at least 8 characters.
+
+**Common mistakes:**
+- Using a short or trivial admin token. This token is the only thing protecting your admin console. Use something strong.
+- Forgetting to save the admin token. There is no "forgot password" flow -- you would need to edit `secrets.env` manually.
+
+---
+
+## Step 2: Connections Hub
+
+**What you see (first visit -- no connections yet):**
+
+```
++--------------------------------------------------+
+|                  Connections                       |
+|                                                    |
+|  Connections are reusable model endpoints. Start   |
+|  with one, or mix local and remote providers if    |
+|  you want the best of both.                        |
+|                                                    |
+|  +----------------------------------------------+ |
+|  |           No connections yet                   | |
+|  |                                                | |
+|  |  Add a local model server like Ollama or LM    | |
+|  |  Studio, or connect a hosted OpenAI-compatible  | |
+|  |  provider.                                      | |
+|  |                                                | |
+|  |       [Add your first connection]              | |
+|  +----------------------------------------------+ |
+|                                                    |
+|  [Back]  [Add connection]  [Continue (disabled)]   |
++--------------------------------------------------+
+```
+
+**What you see (after adding connections):**
+
+```
++--------------------------------------------------+
+|                  Connections                       |
+|                                                    |
+|  +----------------------------------------------+ |
+|  | Ollama   [Local] [Tested]                     | |
+|  | http://localhost:11434                         | |
+|  |                      [Edit] [Duplicate] [Remove]|
+|  +----------------------------------------------+ |
+|  | OpenAI   [Remote] [Tested]                    | |
+|  | https://api.openai.com                        | |
+|  |                      [Edit] [Duplicate] [Remove]|
+|  +----------------------------------------------+ |
+|                                                    |
+|  [Back]  [Add connection]  [Continue]              |
++--------------------------------------------------+
+```
+
+Each saved connection shows:
+- **Name** (or provider name if no custom name was set)
+- **Type badge**: "Local" or "Remote"
+- **Tested badge**: Green checkmark if the connection was tested successfully
+- **Base URL** in monospace
+- **Actions**: Edit, Duplicate, Remove
+
+**What to do:** Click **Add your first connection** (or **Add connection**) to go to the Connection Type screen. You need at least one connection before you can continue.
+
+**Tips:**
+- You can add multiple connections. For example, use Ollama for chat and OpenAI for embeddings.
+- Duplicate lets you create a variant of an existing connection (e.g., same provider but different API key or base URL).
+- The Continue button stays disabled until you have at least one connection.
+
+---
+
+## Step 3a: Connection Type
+
+**What you see:**
+
+```
++--------------------------------------------------+
+|              Add a connection                      |
+|                                                    |
+|  Where are your models hosted?                     |
+|                                                    |
+|  +----------------------------------------------+ |
+|  | [Cloud icon]                                   | |
+|  | Remote OpenAI-compatible         [Hosted]      | |
+|  | Best for OpenAI, Groq, Together, gateways,     | |
+|  | and work proxies. Usually requires an API key   | |
+|  | and starts with a provider default URL.          | |
+|  | Recommended if you already use a hosted API     | |
+|  | provider.                                    >  | |
+|  +----------------------------------------------+ |
+|                                                    |
+|  +----------------------------------------------+ |
+|  | [Server icon]                                  | |
+|  | Local OpenAI-compatible        [On-Device]     | |
+|  | Best for Ollama, LM Studio, and Docker Model   | |
+|  | Runner. We will try to detect what is already   | |
+|  | running on this machine first.                  | |
+|  | Recommended for most self-hosted OpenPalm       | |
+|  | setups.                                      >  | |
+|  +----------------------------------------------+ |
+|                                                    |
+|  [Back]                                            |
++--------------------------------------------------+
+```
+
+**Two options:**
+
+| Option | Best for | Needs API key? |
+|--------|----------|---------------|
+| **Remote OpenAI-compatible** | OpenAI, Groq, Together, Mistral, DeepSeek, xAI, Anthropic, hosted proxies | Usually yes |
+| **Local OpenAI-compatible** | Ollama, LM Studio, Docker Model Runner | Usually no |
+
+**What to do:** Click one of the two cards. The wizard advances to the Connection Details screen with defaults set for your choice.
+
+**What happens behind the scenes:**
+- **Remote**: Sets provider to OpenAI and pre-fills `https://api.openai.com` as the base URL.
+- **Local**: Sets provider to Ollama, pre-fills `http://localhost:11434`, and immediately begins auto-detecting local providers running on your machine.
+
+---
+
+## Step 3b: Connection Details (Remote)
+
+**What you see when you chose Remote:**
+
+```
++--------------------------------------------------+
+|             Connection details                     |
+|                                                    |
+|  Give this connection a friendly name, confirm     |
+|  the endpoint details, and test it before saving.  |
+|                                                    |
+|  +----------------------------------------------+ |
+|  | [Remote]  Remote connection                    | |
+|  | Best for hosted providers, gateways, and work  | |
+|  | proxies that expose an OpenAI-compatible API.  | |
+|  | - Usually requires an API key.                 | |
+|  | - We prefill the base URL using the selected   | |
+|  |   provider when possible.                      | |
+|  | - Good for OpenAI, Groq, Together, Mistral,    | |
+|  |   and hosted proxies.                          | |
+|  +----------------------------------------------+ |
+|                                                    |
+|  Connection name                                   |
+|  +----------------------------------------------+ |
+|  | e.g., "LM Studio local", "Work proxy"         | |
+|  +----------------------------------------------+ |
+|                                                    |
+|  [OpenAI] [Anthropic] [Groq] [Together]           |
+|  [Mistral] [DeepSeek] [xAI]                       |
+|                                                    |
+|  API key                                           |
+|  +----------------------------------------------+ |
+|  | Paste your API key                            | |
+|  +----------------------------------------------+ |
+|  Your key stays server-side and will be reused     |
+|  whenever this connection is selected.             |
+|                                                    |
+|  Base URL                                          |
+|  +----------------------------------------------+ |
+|  | https://api.openai.com                        | |
+|  +----------------------------------------------+ |
+|  Enter the server base URL without a trailing /v1  |
+|  (OpenPalm adds /v1 automatically when needed).   |
+|                                                    |
+|  [Cancel]  [Test Connection]  [Save connection]    |
++--------------------------------------------------+
+```
+
+**Provider chip bar:** Click any provider chip to switch. This auto-updates the base URL:
+
+| Provider | Default Base URL |
+|----------|-----------------|
+| OpenAI | `https://api.openai.com` |
+| Anthropic | (no default) |
+| Groq | `https://api.groq.com/openai` |
+| Together | `https://api.together.xyz` |
+| Mistral | `https://api.mistral.ai` |
+| DeepSeek | `https://api.deepseek.com` |
+| xAI | `https://api.x.ai` |
+
+**Fields:**
+
+| Field | Required | Notes |
+|-------|----------|-------|
+| Connection name | Yes (auto-filled from provider if left blank) | A friendly name shown throughout the wizard. |
+| API key | Yes (for most cloud providers) | Stored server-side in `secrets.env`. Masked in the review screen. |
+| Base URL | Auto-filled | Do NOT include `/v1` at the end. The wizard warns you if you do. |
+
+**What to do:**
+1. Pick your provider from the chip bar (it pre-fills the URL).
+2. Paste your API key.
+3. Optionally give the connection a custom name.
+4. Click **Test Connection** -- the wizard calls the provider's models endpoint and shows a green success message with the number of models found.
+5. Click **Save connection** to return to the Connections Hub.
+
+**Auto-test behavior:** The wizard automatically tests the connection about 800ms after you stop typing in the API key field, so you may see the test happen without clicking the button.
+
+**Common mistakes:**
+- Including `/v1` at the end of the Base URL. The wizard shows a yellow warning if it detects this.
+- Pasting an expired or incorrect API key. The Test Connection button will show the error.
+- Forgetting to name the connection. The wizard auto-names it after the provider, but a custom name helps when you have multiple connections to the same provider.
+
+---
+
+## Step 3b: Connection Details (Local)
+
+**What you see when you chose Local:**
+
+```
++--------------------------------------------------+
+|             Connection details                     |
+|                                                    |
+|  Give this connection a friendly name, confirm     |
+|  the endpoint details, and test it before saving.  |
+|                                                    |
+|  +----------------------------------------------+ |
+|  | [Local]  Local connection                      | |
+|  | Best for Ollama, LM Studio, and Docker Model  | |
+|  | Runner running on this machine or your LAN.   | |
+|  | - Usually does not need an API key.            | |
+|  | - We try to detect running local providers     | |
+|  |   automatically.                               | |
+|  | - Use a localhost or LAN address that this     | |
+|  |   host can reach.                              | |
+|  +----------------------------------------------+ |
+|                                                    |
+|  [spinner] Detecting local providers...            |
+|                                                    |
+|  (After detection:)                                |
+|  +----------------------------------------------+ |
+|  | [green dot] Ollama                             | |
+|  | Detected at http://localhost:11434             | |
+|  +----------------------------------------------+ |
+|                                                    |
+|  Connection name                                   |
+|  +----------------------------------------------+ |
+|  | Ollama                                        | |
+|  +----------------------------------------------+ |
+|                                                    |
+|  Base URL                                          |
+|  +----------------------------------------------+ |
+|  | http://localhost:11434                         | |
+|  +----------------------------------------------+ |
+|                                                    |
+|  [Connected -- 12 models found.]                   |
+|                                                    |
+|  [Cancel]  [Test Connection]  [Save connection]    |
++--------------------------------------------------+
+```
+
+**Local provider auto-detection:** When you choose "Local", the wizard probes common local endpoints to see what is already running:
+
+| Provider | Detection URL |
+|----------|--------------|
+| Ollama | `http://localhost:11434` |
+| LM Studio | `http://localhost:1234` |
+| Docker Model Runner | `http://localhost:12434` |
+
+Detected providers appear as clickable buttons with a green status dot. Click one to auto-fill its URL and name.
+
+**If Ollama is not detected:** The wizard shows an "Enable Ollama" section:
+
+```
++----------------------------------------------+
+| Ollama not detected                           |
+|                                                |
+| We can add Ollama to your stack and pull two  |
+| small default models (llama3.2:latest +       |
+| nomic-embed-text).                            |
+|                                                |
+| [Enable Ollama]                               |
++----------------------------------------------+
+```
+
+Clicking **Enable Ollama** adds an Ollama service to your Docker Compose stack, starts it, and pulls two default models. This can take several minutes. A progress indicator shows the current status. Once complete:
+- The connection is automatically marked as tested.
+- Default chat and embedding models are pre-selected.
+- You return to the Connections Hub automatically.
+
+**If no providers are detected at all:** A manual provider dropdown appears letting you choose Ollama, LM Studio, or Docker Model Runner and type the base URL yourself.
+
+**Common mistakes:**
+- Ollama is not running. Start it before running the wizard, or use the Enable Ollama button.
+- Using `localhost` when OpenPalm runs in Docker. If the admin container cannot reach `localhost:11434`, use `host.docker.internal:11434` instead (the Enable Ollama path handles this automatically).
+
+---
+
+## Step 4: Required Models
+
+**What you see:**
+
+```
++--------------------------------------------------+
+|              Required models                       |
+|                                                    |
+|  Choose the default chat, small, and embedding     |
+|  models OpenPalm should use first. You can change  |
+|  them later from the admin UI.                     |
+|                                                    |
+|  +----------------------------------------------+ |
+|  | Chat model (LLM)                              | |
+|  | This model is used for responses and tool use  | |
+|  | in supported apps.                             | |
+|  |                                                | |
+|  | Connection                                     | |
+|  | [ Ollama                              v ]      | |
+|  |                                                | |
+|  | Chat model                                     | |
+|  | [ llama3.2:latest                     v ]      | |
+|  |                                                | |
+|  | Small model (for lightweight tasks)            | |
+|  | [ llama3.2:latest                     v ]      | |
+|  | Memory uses this model by default during       | |
+|  | setup.                                         | |
+|  +----------------------------------------------+ |
+|                                                    |
+|  +----------------------------------------------+ |
+|  | Embeddings                                     | |
+|  | Used for vector search / memory features.      | |
+|  |                                                | |
+|  | Connection                                     | |
+|  | [ Ollama                              v ]      | |
+|  |                                                | |
+|  | Embedding model                                | |
+|  | [ nomic-embed-text                    v ]      | |
+|  | Used for memory vector embeddings. The list     | |
+|  | prefers embedding-capable models.               | |
+|  | Dimensions auto-detected for this model: 768.  | |
+|  |                                                | |
+|  | Embedding dimensions                            | |
+|  | [ 768                                         ] | |
+|  | Only set this if you know your embedder's       | |
+|  | output dimensions.                              | |
+|  +----------------------------------------------+ |
+|                                                    |
+|  Add connection (link)                             |
+|                                                    |
+|  [Back]                              [Continue]    |
++--------------------------------------------------+
+```
+
+This screen has two cards:
+
+### Chat Model (LLM) Card
+
+| Field | Purpose |
+|-------|---------|
+| Connection | Which connection to use for chat. Dropdown of all your saved connections. |
+| Chat model | The primary model for AI responses and tool use. Shows a dropdown if models were fetched, or a text input for manual entry. |
+| Small model | A lighter model for background tasks like memory extraction. Defaults to the same as the chat model. Memory uses this model by default. |
+
+### Embeddings Card
+
+| Field | Purpose |
+|-------|---------|
+| Connection | Which connection to use for embeddings (can be the same or different from the chat connection). |
+| Embedding model | Model for generating vector embeddings. The dropdown filters to show embedding-capable models first. |
+| Embedding dimensions | Auto-detected when possible. Only change this if you know your model uses different dimensions. |
+
+**Smart defaults:** If you have only one connection, the wizard pre-selects it for both LLM and embeddings and picks the most likely chat and embedding models from the available model list.
+
+**Auto-detection of embedding dimensions:** When you select a known embedding model (e.g., `nomic-embed-text` on Ollama or `text-embedding-3-small` on OpenAI), the wizard auto-fills the correct dimensions and shows a hint like "Dimensions auto-detected for this model: 768."
+
+**The "Add connection" link** at the bottom lets you add another connection without going back. This is useful if you want to use one provider for chat and another for embeddings.
+
+**Validation before continuing:**
+- A chat connection must be selected.
+- An embedding connection must be selected.
+- A chat model must be specified.
+- An embedding model must be specified.
+
+**Common mistakes:**
+- Leaving the embedding model empty. The wizard validates this before letting you continue.
+- Setting wrong embedding dimensions. If the wizard auto-detects dimensions, trust the auto-detected value. Mismatched dimensions will cause memory features to fail.
+- Using a chat model as the embedding model (or vice versa). The dropdown filters help, but if typing manually, make sure you pick an embedding-specific model like `nomic-embed-text` or `text-embedding-3-small`.
+
+---
+
+## Step 5: Optional Add-ons
+
+**What you see:**
+
+```
++--------------------------------------------------+
+|             Optional add-ons                       |
+|                                                    |
+|  Enable only what you want right now. Leaving      |
+|  everything off is perfectly fine.                  |
+|                                                    |
+|  +----------------------------------------------+ |
+|  | [ ] Enable reranking                           | |
+|  |  Improves search result relevance by           | |
+|  |  re-ordering retrieved items.                  | |
+|  +----------------------------------------------+ |
+|                                                    |
+|  +----------------------------------------------+ |
+|  | [ ] Enable text-to-speech                      | |
+|  |  Turns responses into audio.                   | |
+|  +----------------------------------------------+ |
+|                                                    |
+|  +----------------------------------------------+ |
+|  | [ ] Enable speech-to-text                      | |
+|  |  Transcribes audio into text.                  | |
+|  +----------------------------------------------+ |
+|                                                    |
+|  [Back]                              [Continue]    |
++--------------------------------------------------+
+```
+
+Each add-on is a collapsible section. Checking the box expands configuration fields for that add-on.
+
+### Reranking (when enabled)
+
+| Field | Purpose |
+|-------|---------|
+| Reranker type | "Use an LLM to rerank" or "Use a dedicated reranker" (radio buttons) |
+| Connection | Which connection provides the reranking model |
+| Model | The reranking model (e.g., `rerank-2`) |
+| Top N results | How many results to keep after reranking (default: 5) |
+
+### Text-to-Speech (when enabled)
+
+| Field | Purpose |
+|-------|---------|
+| Connection | Which connection provides TTS |
+| Model (optional) | TTS model (e.g., `tts-1`) |
+| Voice (optional) | Voice name (e.g., `alloy`) |
+| Output format (optional) | Audio format (e.g., `mp3`) |
+
+### Speech-to-Text (when enabled)
+
+| Field | Purpose |
+|-------|---------|
+| Connection | Which connection provides STT |
+| Model (optional) | STT model (e.g., `whisper-1`) |
+| Language (optional) | Language code (e.g., `en`) |
+
+**What to do:** Toggle on any add-ons you want, fill in the fields, and click **Continue**. Or leave everything off and click **Continue** -- all add-ons are optional and can be configured later from the admin UI.
+
+**Tip:** Most users skip this step on first setup. You can always enable add-ons later through the admin Connections page.
+
+---
+
+## Step 6: Review and Install
+
+**What you see:**
+
+```
++--------------------------------------------------+
+|            Review your setup                       |
+|                                                    |
+|  Confirm connections and model selections. You     |
+|  can edit anything before saving.                  |
+|                                                    |
+|  Account                                  [Edit]   |
+|  -----------------------------------------         |
+|  Name          Jane Doe                            |
+|  Email         jane@example.com                    |
+|  Admin Token   Set                                 |
+|                                                    |
+|  Connections                              [Edit]   |
+|  -----------------------------------------         |
+|  Provider      Local -- Ollama                     |
+|  Base URL      http://ollama:11434                 |
+|  Ollama        Enabled (in-stack)                  |
+|                                                    |
+|  Required models                          [Edit]   |
+|  -----------------------------------------         |
+|  Chat Model    llama3.2:latest (Ollama)            |
+|  Small Model   llama3.2:latest (Ollama)            |
+|  Embedding     nomic-embed-text (Ollama)           |
+|    Model                                           |
+|  Memory Model  llama3.2:latest (Ollama)            |
+|  Embedding     768                                 |
+|    Dimensions                                      |
+|  Memory        jane_doe                            |
+|    User ID                                         |
+|                                                    |
+|  Optional add-ons                         [Edit]   |
+|  -----------------------------------------         |
+|  None configured                                   |
+|                                                    |
+|  Config Exports                                    |
+|  -----------------------------------------         |
+|  OpenCode config    [Download opencode.json]       |
+|  Mem0 config        [Download mem0-config.json]    |
+|                                                    |
+|  [Back]                                  [Save]    |
++--------------------------------------------------+
+```
+
+The review screen is divided into sections, each with an **Edit** button that jumps back to the relevant wizard step:
+
+| Section | Edit jumps to |
+|---------|--------------|
+| Account | Step 1 (Welcome) |
+| Connections | Step 2 (Connections Hub) |
+| Required models | Step 4 (Required Models) |
+| Optional add-ons | Step 5 (Optional Add-ons) |
+
+### What is shown
+
+- **Account**: Your name, email (if provided), and whether the admin token is set.
+- **Connections**: Each connection with its type (Local/Cloud), provider name, API key (masked as `sk-...last4`), and base URL.
+- **Ollama**: Shows "Enabled (in-stack)" if you used the Enable Ollama feature.
+- **Required models**: Chat model, small model, embedding model, memory model (defaults to the small model), embedding dimensions, and memory user ID.
+- **Optional add-ons**: Shows configuration for each enabled add-on, or "None configured" if all are off.
+
+### Config Exports
+
+Two download buttons let you export generated configuration files before installing:
+- **Download opencode.json** -- OpenCode configuration with your model selections
+- **Download mem0-config.json** -- Memory service configuration
+
+These are useful for backup or for manual configuration outside the wizard.
+
+### Installing
+
+Click **Save** to begin installation. The wizard:
+1. Sends all your configuration to the admin API (`POST /admin/setup`).
+2. Generates and writes configuration files (`secrets.env`, `stack.env`, connection profiles, OpenCode config, memory config).
+3. Assembles the Docker Compose stack.
+4. Transitions to the Deploying screen.
+
+**Common mistakes:**
+- Not reviewing the embedding dimensions. If they are wrong, memory features will not work correctly after setup.
+- Clicking Save with an unreachable provider. The wizard does not re-test connections at this point -- make sure your providers are still running.
+
+---
+
+## Step 7: Deploying
+
+**What you see during deployment:**
+
+```
++--------------------------------------------------+
+|          Setting Up Your Stack                     |
+|                                                    |
+|  Pulling container images...                       |
+|                                                    |
+|  Overall progress                          45%     |
+|  [==================                          ]    |
+|  Pulling caddy image...                            |
+|                                                    |
+|  [check] Admin         Running                     |
+|  [==========================================] 100% |
+|                                                    |
+|  [check] Caddy         Image ready                 |
+|  [============================            ]  70%   |
+|                                                    |
+|  [spinner] Guardian     Pulling image...           |
+|  [=============                           ]  30%   |
+|                                                    |
+|  [spinner] Assistant    Pulling image...           |
+|  [========                                ]  20%   |
+|                                                    |
+|  [spinner] Memory       Pulling image...           |
+|  [=====                                   ]  15%   |
+|                                                    |
+|  Tips while you wait                               |
+|  What is happening right now?                      |
+|  - First startup is the slowest because container  |
+|    images still need to download.                  |
+|  - You can keep this tab open while the stack      |
+|    comes online.                                   |
+|  - If a provider is local, make sure it is still   |
+|    running on this machine.                        |
++--------------------------------------------------+
+```
+
+The deploying screen does not show the step dots. It has three phases:
+
+### Phase 1: Pulling
+
+The wizard polls `GET /admin/setup/deploy-status` every 2 seconds. Each service shows:
+- A **spinner** while its image is being pulled
+- A **checkmark** once the image is ready
+- A progress bar filling from left to right
+
+**Phase message**: "Pulling container images..."
+
+### Phase 2: Starting
+
+After all images are pulled, services start up:
+
+**Phase message**: "Starting services..."
+
+Each service's progress bar completes and status changes to "Running" as its container comes online.
+
+### Phase 3: Ready
+
+```
++--------------------------------------------------+
+|          Setting Up Your Stack                     |
+|                                                    |
+|  All services are up and running.                  |
+|                                                    |
+|  Overall progress                         100%     |
+|  [==========================================]      |
+|                                                    |
+|  [check] Admin         Running                     |
+|  [check] Caddy         Running                     |
+|  [check] Guardian      Running                     |
+|  [check] Assistant     Running                     |
+|  [check] Memory        Running                     |
+|                                                    |
+|  Tips while you wait                               |
+|  - Your core services are online and ready for     |
+|    the console.                                    |
+|  - You can revisit Connections later to swap        |
+|    models or add more providers.                   |
+|                                                    |
+|                         [Go to Console]            |
++--------------------------------------------------+
+```
+
+When all services are running, the **Go to Console** button appears. Click it to open the admin dashboard at `http://localhost/`.
+
+### Error State
+
+If deployment fails, the wizard shows a diagnostic summary:
+
+```
++--------------------------------------------------+
+|          Setting Up Your Stack                     |
+|                                                    |
+|  OpenPalm could not finish starting.               |
+|                                                    |
+|  Overall progress              Needs attention     |
+|  [====================                        ]    |
+|                                                    |
+|  +----------------------------------------------+ |
+|  | Setup needs attention                         | |
+|  |                                                | |
+|  | OpenPalm could not finish starting the stack  | |
+|  |                                                | |
+|  | Error response from daemon: ...               | |
+|  |                                                | |
+|  | - Go back to Review to adjust settings, then  | |
+|  |   try again.                                  | |
+|  | - Open Technical details if you need the raw  | |
+|  |   Docker error for troubleshooting.           | |
+|  +----------------------------------------------+ |
+|                                                    |
+|  [> Technical details]                             |
+|      (expandable raw error output)                 |
+|                                                    |
+|  [Back to Review]              [Try Again]         |
++--------------------------------------------------+
+```
+
+The error card includes:
+- A human-readable summary of what went wrong
+- Recovery steps tailored to the type of error
+- A collapsible "Technical details" section with the full Docker error output
+
+**Recovery options:**
+- **Back to Review**: Returns to Step 6 so you can edit settings.
+- **Try Again**: Resubmits the current configuration for another deployment attempt.
+
+**Common deployment errors:**
+
+| Error | Likely cause | Fix |
+|-------|-------------|-----|
+| "Docker is not available" | Docker daemon stopped | Start Docker, then Try Again |
+| "Error mounting..." | Stale mount paths from previous failed run | Reset dev environment or clear STATE_HOME |
+| Network/timeout errors | Slow internet or unreachable registry | Wait and Try Again, or check network |
+
+---
+
+## After the Wizard
+
+Once you click **Go to Console**, you are taken to the admin dashboard. From there:
+
+- **Connections page**: Edit connections, add new providers, re-test endpoints
+- **Memory page**: View and manage memory entries
+- **Channels page**: Install channels from the registry (Discord, API, etc.)
+- **Containers page**: Monitor service status, restart services
+
+If you ever need to re-run the wizard from scratch, delete the setup state file:
+
+```bash
+# Default path:
+rm ~/.local/share/openpalm/admin/setup-state.json
+
+# Dev environment:
+rm .dev/data/admin/setup-state.json
+```
+
+Then restart the admin container and navigate to `/setup`.
+
+---
+
+## Quick Reference: Wizard Flow Summary
+
+```
+  [1. Welcome]
+       |
+       | Enter name, email, admin token
+       v
+  [2. Connections Hub]  <---------+
+       |                          |
+       | Add connection           | (Add another)
+       v                          |
+  [3a. Connection Type]           |
+       |                          |
+       | Choose Remote or Local   |
+       v                          |
+  [3b. Connection Details]        |
+       |                          |
+       | Configure, test, save ---+
+       v
+  [4. Required Models]
+       |
+       | Pick chat + embedding models
+       v
+  [5. Optional Add-ons]
+       |
+       | Toggle reranking, TTS, STT
+       v
+  [6. Review & Install]
+       |
+       | Confirm and click Save
+       v
+  [7. Deploying]
+       |
+       | Wait for images + containers
+       v
+  [Admin Console]
+```
+
+---
+
+## See Also
+
+- [Setup Guide](setup-guide.md) -- Installation, updating, troubleshooting
+- [Manual Setup](manual-setup.md) -- Step-by-step host configuration without scripts
+- [Managing OpenPalm](managing-openpalm.md) -- Day-to-day administration
+- [Troubleshooting](troubleshooting.md) -- Common problems and solutions

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -270,7 +270,7 @@ mismatch between the new admin image and the old staged files.
    ```bash
    rm -rf ~/.local/state/openpalm/artifacts
    # Re-run the installer
-   curl -fsSL https://raw.githubusercontent.com/itlackey/openpalm/main/scripts/setup.sh | bash
+   curl -fsSL https://raw.githubusercontent.com/itlackey/openpalm/v0.9.0-rc5/scripts/setup.sh | bash
    ```
 4. Pull the latest images explicitly:
    ```bash
@@ -300,7 +300,7 @@ docker compose down -v
 rm -rf ~/.config/openpalm ~/.local/share/openpalm ~/.local/state/openpalm
 
 # Re-run the installer
-curl -fsSL https://raw.githubusercontent.com/itlackey/openpalm/main/scripts/setup.sh | bash
+curl -fsSL https://raw.githubusercontent.com/itlackey/openpalm/v0.9.0-rc5/scripts/setup.sh | bash
 ```
 
 On Windows (PowerShell):
@@ -310,7 +310,7 @@ docker compose down -v
 Remove-Item -Recurse -Force "$env:USERPROFILE\.config\openpalm", `
   "$env:USERPROFILE\.local\share\openpalm", `
   "$env:USERPROFILE\.local\state\openpalm"
-irm https://raw.githubusercontent.com/itlackey/openpalm/main/scripts/setup.ps1 | iex
+irm https://raw.githubusercontent.com/itlackey/openpalm/v0.9.0-rc5/scripts/setup.ps1 | iex
 ```
 
 This removes all configuration, data, and state. Back up CONFIG_HOME and

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -10,10 +10,10 @@ One-liner installer for Mac/Linux and Windows respectively.
 
 ```bash
 # Mac / Linux
-curl -fsSL https://raw.githubusercontent.com/itlackey/openpalm/main/scripts/setup.sh | bash
+curl -fsSL https://raw.githubusercontent.com/itlackey/openpalm/v0.9.0-rc5/scripts/setup.sh | bash
 
 # Windows (PowerShell)
-irm https://raw.githubusercontent.com/itlackey/openpalm/main/scripts/setup.ps1 | iex
+irm https://raw.githubusercontent.com/itlackey/openpalm/v0.9.0-rc5/scripts/setup.ps1 | iex
 ```
 
 Re-run to update — secrets are never overwritten. Options:
@@ -21,7 +21,7 @@ Re-run to update — secrets are never overwritten. Options:
 | Flag | Effect |
 |---|---|
 | `--force` | Skip confirmation prompts |
-| `--version TAG` | Install a specific release tag (default: `main`) |
+| `--version TAG` | Install a specific release tag (default: current release) |
 | `--no-start` | Set up files but don't start Docker services |
 | `--no-open` | Don't open the admin UI after install |
 
@@ -30,7 +30,7 @@ Re-run to update — secrets are never overwritten. Options:
 Installs the compiled OpenPalm CLI binary from GitHub Releases into `~/.local/bin/openpalm` by default.
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/itlackey/openpalm/main/scripts/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/itlackey/openpalm/v0.9.0-rc5/scripts/install.sh | bash
 ```
 
 Options:

--- a/scripts/release-e2e-test.sh
+++ b/scripts/release-e2e-test.sh
@@ -1,0 +1,771 @@
+#!/usr/bin/env bash
+#
+# End-to-end test for the OpenPalm production install path.
+#
+# Simulates what a user would experience running `curl | bash` on a clean
+# machine with only Docker installed. Exercises:
+#
+#   1. Production setup.sh (asset download, dir creation, secrets seeding)
+#   2. Admin container health (image pull, startup, HTTP 200)
+#   3. Setup wizard API (GET status, POST complete, deploy-status polling)
+#   4. All-service health checks (admin, memory, assistant, guardian, caddy)
+#   5. Chat channel message round-trip (if installed)
+#   6. Cleanup (or --keep to leave stack running)
+#
+# This script is CI-friendly: structured output, deterministic exit codes,
+# no interactive prompts, no browser opens.
+#
+# Required environment variables:
+#   ADMIN_TOKEN         Admin token to set during setup (default: test-admin-token)
+#
+# Provider configuration (at least one required):
+#   OPENAI_API_KEY      OpenAI API key (if using OpenAI)
+#   OLLAMA_URL          Ollama base URL (default: http://host.docker.internal:11434)
+#   SYSTEM_MODEL        LLM model name (default: qwen2.5-coder:3b)
+#   EMBED_MODEL         Embedding model name (default: nomic-embed-text:latest)
+#   EMBED_DIMS          Embedding dimensions (default: 768)
+#
+# Optional environment variables:
+#   OPENPALM_IMAGE_TAG         Image tag to test (default: latest)
+#   OPENPALM_IMAGE_NAMESPACE   Image namespace (default: openpalm)
+#   OPENPALM_CONFIG_HOME       Override config dir (default: temp dir)
+#   OPENPALM_DATA_HOME         Override data dir (default: temp dir)
+#   OPENPALM_STATE_HOME        Override state dir (default: temp dir)
+#   OPENPALM_WORK_DIR          Override work dir (default: temp dir)
+#
+# Usage:
+#   ./scripts/release-e2e-test.sh [OPTIONS]
+#
+# Options:
+#   --keep              Leave the stack running after tests (skip cleanup)
+#   --skip-install      Skip setup.sh and test against an already-running stack
+#   --version TAG       GitHub ref / release tag to test (default: main)
+#   --provider PROVIDER Provider to use: ollama, openai (default: ollama)
+#   --timeout SECS      Max seconds to wait for services (default: 300)
+#   -h, --help          Show this help
+#
+set -euo pipefail
+
+# ── Argument parsing ──────────────────────────────────────────────────
+
+KEEP=0
+SKIP_INSTALL=0
+VERSION="main"
+PROVIDER="ollama"
+SERVICE_TIMEOUT=300
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --keep) KEEP=1 ;;
+    --skip-install) SKIP_INSTALL=1 ;;
+    --version) shift; VERSION="${1:?--version requires a value}" ;;
+    --provider) shift; PROVIDER="${1:?--provider requires a value}" ;;
+    --timeout) shift; SERVICE_TIMEOUT="${1:?--timeout requires a value}" ;;
+    -h|--help)
+      sed -n '2,/^set -/{ /^#/s/^# \?//p }' "$0"
+      exit 0
+      ;;
+    *) echo "Unknown option: $1" >&2; exit 1 ;;
+  esac
+  shift
+done
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# ── Test infrastructure ───────────────────────────────────────────────
+
+PASS=0
+FAIL=0
+TESTS=0
+STEP=0
+
+pass() { PASS=$((PASS + 1)); TESTS=$((TESTS + 1)); echo "  PASS: $1"; }
+fail() { FAIL=$((FAIL + 1)); TESTS=$((TESTS + 1)); echo "  FAIL: $1"; }
+skip() { TESTS=$((TESTS + 1)); echo "  SKIP: $1"; }
+
+step() {
+  STEP=$((STEP + 1))
+  echo ""
+  echo "=== Step $STEP: $1 ==="
+}
+
+# ── Defaults ──────────────────────────────────────────────────────────
+
+ADMIN_TOKEN="${ADMIN_TOKEN:-test-admin-token}"
+OLLAMA_URL="${OLLAMA_URL:-http://host.docker.internal:11434}"
+SYSTEM_MODEL="${SYSTEM_MODEL:-qwen2.5-coder:3b}"
+EMBED_MODEL="${EMBED_MODEL:-nomic-embed-text:latest}"
+EMBED_DIMS="${EMBED_DIMS:-768}"
+
+# ── Temp directory for isolated install ───────────────────────────────
+
+USE_TEMP_DIRS=0
+TEMP_ROOT=""
+
+if [ "$SKIP_INSTALL" -eq 0 ]; then
+  # Use temp dirs unless explicitly overridden — ensures clean-machine simulation
+  if [ -z "${OPENPALM_CONFIG_HOME:-}" ] && [ -z "${OPENPALM_DATA_HOME:-}" ] && \
+     [ -z "${OPENPALM_STATE_HOME:-}" ] && [ -z "${OPENPALM_WORK_DIR:-}" ]; then
+    USE_TEMP_DIRS=1
+    TEMP_ROOT="$(mktemp -d -t openpalm-release-test-XXXXXX)"
+    export OPENPALM_CONFIG_HOME="$TEMP_ROOT/config"
+    export OPENPALM_DATA_HOME="$TEMP_ROOT/data"
+    export OPENPALM_STATE_HOME="$TEMP_ROOT/state"
+    export OPENPALM_WORK_DIR="$TEMP_ROOT/work"
+    echo "Using temp dirs under: $TEMP_ROOT"
+  fi
+fi
+
+CONFIG_HOME="${OPENPALM_CONFIG_HOME:-${HOME}/.config/openpalm}"
+DATA_HOME="${OPENPALM_DATA_HOME:-${HOME}/.local/share/openpalm}"
+STATE_HOME="${OPENPALM_STATE_HOME:-${HOME}/.local/state/openpalm}"
+
+# ── Cleanup handler ──────────────────────────────────────────────────
+
+cleanup() {
+  if [ "$KEEP" -eq 1 ]; then
+    echo ""
+    echo "  --keep flag set. Stack is still running."
+    echo "  Config: ${CONFIG_HOME}"
+    echo "  Data:   ${DATA_HOME}"
+    echo "  State:  ${STATE_HOME}"
+    return
+  fi
+
+  echo ""
+  echo "=== Cleanup ==="
+
+  # Stop and remove containers
+  docker compose --project-name openpalm down --volumes --remove-orphans 2>/dev/null || true
+  echo "  Containers stopped"
+
+  # Remove temp dirs if we created them
+  if [ "$USE_TEMP_DIRS" -eq 1 ] && [ -n "$TEMP_ROOT" ] && [ -d "$TEMP_ROOT" ]; then
+    # Some container data may be root-owned; use docker to clean
+    docker run --rm -v "$TEMP_ROOT:/cleanup" alpine rm -rf /cleanup 2>/dev/null || true
+    rm -rf "$TEMP_ROOT" 2>/dev/null || true
+    echo "  Temp dirs removed: $TEMP_ROOT"
+  fi
+}
+
+trap cleanup EXIT
+
+# ── Step 1: Preflight ─────────────────────────────────────────────────
+
+step "Preflight checks"
+
+if ! command -v docker &>/dev/null; then
+  fail "Docker is not installed"
+  echo "ABORTING -- Docker is required"
+  exit 1
+fi
+pass "Docker is installed"
+
+if ! docker info &>/dev/null; then
+  fail "Docker daemon is not running"
+  echo "ABORTING -- Docker daemon must be running"
+  exit 1
+fi
+pass "Docker daemon is running"
+
+if ! docker compose version &>/dev/null; then
+  fail "Docker Compose v2 not available"
+  echo "ABORTING -- Docker Compose v2 is required"
+  exit 1
+fi
+pass "Docker Compose v2 available"
+
+if ! command -v curl &>/dev/null; then
+  fail "curl is not installed"
+  echo "ABORTING -- curl is required"
+  exit 1
+fi
+pass "curl is installed"
+
+# Check for python3 or jq (need one for JSON parsing)
+JSON_PARSER=""
+if command -v python3 &>/dev/null; then
+  JSON_PARSER="python3"
+elif command -v jq &>/dev/null; then
+  JSON_PARSER="jq"
+else
+  fail "Neither python3 nor jq found (needed for JSON parsing)"
+  echo "ABORTING -- install python3 or jq"
+  exit 1
+fi
+pass "JSON parser available ($JSON_PARSER)"
+
+# ── JSON helper ───────────────────────────────────────────────────────
+
+json_get() {
+  local json="$1" field="$2"
+  if [ "$JSON_PARSER" = "python3" ]; then
+    echo "$json" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('$field',''))" 2>/dev/null || echo ""
+  else
+    echo "$json" | jq -r ".$field // empty" 2>/dev/null || echo ""
+  fi
+}
+
+# ── Step 2: Ensure no conflicting stack ───────────────────────────────
+
+step "Stop any existing openpalm stack"
+
+docker compose --project-name openpalm down 2>/dev/null || true
+remaining=$(docker ps --format '{{.Names}}' | grep openpalm || true)
+if [ -z "$remaining" ]; then
+  pass "No conflicting containers"
+else
+  fail "Containers still running: $remaining"
+  echo "ABORTING -- stop existing openpalm containers first"
+  exit 1
+fi
+
+# ── Step 3: Run setup.sh ─────────────────────────────────────────────
+
+if [ "$SKIP_INSTALL" -eq 0 ]; then
+  step "Run production setup.sh"
+
+  SETUP_ARGS=(--force --no-open --version "$VERSION")
+  SETUP_LOG="$(mktemp)"
+
+  # Run setup.sh from the repo (or could curl from GitHub for true production test)
+  SETUP_EXIT=0
+  if [ -f "$ROOT_DIR/scripts/setup.sh" ]; then
+    echo "  Running setup.sh from local repo..."
+    bash "$ROOT_DIR/scripts/setup.sh" "${SETUP_ARGS[@]}" > "$SETUP_LOG" 2>&1 || SETUP_EXIT=$?
+  else
+    echo "  Downloading setup.sh from GitHub..."
+    curl -fsSL "https://raw.githubusercontent.com/itlackey/openpalm/$VERSION/scripts/setup.sh" \
+      -o "$SETUP_LOG.script" 2>/dev/null
+    bash "$SETUP_LOG.script" "${SETUP_ARGS[@]}" > "$SETUP_LOG" 2>&1 || SETUP_EXIT=$?
+    rm -f "$SETUP_LOG.script"
+  fi
+
+  # Show setup output indented
+  sed 's/^/  [setup.sh] /' "$SETUP_LOG"
+  rm -f "$SETUP_LOG"
+
+  if [ "$SETUP_EXIT" -eq 0 ]; then
+    pass "setup.sh completed successfully"
+  else
+    fail "setup.sh exited with code $SETUP_EXIT"
+    echo "ABORTING -- setup.sh failed"
+    exit 1
+  fi
+
+  # Verify directory structure was created
+  for dir in "$CONFIG_HOME" "$DATA_HOME" "$STATE_HOME"; do
+    if [ -d "$dir" ]; then
+      pass "Directory created: $dir"
+    else
+      fail "Directory missing: $dir"
+    fi
+  done
+
+  # Verify key files were downloaded
+  for file in "$STATE_HOME/artifacts/docker-compose.yml" "$STATE_HOME/artifacts/Caddyfile"; do
+    if [ -f "$file" ] && [ -s "$file" ]; then
+      pass "Asset present: $(basename "$file")"
+    else
+      fail "Asset missing or empty: $file"
+    fi
+  done
+
+  # Verify secrets.env was seeded
+  if [ -f "$CONFIG_HOME/secrets.env" ]; then
+    pass "secrets.env created"
+  else
+    fail "secrets.env not created"
+  fi
+else
+  step "Skipping install (--skip-install)"
+  echo "  Testing against already-running stack"
+fi
+
+# ── Step 4: Wait for admin to be healthy ──────────────────────────────
+
+step "Wait for admin container health"
+
+ADMIN_URL="http://127.0.0.1:8100"
+ADMIN_HEALTHY=false
+elapsed=0
+while [ $elapsed -lt "$SERVICE_TIMEOUT" ]; do
+  if curl -sf "$ADMIN_URL/" > /dev/null 2>&1; then
+    ADMIN_HEALTHY=true
+    break
+  fi
+  sleep 3
+  elapsed=$((elapsed + 3))
+  if [ $((elapsed % 15)) -eq 0 ]; then
+    echo "  Waiting for admin... (${elapsed}s / ${SERVICE_TIMEOUT}s)"
+  fi
+done
+
+if [ "$ADMIN_HEALTHY" = "true" ]; then
+  pass "Admin is healthy (responded in ${elapsed}s)"
+else
+  fail "Admin did not respond within ${SERVICE_TIMEOUT}s"
+  echo ""
+  echo "  Admin container logs (last 30 lines):"
+  docker compose --project-name openpalm logs admin --tail 30 2>/dev/null || true
+  echo "ABORTING -- cannot continue without admin"
+  exit 1
+fi
+
+# ── Step 5: Verify setup wizard responds ──────────────────────────────
+
+step "Verify setup wizard API"
+
+SETUP_RESPONSE=$(curl -sf "$ADMIN_URL/admin/setup" 2>/dev/null || echo '{}')
+SETUP_COMPLETE=$(json_get "$SETUP_RESPONSE" "setupComplete")
+SETUP_TOKEN=$(json_get "$SETUP_RESPONSE" "setupToken")
+
+if [ "$SKIP_INSTALL" -eq 1 ]; then
+  # If skip-install, setup might already be complete
+  if [ "$SETUP_COMPLETE" = "True" ] || [ "$SETUP_COMPLETE" = "true" ]; then
+    pass "Setup is already complete (--skip-install mode)"
+    # Use provided admin token for subsequent requests
+    SETUP_TOKEN=""
+  else
+    pass "Setup API responds (setupComplete=$SETUP_COMPLETE)"
+  fi
+else
+  if [ "$SETUP_COMPLETE" = "False" ] || [ "$SETUP_COMPLETE" = "false" ]; then
+    pass "Setup is NOT complete (fresh install confirmed)"
+  else
+    fail "Expected setup to be incomplete on fresh install, got: $SETUP_COMPLETE"
+  fi
+
+  if [ -n "$SETUP_TOKEN" ]; then
+    pass "Setup token received (for wizard authentication)"
+  else
+    fail "No setup token in response"
+  fi
+fi
+
+# ── Step 6: Complete setup wizard ─────────────────────────────────────
+
+NEED_SETUP=true
+if [ "$SKIP_INSTALL" -eq 1 ]; then
+  if [ "$SETUP_COMPLETE" = "True" ] || [ "$SETUP_COMPLETE" = "true" ]; then
+    NEED_SETUP=false
+  fi
+fi
+
+if [ "$NEED_SETUP" = "true" ]; then
+  step "Complete setup wizard via API"
+
+  # Build the setup payload based on provider
+  case "$PROVIDER" in
+    ollama)
+      SETUP_PAYLOAD=$(cat <<PAYLOAD
+{
+  "adminToken": "$ADMIN_TOKEN",
+  "memoryUserId": "release-test",
+  "connections": [
+    {
+      "id": "ollama-local",
+      "name": "Ollama",
+      "provider": "ollama",
+      "baseUrl": "$OLLAMA_URL",
+      "apiKey": ""
+    }
+  ],
+  "assignments": {
+    "llm": {
+      "connectionId": "ollama-local",
+      "model": "$SYSTEM_MODEL"
+    },
+    "embeddings": {
+      "connectionId": "ollama-local",
+      "model": "$EMBED_MODEL",
+      "embeddingDims": $EMBED_DIMS
+    }
+  }
+}
+PAYLOAD
+)
+      ;;
+    openai)
+      if [ -z "${OPENAI_API_KEY:-}" ]; then
+        fail "OPENAI_API_KEY is required for --provider openai"
+        echo "ABORTING -- set OPENAI_API_KEY"
+        exit 1
+      fi
+      SETUP_PAYLOAD=$(cat <<PAYLOAD
+{
+  "adminToken": "$ADMIN_TOKEN",
+  "memoryUserId": "release-test",
+  "connections": [
+    {
+      "id": "openai",
+      "name": "OpenAI",
+      "provider": "openai",
+      "baseUrl": "",
+      "apiKey": "$OPENAI_API_KEY"
+    }
+  ],
+  "assignments": {
+    "llm": {
+      "connectionId": "openai",
+      "model": "gpt-4o-mini"
+    },
+    "embeddings": {
+      "connectionId": "openai",
+      "model": "text-embedding-3-small",
+      "embeddingDims": 1536
+    }
+  }
+}
+PAYLOAD
+)
+      ;;
+    *)
+      fail "Unknown provider: $PROVIDER (supported: ollama, openai)"
+      exit 1
+      ;;
+  esac
+
+  # Determine auth token for the setup POST
+  AUTH_TOKEN="${SETUP_TOKEN:-$ADMIN_TOKEN}"
+
+  SETUP_RESULT=$(curl -sf -X POST "$ADMIN_URL/admin/setup" \
+    -H "x-admin-token: $AUTH_TOKEN" \
+    -H "content-type: application/json" \
+    -d "$SETUP_PAYLOAD" 2>&1 || echo '{"ok": false, "error": "curl failed"}')
+
+  SETUP_OK=$(json_get "$SETUP_RESULT" "ok")
+
+  if [ "$SETUP_OK" = "True" ] || [ "$SETUP_OK" = "true" ]; then
+    pass "Setup wizard completed (async deploy started)"
+  else
+    # The setup POST may drop the connection when Caddy restarts.
+    # Wait and re-check the status.
+    sleep 10
+    RETRY_RESPONSE=$(curl -sf "$ADMIN_URL/admin/setup" \
+      -H "x-admin-token: $ADMIN_TOKEN" 2>/dev/null || echo '{}')
+    RETRY_COMPLETE=$(json_get "$RETRY_RESPONSE" "setupComplete")
+
+    if [ "$RETRY_COMPLETE" = "True" ] || [ "$RETRY_COMPLETE" = "true" ]; then
+      pass "Setup wizard completed (verified via status re-check)"
+    else
+      fail "Setup wizard failed. Response: $SETUP_RESULT"
+      echo ""
+      echo "  Admin logs (last 20 lines):"
+      docker compose --project-name openpalm logs admin --tail 20 2>/dev/null || true
+    fi
+  fi
+
+  # ── Step 6b: Poll deploy-status until complete ────────────────────
+
+  step "Wait for background deploy to finish"
+
+  deploy_elapsed=0
+  DEPLOY_DONE=false
+  while [ $deploy_elapsed -lt "$SERVICE_TIMEOUT" ]; do
+    DEPLOY_STATUS=$(curl -sf "$ADMIN_URL/admin/setup/deploy-status" \
+      -H "x-admin-token: $ADMIN_TOKEN" 2>/dev/null || echo '{}')
+    DEPLOY_ACTIVE=$(json_get "$DEPLOY_STATUS" "active")
+
+    if [ "$DEPLOY_ACTIVE" = "False" ] || [ "$DEPLOY_ACTIVE" = "false" ]; then
+      DEPLOY_DONE=true
+      break
+    fi
+
+    sleep 5
+    deploy_elapsed=$((deploy_elapsed + 5))
+    if [ $((deploy_elapsed % 30)) -eq 0 ]; then
+      echo "  Deploy in progress... (${deploy_elapsed}s / ${SERVICE_TIMEOUT}s)"
+    fi
+  done
+
+  if [ "$DEPLOY_DONE" = "true" ]; then
+    pass "Background deploy completed (${deploy_elapsed}s)"
+  else
+    # Deploy may have finished but status endpoint still active due to timing;
+    # fall through to health checks
+    echo "  Deploy status still active after ${SERVICE_TIMEOUT}s -- continuing to health checks"
+  fi
+fi
+
+# ── Step 7: Wait for all services healthy ─────────────────────────────
+
+step "Wait for all services to be healthy"
+
+HEALTHCHECK_SVCS="admin memory assistant guardian docker-socket-proxy"
+MAX_WAIT="$SERVICE_TIMEOUT"
+elapsed=0
+while [ $elapsed -lt "$MAX_WAIT" ]; do
+  ALL_UP=true
+  WAIT_MSG=""
+  for svc in $HEALTHCHECK_SVCS; do
+    status=$(docker inspect --format '{{.State.Health.Status}}' "openpalm-${svc}-1" 2>/dev/null || echo "missing")
+    if [ "$status" != "healthy" ]; then
+      ALL_UP=false
+      WAIT_MSG="$svc is $status"
+      break
+    fi
+  done
+  # Also check caddy is running (no healthcheck defined)
+  caddy_status=$(docker inspect --format '{{.State.Status}}' "openpalm-caddy-1" 2>/dev/null || echo "missing")
+  if [ "$caddy_status" != "running" ]; then
+    ALL_UP=false
+    WAIT_MSG="caddy is $caddy_status"
+  fi
+  if [ "$ALL_UP" = "true" ]; then
+    break
+  fi
+  if [ $((elapsed % 15)) -eq 0 ]; then
+    echo "  Waiting... ($elapsed/${MAX_WAIT}s) -- $WAIT_MSG"
+  fi
+  sleep 5
+  elapsed=$((elapsed + 5))
+done
+
+ALL_HEALTHY=true
+for svc in $HEALTHCHECK_SVCS; do
+  status=$(docker inspect --format '{{.State.Health.Status}}' "openpalm-${svc}-1" 2>/dev/null || echo "missing")
+  if [ "$status" = "healthy" ]; then
+    pass "$svc is healthy"
+  else
+    fail "$svc status: $status"
+    ALL_HEALTHY=false
+    # Show logs for failed service
+    echo "  Last 10 log lines for $svc:"
+    docker compose --project-name openpalm logs "$svc" --tail 10 2>/dev/null || true
+  fi
+done
+
+# Caddy - check running status
+caddy_status=$(docker inspect --format '{{.State.Status}}' "openpalm-caddy-1" 2>/dev/null || echo "missing")
+if [ "$caddy_status" = "running" ]; then
+  pass "caddy is running"
+else
+  fail "caddy status: $caddy_status"
+  ALL_HEALTHY=false
+fi
+
+# ── Step 8: Verify setup marked complete ──────────────────────────────
+
+step "Verify setup is marked complete"
+
+FINAL_STATUS=$(curl -sf "$ADMIN_URL/admin/setup" \
+  -H "x-admin-token: $ADMIN_TOKEN" 2>/dev/null || echo '{}')
+FINAL_COMPLETE=$(json_get "$FINAL_STATUS" "setupComplete")
+
+if [ "$FINAL_COMPLETE" = "True" ] || [ "$FINAL_COMPLETE" = "true" ]; then
+  pass "Setup is marked complete"
+else
+  fail "Setup is NOT marked complete: $FINAL_COMPLETE"
+fi
+
+# ── Step 9: Verify secrets.env has expected values ────────────────────
+
+if [ "$SKIP_INSTALL" -eq 0 ]; then
+  step "Verify secrets.env"
+
+  secrets="$CONFIG_HOME/secrets.env"
+
+  check_env_key() {
+    local key="$1"
+    local actual
+    actual=$(grep "^${key}=" "$secrets" 2>/dev/null | head -1 | cut -d= -f2-)
+    if [ -n "$actual" ]; then
+      pass "$key is set in secrets.env"
+    else
+      fail "$key is empty or missing in secrets.env"
+    fi
+  }
+
+  check_env_val() {
+    local key="$1" expected="$2"
+    local actual
+    actual=$(grep "^${key}=" "$secrets" 2>/dev/null | head -1 | cut -d= -f2-)
+    if [ "$actual" = "$expected" ]; then
+      pass "$key=$expected"
+    else
+      fail "$key expected '$expected', got '$actual'"
+    fi
+  }
+
+  check_env_val "ADMIN_TOKEN" "$ADMIN_TOKEN"
+  check_env_val "MEMORY_USER_ID" "release-test"
+  check_env_key "SYSTEM_LLM_PROVIDER"
+  check_env_key "SYSTEM_LLM_MODEL"
+else
+  step "Skipping secrets.env check (--skip-install)"
+fi
+
+# ── Step 10: Verify admin API with token ──────────────────────────────
+
+step "Verify admin API authentication"
+
+# Authenticated request should succeed
+AUTH_RESPONSE=$(curl -sf "$ADMIN_URL/admin/setup" \
+  -H "x-admin-token: $ADMIN_TOKEN" 2>/dev/null)
+if [ -n "$AUTH_RESPONSE" ]; then
+  pass "Authenticated admin API request succeeds"
+else
+  fail "Authenticated admin API request failed"
+fi
+
+# ── Step 11: Verify memory service ────────────────────────────────────
+
+step "Verify memory service"
+
+MEMORY_URL="http://127.0.0.1:8765"
+MEMORY_OK=false
+for attempt in 1 2 3 4 5 6; do
+  MEMORY_STATUS=$(curl -sf -o /dev/null -w '%{http_code}' \
+    "$MEMORY_URL/health" 2>/dev/null || echo "error")
+  if [ "$MEMORY_STATUS" = "200" ]; then
+    MEMORY_OK=true
+    break
+  fi
+  echo "  Attempt $attempt: HTTP $MEMORY_STATUS, retrying in 10s..."
+  sleep 10
+done
+
+if [ "$MEMORY_OK" = "true" ]; then
+  pass "Memory service health endpoint responds"
+else
+  fail "Memory service not healthy (HTTP $MEMORY_STATUS)"
+fi
+
+# Verify memory user can be queried
+MEMORY_FILTER_STATUS=$(curl -sf -o /dev/null -w '%{http_code}' \
+  -X POST "$MEMORY_URL/api/v1/memories/filter" \
+  -H 'content-type: application/json' \
+  -d '{"user_id": "release-test"}' 2>/dev/null || echo "error")
+
+if [ "$MEMORY_FILTER_STATUS" = "200" ]; then
+  pass "Memory user filter API responds (HTTP 200)"
+else
+  fail "Memory user filter returned HTTP $MEMORY_FILTER_STATUS"
+fi
+
+# ── Step 12: Verify assistant container env ───────────────────────────
+
+step "Verify assistant container environment"
+
+check_container_env() {
+  local container="$1" var="$2" check_type="$3" expected="${4:-}"
+  local actual
+  actual=$(docker exec "$container" printenv "$var" 2>/dev/null || echo "")
+
+  if [ "$check_type" = "equals" ]; then
+    if [ "$actual" = "$expected" ]; then
+      pass "$container $var=$expected"
+    else
+      fail "$container $var expected '$expected', got '$actual'"
+    fi
+  elif [ "$check_type" = "nonempty" ]; then
+    if [ -n "$actual" ]; then
+      pass "$container $var is set"
+    else
+      fail "$container $var is empty"
+    fi
+  elif [ "$check_type" = "endswith" ]; then
+    if echo "$actual" | grep -q "${expected}$"; then
+      pass "$container $var ends with '$expected'"
+    else
+      fail "$container $var should end with '$expected', got '$actual'"
+    fi
+  fi
+}
+
+check_container_env "openpalm-assistant-1" "OPENPALM_ADMIN_TOKEN" "equals" "$ADMIN_TOKEN"
+check_container_env "openpalm-assistant-1" "MEMORY_USER_ID" "nonempty"
+check_container_env "openpalm-assistant-1" "OPENAI_BASE_URL" "endswith" "/v1"
+
+# ── Step 13: Verify Caddy proxy ───────────────────────────────────────
+
+step "Verify Caddy reverse proxy"
+
+CADDY_PORT="${OPENPALM_INGRESS_PORT:-8080}"
+CADDY_URL="http://127.0.0.1:$CADDY_PORT"
+
+CADDY_STATUS=$(curl -sf -o /dev/null -w '%{http_code}' "$CADDY_URL/" 2>/dev/null || echo "error")
+if [ "$CADDY_STATUS" = "200" ] || [ "$CADDY_STATUS" = "302" ]; then
+  pass "Caddy proxy responds on port $CADDY_PORT (HTTP $CADDY_STATUS)"
+else
+  fail "Caddy proxy returned HTTP $CADDY_STATUS on port $CADDY_PORT"
+fi
+
+# ── Step 14: Test chat channel (if installed) ─────────────────────────
+
+step "Check for chat channel"
+
+CHAT_CONTAINER=$(docker ps --format '{{.Names}}' | grep "openpalm-channel-chat" || true)
+if [ -n "$CHAT_CONTAINER" ]; then
+  pass "Chat channel container is running: $CHAT_CONTAINER"
+
+  # Check chat channel health
+  CHAT_HEALTH=$(docker inspect --format '{{.State.Health.Status}}' "$CHAT_CONTAINER" 2>/dev/null || echo "no-healthcheck")
+  if [ "$CHAT_HEALTH" = "healthy" ]; then
+    pass "Chat channel is healthy"
+  elif [ "$CHAT_HEALTH" = "no-healthcheck" ]; then
+    # Container running but no healthcheck defined
+    CHAT_RUNNING=$(docker inspect --format '{{.State.Status}}' "$CHAT_CONTAINER" 2>/dev/null || echo "unknown")
+    if [ "$CHAT_RUNNING" = "running" ]; then
+      pass "Chat channel is running (no healthcheck defined)"
+    else
+      fail "Chat channel status: $CHAT_RUNNING"
+    fi
+  else
+    fail "Chat channel health: $CHAT_HEALTH"
+  fi
+else
+  skip "Chat channel not installed (optional)"
+fi
+
+# ── Step 15: Verify no root-owned files (if we created temp dirs) ────
+
+if [ "$SKIP_INSTALL" -eq 0 ] && [ "$USE_TEMP_DIRS" -eq 1 ]; then
+  step "Check file ownership"
+
+  root_files=$(find "$TEMP_ROOT" -not -user "$(whoami)" 2>/dev/null || true)
+  if [ -z "$root_files" ]; then
+    pass "No root-owned files in install directories"
+  else
+    root_count=$(echo "$root_files" | wc -l)
+    fail "Root-owned files found ($root_count files)"
+    echo "$root_files" | head -5 | while read -r f; do echo "    $f"; done
+    if [ "$root_count" -gt 5 ]; then
+      echo "    ... and $((root_count - 5)) more"
+    fi
+  fi
+fi
+
+# ── Step 16: List all running containers ──────────────────────────────
+
+step "Running container summary"
+
+echo ""
+echo "  Container statuses:"
+docker ps --filter "name=openpalm" --format "    {{.Names}}\t{{.Status}}" 2>/dev/null || true
+echo ""
+
+container_count=$(docker ps --filter "name=openpalm" --format '{{.Names}}' 2>/dev/null | wc -l)
+if [ "$container_count" -ge 5 ]; then
+  pass "$container_count containers running (expected >= 5 core services)"
+else
+  fail "Only $container_count containers running (expected >= 5)"
+fi
+
+# ── Summary ──────────────────────────────────────────────────────────
+
+echo ""
+echo "=========================================="
+echo "  RESULTS: $PASS passed, $FAIL failed (${TESTS} total)"
+echo "=========================================="
+
+if [ "$FAIL" -gt 0 ]; then
+  echo ""
+  echo "  FAILED -- $FAIL test(s) did not pass"
+  exit 1
+else
+  echo ""
+  echo "  ALL TESTS PASSED"
+  exit 0
+fi

--- a/scripts/setup.ps1
+++ b/scripts/setup.ps1
@@ -3,14 +3,21 @@
 #
 # One-liner install (Windows PowerShell):
 #   irm https://raw.githubusercontent.com/itlackey/openpalm/main/scripts/setup.ps1 | iex
+#
+# Re-run to update (assets are re-downloaded, secrets are never overwritten).
 
 $ErrorActionPreference = 'Stop'
 Set-StrictMode -Version Latest
 
+# ── Constants ─────────────────────────────────────────────────────────
+
+$ScriptVersion = '1.0.0'
 $Repo = 'itlackey/openpalm'
 $DefaultVersion = 'main'
 $HealthTimeout = 120
 $HealthInterval = 3
+
+# ── Output helpers ────────────────────────────────────────────────────
 
 function Info([string]$Message) { Write-Host "▸ $Message" -ForegroundColor Blue }
 function Ok([string]$Message) { Write-Host "✓ $Message" -ForegroundColor Green }
@@ -18,8 +25,10 @@ function Warn([string]$Message) { Write-Host "⚠ $Message" -ForegroundColor Yel
 function Die([string]$Message) { Write-Host "✗ $Message" -ForegroundColor Red; exit 1 }
 function Header([string]$Message) { Write-Host "`n── $Message ──`n" -ForegroundColor Cyan }
 
+# ── Usage ─────────────────────────────────────────────────────────────
+
 function Usage {
-  @'
+  @"
 Usage: setup.ps1 [OPTIONS]
 
 Install or update the OpenPalm stack using published Docker Hub images.
@@ -32,18 +41,21 @@ Options:
   -h, --help     Show this help
 
 Environment overrides:
-  OPENPALM_CONFIG_HOME   Config directory
-  OPENPALM_DATA_HOME     Data directory
-  OPENPALM_STATE_HOME    State directory
-  OPENPALM_WORK_DIR      Work directory
+  OPENPALM_CONFIG_HOME   Config directory (default: %APPDATA%\openpalm)
+  OPENPALM_DATA_HOME     Data directory   (default: %LOCALAPPDATA%\openpalm)
+  OPENPALM_STATE_HOME    State directory  (default: %LOCALAPPDATA%\openpalm\state)
+  OPENPALM_WORK_DIR      Work directory   (default: ~\openpalm)
 
 Examples:
   # Standard install
   irm https://raw.githubusercontent.com/itlackey/openpalm/main/scripts/setup.ps1 | iex
 
+  # Install with custom paths
+  `$env:OPENPALM_CONFIG_HOME='D:\openpalm\config'; .\setup.ps1
+
   # Update to latest (skip prompt)
-  ./scripts/setup.ps1 --force
-'@ | Write-Host
+  .\scripts\setup.ps1 --force
+"@ | Write-Host
 }
 
 # ── Argument parsing ──────────────────────────────────────────────────
@@ -89,12 +101,20 @@ function Convert-ToDockerPath([string]$Path) {
 Header 'Preflight checks'
 
 if (-not (Get-Command docker -ErrorAction SilentlyContinue)) {
-  Die 'Docker is not installed. Install Docker Desktop first: https://docs.docker.com/get-docker/'
+  Die 'Docker is not installed. Install Docker Desktop for Windows: https://docs.docker.com/desktop/install/windows-install/'
 }
-try { docker info *> $null } catch { Die 'Docker is not running. Start Docker and retry.' }
+
+# Native commands don't throw in PowerShell — check $LASTEXITCODE explicitly
+docker info *> $null
+if ($LASTEXITCODE -ne 0) {
+  Die 'Docker is not running (or current user lacks permission). Start Docker Desktop and retry.'
+}
 Ok 'Docker is running'
 
-try { docker compose version *> $null } catch { Die 'Docker Compose v2 is required.' }
+docker compose version *> $null
+if ($LASTEXITCODE -ne 0) {
+  Die 'Docker Compose v2 is required. It is included with Docker Desktop.'
+}
 Ok 'Docker Compose v2 available'
 
 # ── Platform detection ────────────────────────────────────────────────
@@ -103,14 +123,23 @@ Header 'Detecting platform'
 
 $HostUid = if ($env:OPENPALM_UID) { $env:OPENPALM_UID } else { '1000' }
 $HostGid = if ($env:OPENPALM_GID) { $env:OPENPALM_GID } else { '1000' }
+
+# Docker Desktop for Windows uses a named pipe, not a unix socket.
+# The docker-socket-proxy in compose expects the socket path for Linux containers.
 $DockerSock = '/var/run/docker.sock'
 
 try {
-  $hostUrl = (docker context inspect --format '{{.Endpoints.docker.Host}}' 2>$null | Select-Object -First 1).Trim()
-  if ($hostUrl -like 'unix://*') {
-    $detected = $hostUrl.Substring(7)
-    if (-not [string]::IsNullOrWhiteSpace($detected) -and (Test-Path -LiteralPath $detected)) {
-      $DockerSock = $detected
+  $hostUrl = (docker context inspect --format '{{.Endpoints.docker.Host}}' 2>$null | Select-Object -First 1)
+  if ($hostUrl) {
+    $hostUrl = $hostUrl.Trim()
+    if ($hostUrl -like 'unix://*') {
+      $detected = $hostUrl.Substring(7)
+      if (-not [string]::IsNullOrWhiteSpace($detected)) {
+        $DockerSock = $detected
+      }
+    } elseif ($hostUrl -like 'npipe://*') {
+      # Windows named pipe — keep default /var/run/docker.sock for Linux containers
+      Info "Docker is using Windows named pipe (normal for Docker Desktop)"
     }
   }
 } catch { }
@@ -124,9 +153,13 @@ Header 'Resolving paths'
 
 $home_dir = if ($env:USERPROFILE) { $env:USERPROFILE } elseif ($HOME) { $HOME } else { [Environment]::GetFolderPath('UserProfile') }
 
-$LocalConfigHome = if ($env:OPENPALM_CONFIG_HOME) { $env:OPENPALM_CONFIG_HOME } else { Join-Path $home_dir '.config/openpalm' }
-$LocalDataHome = if ($env:OPENPALM_DATA_HOME) { $env:OPENPALM_DATA_HOME } else { Join-Path $home_dir '.local/share/openpalm' }
-$LocalStateHome = if ($env:OPENPALM_STATE_HOME) { $env:OPENPALM_STATE_HOME } else { Join-Path $home_dir '.local/state/openpalm' }
+# Use Windows-idiomatic paths: APPDATA for config, LOCALAPPDATA for data/state
+$defaultConfigBase = if ($env:APPDATA) { $env:APPDATA } else { Join-Path $home_dir 'AppData\Roaming' }
+$defaultLocalBase = if ($env:LOCALAPPDATA) { $env:LOCALAPPDATA } else { Join-Path $home_dir 'AppData\Local' }
+
+$LocalConfigHome = if ($env:OPENPALM_CONFIG_HOME) { $env:OPENPALM_CONFIG_HOME } else { Join-Path $defaultConfigBase 'openpalm' }
+$LocalDataHome = if ($env:OPENPALM_DATA_HOME) { $env:OPENPALM_DATA_HOME } else { Join-Path $defaultLocalBase 'openpalm' }
+$LocalStateHome = if ($env:OPENPALM_STATE_HOME) { $env:OPENPALM_STATE_HOME } else { Join-Path $defaultLocalBase 'openpalm\state' }
 $LocalWorkDir = if ($env:OPENPALM_WORK_DIR) { $env:OPENPALM_WORK_DIR } else { Join-Path $home_dir 'openpalm' }
 
 $ConfigHome = Convert-ToDockerPath $LocalConfigHome
@@ -134,10 +167,14 @@ $DataHome = Convert-ToDockerPath $LocalDataHome
 $StateHome = Convert-ToDockerPath $LocalStateHome
 $WorkDir = Convert-ToDockerPath $LocalWorkDir
 
-Info "CONFIG_HOME: $ConfigHome"
-Info "DATA_HOME:   $DataHome"
-Info "STATE_HOME:  $StateHome"
-Info "WORK_DIR:    $WorkDir"
+Info "CONFIG_HOME: $LocalConfigHome"
+Info "  (Docker):  $ConfigHome"
+Info "DATA_HOME:   $LocalDataHome"
+Info "  (Docker):  $DataHome"
+Info "STATE_HOME:  $LocalStateHome"
+Info "  (Docker):  $StateHome"
+Info "WORK_DIR:    $LocalWorkDir"
+Info "  (Docker):  $WorkDir"
 
 # ── Existing install check ────────────────────────────────────────────
 
@@ -165,10 +202,10 @@ $dirs = @(
   (Join-Path $LocalConfigHome 'stash'),
   $LocalDataHome, (Join-Path $LocalDataHome 'memory'),
   (Join-Path $LocalDataHome 'assistant'), (Join-Path $LocalDataHome 'guardian'),
-  (Join-Path $LocalDataHome 'caddy/data'), (Join-Path $LocalDataHome 'caddy/config'),
+  (Join-Path $LocalDataHome 'caddy\data'), (Join-Path $LocalDataHome 'caddy\config'),
   (Join-Path $LocalDataHome 'automations'),
   $LocalStateHome, (Join-Path $LocalStateHome 'artifacts'),
-  (Join-Path $LocalStateHome 'audit'), (Join-Path $LocalStateHome 'artifacts/channels'),
+  (Join-Path $LocalStateHome 'audit'), (Join-Path $LocalStateHome 'artifacts\channels'),
   (Join-Path $LocalStateHome 'automations'),
   $LocalWorkDir
 )
@@ -178,6 +215,26 @@ Ok 'Directory tree created'
 # ── Asset download ────────────────────────────────────────────────────
 
 Header 'Downloading assets'
+
+# Try to download SHA256SUMS for checksum verification
+$ChecksumsContent = $null
+$checksumsReleaseUrl = "https://github.com/$Repo/releases/download/$OptVersion/SHA256SUMS"
+$checksumsRawUrl = "https://raw.githubusercontent.com/$Repo/$OptVersion/core/assets/SHA256SUMS"
+foreach ($csUrl in @($checksumsReleaseUrl, $checksumsRawUrl)) {
+  try {
+    $ChecksumsContent = (Invoke-WebRequest -Uri $csUrl -UseBasicParsing -ErrorAction Stop).Content
+    if ($ChecksumsContent) {
+      $label = if ($csUrl -eq $checksumsReleaseUrl) { 'release' } else { 'raw' }
+      Ok "Downloaded SHA256SUMS ($label)"
+      break
+    }
+  } catch {
+    $ChecksumsContent = $null
+  }
+}
+if (-not $ChecksumsContent) {
+  Info 'No SHA256SUMS found — skipping checksum verification'
+}
 
 function Download-Asset([string]$Filename, [string]$Destination) {
   $releaseUrl = "https://github.com/$Repo/releases/download/$OptVersion/$Filename"
@@ -205,15 +262,29 @@ function Download-Asset([string]$Filename, [string]$Destination) {
     Die "Downloaded $Filename is empty. Check --version and network."
   }
 
+  # Checksum verification — validate against SHA256SUMS if available
+  if ($ChecksumsContent) {
+    $checksumLine = ($ChecksumsContent -split "`n") | Where-Object { $_ -match "\b$([regex]::Escape($Filename))\b" } | Select-Object -First 1
+    if ($checksumLine) {
+      $expected = ($checksumLine -split '\s+')[0]
+      $actual = (Get-FileHash -LiteralPath $tmp -Algorithm SHA256).Hash.ToLowerInvariant()
+      if ($actual -ne $expected.ToLowerInvariant()) {
+        Remove-Item -LiteralPath $tmp -Force
+        Die "Checksum mismatch for $Filename (expected=$expected, got=$actual)"
+      }
+      Ok "Checksum verified: $Filename"
+    }
+  }
+
   Move-Item -LiteralPath $tmp -Destination $Destination -Force
 }
 
 Download-Asset 'docker-compose.yml' (Join-Path $LocalDataHome 'docker-compose.yml')
-Download-Asset 'Caddyfile' (Join-Path $LocalDataHome 'caddy/Caddyfile')
+Download-Asset 'Caddyfile' (Join-Path $LocalDataHome 'caddy\Caddyfile')
 
 # Bootstrap staging
-Copy-Item -LiteralPath (Join-Path $LocalDataHome 'docker-compose.yml') -Destination (Join-Path $LocalStateHome 'artifacts/docker-compose.yml') -Force
-Copy-Item -LiteralPath (Join-Path $LocalDataHome 'caddy/Caddyfile') -Destination (Join-Path $LocalStateHome 'artifacts/Caddyfile') -Force
+Copy-Item -LiteralPath (Join-Path $LocalDataHome 'docker-compose.yml') -Destination (Join-Path $LocalStateHome 'artifacts\docker-compose.yml') -Force
+Copy-Item -LiteralPath (Join-Path $LocalDataHome 'caddy\Caddyfile') -Destination (Join-Path $LocalStateHome 'artifacts\Caddyfile') -Force
 
 # ── Pull admin image ─────────────────────────────────────────────────
 
@@ -256,7 +327,7 @@ MEMORY_USER_ID=$detectedUser
 Header 'Configuring stack environment'
 
 $dataStackEnv = Join-Path $LocalDataHome 'stack.env'
-$stagedStackEnv = Join-Path $LocalStateHome 'artifacts/stack.env'
+$stagedStackEnv = Join-Path $LocalStateHome 'artifacts\stack.env'
 
 if (Test-Path -LiteralPath $dataStackEnv -PathType Leaf) {
   Ok 'stack.env exists — not overwriting'
@@ -287,12 +358,12 @@ Copy-Item -LiteralPath $dataStackEnv -Destination $stagedStackEnv -Force
 
 # ── OpenCode config seeding ──────────────────────────────────────────
 
-$opencodeConfig = Join-Path $LocalConfigHome 'assistant/opencode.json'
+$opencodeConfig = Join-Path $LocalConfigHome 'assistant\opencode.json'
 if (-not (Test-Path -LiteralPath $opencodeConfig -PathType Leaf)) {
   '{ "$schema": "https://opencode.ai/config.json" }' | Set-Content -LiteralPath $opencodeConfig -Encoding UTF8
 }
 foreach ($sub in @('tools', 'plugins', 'skills')) {
-  New-Item -ItemType Directory -Path (Join-Path $LocalConfigHome "assistant/$sub") -Force | Out-Null
+  New-Item -ItemType Directory -Path (Join-Path $LocalConfigHome "assistant\$sub") -Force | Out-Null
 }
 
 # ── Docker Compose lifecycle ──────────────────────────────────────────
@@ -300,17 +371,21 @@ foreach ($sub in @('tools', 'plugins', 'skills')) {
 function Compose-Cmd([string[]]$ComposeArgs) {
   $allArgs = @(
     'compose', '--project-name', 'openpalm',
-    '-f', (Join-Path $LocalStateHome 'artifacts/docker-compose.yml'),
+    '-f', (Join-Path $LocalStateHome 'artifacts\docker-compose.yml'),
     '--env-file', (Join-Path $LocalConfigHome 'secrets.env'),
-    '--env-file', (Join-Path $LocalStateHome 'artifacts/stack.env')
+    '--env-file', (Join-Path $LocalStateHome 'artifacts\stack.env')
   ) + $ComposeArgs
   & docker @allArgs
   if ($LASTEXITCODE -ne 0) { Die "docker compose command failed: $($ComposeArgs -join ' ')" }
 }
 
 if ($OptNoStart) {
-  Ok 'Skipping Docker start (--no-start).'
-  Info "  Run: docker compose --project-name openpalm -f $LocalStateHome/artifacts/docker-compose.yml --env-file $LocalConfigHome/secrets.env --env-file $LocalStateHome/artifacts/stack.env up -d"
+  Ok 'Skipping Docker start (--no-start). Run manually:'
+  Info "  docker compose --project-name openpalm ``"
+  Info "    -f $(Join-Path $LocalStateHome 'artifacts\docker-compose.yml') ``"
+  Info "    --env-file $(Join-Path $LocalConfigHome 'secrets.env') ``"
+  Info "    --env-file $(Join-Path $LocalStateHome 'artifacts\stack.env') ``"
+  Info '    up -d'
 } else {
   Header 'Starting services'
 
@@ -327,7 +402,7 @@ if ($OptNoStart) {
   $elapsed = 0
   while ($elapsed -lt $HealthTimeout) {
     try {
-      Invoke-WebRequest -Uri 'http://127.0.0.1:8100/' -UseBasicParsing *> $null
+      $null = Invoke-WebRequest -Uri 'http://127.0.0.1:8100/' -UseBasicParsing -TimeoutSec 5 -ErrorAction Stop
       Ok 'Admin is healthy'
       break
     } catch {
@@ -340,7 +415,7 @@ if ($OptNoStart) {
   if ($elapsed -ge $HealthTimeout) {
     Write-Host ''
     Warn "Admin did not respond within ${HealthTimeout}s."
-    Warn "Check logs: docker compose --project-name openpalm logs admin"
+    Warn "Check logs: docker compose --project-name openpalm -f $(Join-Path $LocalStateHome 'artifacts\docker-compose.yml') logs admin"
     exit 1
   }
 
@@ -362,10 +437,10 @@ if ($IsUpdate) {
 }
 
 Write-Host ''
-Write-Host "Config:        $ConfigHome"
-Write-Host "Data:          $DataHome"
-Write-Host "State:         $StateHome"
-Write-Host "Work dir:      $WorkDir"
+Write-Host "Config:        $LocalConfigHome"
+Write-Host "Data:          $LocalDataHome"
+Write-Host "State:         $LocalStateHome"
+Write-Host "Work dir:      $LocalWorkDir"
 
 if (-not $IsUpdate) {
   Write-Host ''

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -2,15 +2,17 @@
 # OpenPalm — Production Setup Script
 #
 # One-liner install:
-#   curl -fsSL https://raw.githubusercontent.com/itlackey/openpalm/main/scripts/setup.sh | bash
+#   curl -fsSL https://raw.githubusercontent.com/itlackey/openpalm/v0.9.0-rc5/scripts/setup.sh | bash
 #
 # Re-run to update (assets are re-downloaded, secrets are never overwritten).
 set -euo pipefail
 
 # ── Constants ─────────────────────────────────────────────────────────
 
+SCRIPT_VERSION="1.0.0"
 REPO="itlackey/openpalm"
-DEFAULT_VERSION="main"
+SCRIPT_VERSION="0.9.0-rc5"          # Stamped at release time by CI
+DEFAULT_VERSION="v${SCRIPT_VERSION}"
 HEALTH_TIMEOUT=120
 HEALTH_INTERVAL=3
 
@@ -32,14 +34,14 @@ header() { printf "\n${BOLD}── %s ──${NC}\n\n" "$*"; }
 # ── Usage ─────────────────────────────────────────────────────────────
 
 usage() {
-	cat <<'EOF'
+	cat <<EOF
 Usage: setup.sh [OPTIONS]
 
 Install or update the OpenPalm stack using published Docker Hub images.
 
 Options:
   --force       Skip confirmation prompts (for updates)
-  --version TAG GitHub ref to download assets from (default: main)
+  --version TAG GitHub ref to download assets from (default: v${SCRIPT_VERSION})
   --no-start    Set up files but don't start Docker services
   --no-open     Don't open the admin UI in a browser after install
   -h, --help    Show this help
@@ -52,7 +54,7 @@ Environment overrides:
 
 Examples:
   # Standard install
-  curl -fsSL https://raw.githubusercontent.com/itlackey/openpalm/main/scripts/setup.sh | bash
+  curl -fsSL https://raw.githubusercontent.com/itlackey/openpalm/v${SCRIPT_VERSION}/scripts/setup.sh | bash
 
   # Install with custom paths
   OPENPALM_CONFIG_HOME=/opt/openpalm/config bash setup.sh
@@ -220,11 +222,45 @@ download_asset() {
 		die "Downloaded $filename is empty. Check --version and network."
 	fi
 
+	# Checksum verification — validate against SHA256SUMS if available
+	if [[ -n "${CHECKSUMS_FILE:-}" ]]; then
+		local expected
+		expected="$(grep -F "$filename" "$CHECKSUMS_FILE" 2>/dev/null | awk '{print $1}')"
+		if [[ -n "$expected" ]]; then
+			local actual
+			actual="$(sha256sum "$tmp" | awk '{print $1}')"
+			if [[ "$actual" != "$expected" ]]; then
+				rm -f "$tmp"
+				die "Checksum mismatch for $filename (expected=$expected, got=$actual)"
+			fi
+			ok "Checksum verified: $filename"
+		fi
+	fi
+
 	mv -f "$tmp" "$dest"
 }
 
+# Try to download SHA256SUMS for checksum verification
+CHECKSUMS_FILE=""
+checksums_tmp="$(mktemp 2>/dev/null || echo "/tmp/openpalm-checksums.$$")"
+checksums_release_url="https://github.com/${REPO}/releases/download/${OPT_VERSION}/SHA256SUMS"
+checksums_raw_url="https://raw.githubusercontent.com/${REPO}/${OPT_VERSION}/core/assets/SHA256SUMS"
+if curl -fsSL --retry 1 -o "$checksums_tmp" "$checksums_release_url" 2>/dev/null && [[ -s "$checksums_tmp" ]]; then
+	CHECKSUMS_FILE="$checksums_tmp"
+	ok "Downloaded SHA256SUMS (release)"
+elif curl -fsSL --retry 1 -o "$checksums_tmp" "$checksums_raw_url" 2>/dev/null && [[ -s "$checksums_tmp" ]]; then
+	CHECKSUMS_FILE="$checksums_tmp"
+	ok "Downloaded SHA256SUMS (raw)"
+else
+	rm -f "$checksums_tmp"
+	info "No SHA256SUMS found — skipping checksum verification"
+fi
+
 download_asset "docker-compose.yml" "${DATA_HOME}/docker-compose.yml"
 download_asset "Caddyfile" "${DATA_HOME}/caddy/Caddyfile"
+
+# Clean up checksums temp file
+[[ -n "${CHECKSUMS_FILE:-}" ]] && rm -f "$CHECKSUMS_FILE"
 
 # Bootstrap staging: copy to STATE so compose can start admin before first apply
 cp "${DATA_HOME}/docker-compose.yml" "${STATE_HOME}/artifacts/docker-compose.yml"

--- a/scripts/upgrade-test.sh
+++ b/scripts/upgrade-test.sh
@@ -1,0 +1,806 @@
+#!/usr/bin/env bash
+#
+# OpenPalm — Upgrade Path Test Script
+#
+# Verifies that re-running setup.sh (simulating an upgrade) preserves user
+# data and configuration while updating infrastructure artifacts.
+#
+# ── Manual test procedure (cross-version) ──────────────────────────────
+#
+#   1. Install v0.8.x:
+#        curl -fsSL https://raw.githubusercontent.com/itlackey/openpalm/v0.8.0/scripts/setup.sh \
+#          | bash -s -- --version v0.8.0
+#
+#   2. Complete the setup wizard in the browser at http://localhost:8100/setup
+#      - Set an admin token
+#      - Configure an LLM provider
+#      - The wizard will pull remaining images and start all services
+#
+#   3. Seed some user state:
+#      - Add a memory via the assistant or memory API
+#      - Install a channel
+#      - Note the ADMIN_TOKEN and MEMORY_USER_ID in secrets.env
+#
+#   4. Upgrade to the target version:
+#        curl -fsSL https://raw.githubusercontent.com/itlackey/openpalm/main/scripts/setup.sh \
+#          | bash -s -- --force --version <target>
+#
+#   5. Verify:
+#      - secrets.env is NOT overwritten (ADMIN_TOKEN, custom keys preserved)
+#      - stack.env is NOT overwritten (paths, UID/GID preserved)
+#      - Memory database still exists and responds
+#      - All services come back healthy
+#      - Admin token still authenticates
+#      - No errors in container logs
+#
+# ── Automated test (current version → re-run) ─────────────────────────
+#
+# Usage:
+#   ./scripts/upgrade-test.sh [OPTIONS]
+#
+# Options:
+#   --skip-build          Skip image build (use existing images)
+#   --from-version TAG    Version to install first (default: current local build)
+#   --to-version TAG      Version to upgrade to (default: current local build)
+#   --keep                Don't tear down the stack after the test
+#   -h, --help            Show this help
+#
+# Environment overrides:
+#   OPENPALM_CONFIG_HOME  Config directory (default: .upgrade-test/config)
+#   OPENPALM_DATA_HOME    Data directory   (default: .upgrade-test/data)
+#   OPENPALM_STATE_HOME   State directory  (default: .upgrade-test/state)
+#   OPENPALM_WORK_DIR     Work directory   (default: .upgrade-test/work)
+#
+set -euo pipefail
+
+# ── Argument parsing ─────────────────────────────────────────────────
+
+SKIP_BUILD=0
+FROM_VERSION=""
+TO_VERSION=""
+KEEP=0
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/upgrade-test.sh [OPTIONS]
+
+Test that re-running setup.sh preserves user data and configuration.
+
+Options:
+  --skip-build           Skip image build (use existing images)
+  --from-version TAG     Version to install first (default: current local build)
+  --to-version TAG       Version to upgrade to (default: current local build)
+  --keep                 Don't tear down the stack after the test
+  -h, --help             Show this help
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --skip-build) SKIP_BUILD=1 ;;
+    --from-version) shift; FROM_VERSION="${1:?--from-version requires a value}" ;;
+    --to-version) shift; TO_VERSION="${1:?--to-version requires a value}" ;;
+    --keep) KEEP=1 ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "Unknown option: $1" >&2; usage >&2; exit 1 ;;
+  esac
+  shift
+done
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+# ── Test isolation paths ─────────────────────────────────────────────
+# Use a separate directory tree so this test doesn't interfere with .dev/
+
+TEST_ROOT="${ROOT_DIR}/.upgrade-test"
+export OPENPALM_CONFIG_HOME="${OPENPALM_CONFIG_HOME:-${TEST_ROOT}/config}"
+export OPENPALM_DATA_HOME="${OPENPALM_DATA_HOME:-${TEST_ROOT}/data}"
+export OPENPALM_STATE_HOME="${OPENPALM_STATE_HOME:-${TEST_ROOT}/state}"
+export OPENPALM_WORK_DIR="${OPENPALM_WORK_DIR:-${TEST_ROOT}/work}"
+
+PROJECT_NAME="openpalm-upgrade-test"
+ADMIN_PORT=8101
+ADMIN_URL="http://127.0.0.1:${ADMIN_PORT}"
+MEMORY_PORT=8766
+ADMIN_TOKEN="upgrade-test-token"
+
+# ── Colors / Output ──────────────────────────────────────────────────
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+BOLD='\033[1m'
+NC='\033[0m'
+
+PASS=0
+FAIL=0
+TESTS=0
+
+pass() { PASS=$((PASS + 1)); TESTS=$((TESTS + 1)); printf "  ${GREEN}PASS${NC}: %s\n" "$1"; }
+fail() { FAIL=$((FAIL + 1)); TESTS=$((TESTS + 1)); printf "  ${RED}FAIL${NC}: %s\n" "$1"; }
+header() { printf "\n${BOLD}── %s ──${NC}\n\n" "$*"; }
+
+# ── Cleanup on exit ──────────────────────────────────────────────────
+
+cleanup() {
+  if [[ $KEEP -eq 0 ]]; then
+    echo ""
+    echo "Cleaning up..."
+    compose_cmd down --remove-orphans 2>/dev/null || true
+    # Clean root-owned files from container volumes
+    docker run --rm -v "${TEST_ROOT}:/cleanup" alpine rm -rf /cleanup 2>/dev/null || true
+    rm -rf "${TEST_ROOT}" 2>/dev/null || true
+  else
+    echo ""
+    echo "Keeping stack running (--keep). Clean up manually:"
+    echo "  docker compose --project-name ${PROJECT_NAME} down"
+    echo "  rm -rf ${TEST_ROOT}"
+  fi
+}
+trap cleanup EXIT
+
+# ── Helper: compose command ──────────────────────────────────────────
+
+compose_cmd() {
+  docker compose \
+    --project-name "$PROJECT_NAME" \
+    -f "${OPENPALM_STATE_HOME}/artifacts/docker-compose.yml" \
+    --env-file "${OPENPALM_CONFIG_HOME}/secrets.env" \
+    --env-file "${OPENPALM_STATE_HOME}/artifacts/stack.env" \
+    "$@"
+}
+
+# ── Helper: wait for admin health ────────────────────────────────────
+
+wait_for_admin() {
+  local timeout="${1:-90}"
+  local elapsed=0
+  while [[ $elapsed -lt $timeout ]]; do
+    if curl -sf "${ADMIN_URL}/" >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 3
+    elapsed=$((elapsed + 3))
+  done
+  return 1
+}
+
+# ── Helper: wait for all services healthy ────────────────────────────
+
+wait_for_healthy() {
+  local timeout="${1:-180}"
+  local elapsed=0
+  local services="admin memory assistant guardian docker-socket-proxy"
+
+  while [[ $elapsed -lt $timeout ]]; do
+    local all_up=true
+    for svc in $services; do
+      local status
+      status=$(docker inspect --format '{{.State.Health.Status}}' "${PROJECT_NAME}-${svc}-1" 2>/dev/null || echo "missing")
+      if [[ "$status" != "healthy" ]]; then
+        all_up=false
+        break
+      fi
+    done
+    if [[ "$all_up" == "true" ]]; then
+      return 0
+    fi
+    sleep 5
+    elapsed=$((elapsed + 5))
+  done
+  return 1
+}
+
+# ══════════════════════════════════════════════════════════════════════
+# PHASE 1: Initial install
+# ══════════════════════════════════════════════════════════════════════
+
+header "Phase 1: Initial install"
+
+# ── 1a: Clean slate ──────────────────────────────────────────────────
+
+echo "Tearing down any previous test state..."
+compose_cmd down --remove-orphans 2>/dev/null || true
+docker run --rm -v "${TEST_ROOT}:/cleanup" alpine rm -rf /cleanup 2>/dev/null || true
+rm -rf "${TEST_ROOT}" 2>/dev/null || true
+
+# ── 1b: Create directory structure ───────────────────────────────────
+
+mkdir -p \
+  "${OPENPALM_CONFIG_HOME}/channels" \
+  "${OPENPALM_CONFIG_HOME}/assistant/tools" \
+  "${OPENPALM_CONFIG_HOME}/assistant/plugins" \
+  "${OPENPALM_CONFIG_HOME}/assistant/skills" \
+  "${OPENPALM_CONFIG_HOME}/automations" \
+  "${OPENPALM_CONFIG_HOME}/stash" \
+  "${OPENPALM_DATA_HOME}/memory" \
+  "${OPENPALM_DATA_HOME}/assistant" \
+  "${OPENPALM_DATA_HOME}/guardian" \
+  "${OPENPALM_DATA_HOME}/caddy/data" \
+  "${OPENPALM_DATA_HOME}/caddy/config" \
+  "${OPENPALM_DATA_HOME}/automations" \
+  "${OPENPALM_STATE_HOME}/artifacts/channels/public" \
+  "${OPENPALM_STATE_HOME}/artifacts/channels/lan" \
+  "${OPENPALM_STATE_HOME}/audit" \
+  "${OPENPALM_STATE_HOME}/automations" \
+  "${OPENPALM_WORK_DIR}"
+
+# ── 1c: Seed config files ───────────────────────────────────────────
+
+# Detect Docker socket
+docker_sock="/var/run/docker.sock"
+if host_url="$(docker context inspect --format '{{.Endpoints.docker.Host}}' 2>/dev/null)"; then
+  case "$host_url" in
+    unix://*) detected_sock="${host_url#unix://}"; [[ -S "$detected_sock" ]] && docker_sock="$detected_sock" ;;
+  esac
+fi
+
+# Seed secrets.env with a known admin token
+cat >"${OPENPALM_CONFIG_HOME}/secrets.env" <<EOF
+# Upgrade test secrets
+ADMIN_TOKEN=${ADMIN_TOKEN}
+OPENAI_API_KEY=
+OPENAI_BASE_URL=
+MEMORY_USER_ID=upgrade-test-user
+# Custom user key that must survive upgrade
+MY_CUSTOM_KEY=my-custom-value-12345
+EOF
+
+# Seed stack.env
+cat >"${OPENPALM_DATA_HOME}/stack.env" <<EOF
+OPENPALM_CONFIG_HOME=${OPENPALM_CONFIG_HOME}
+OPENPALM_DATA_HOME=${OPENPALM_DATA_HOME}
+OPENPALM_STATE_HOME=${OPENPALM_STATE_HOME}
+OPENPALM_WORK_DIR=${OPENPALM_WORK_DIR}
+OPENPALM_UID=$(id -u)
+OPENPALM_GID=$(id -g)
+OPENPALM_DOCKER_SOCK=${docker_sock}
+OPENPALM_IMAGE_NAMESPACE=openpalm
+OPENPALM_IMAGE_TAG=dev
+OPENPALM_INGRESS_BIND_ADDRESS=127.0.0.1
+OPENPALM_INGRESS_PORT=8180
+EOF
+
+# Seed compose and Caddyfile to DATA_HOME (source of truth)
+cp "${ROOT_DIR}/core/assets/docker-compose.yml" "${OPENPALM_DATA_HOME}/docker-compose.yml"
+cp "${ROOT_DIR}/core/assets/Caddyfile" "${OPENPALM_DATA_HOME}/caddy/Caddyfile"
+
+# Stage artifacts for compose
+cp "${OPENPALM_DATA_HOME}/docker-compose.yml" "${OPENPALM_STATE_HOME}/artifacts/docker-compose.yml"
+cp "${OPENPALM_DATA_HOME}/caddy/Caddyfile" "${OPENPALM_STATE_HOME}/artifacts/Caddyfile"
+cp "${OPENPALM_DATA_HOME}/stack.env" "${OPENPALM_STATE_HOME}/artifacts/stack.env"
+cp "${OPENPALM_CONFIG_HOME}/secrets.env" "${OPENPALM_STATE_HOME}/artifacts/secrets.env"
+
+# Override ports so we don't conflict with a running dev stack.
+# The compose file uses OPENPALM_INGRESS_PORT for Caddy (8180) and hardcodes
+# admin to 127.0.0.1:8100. We override admin's port via a compose override.
+cat >"${OPENPALM_STATE_HOME}/artifacts/compose-port-override.yml" <<EOF
+services:
+  admin:
+    ports:
+      - "127.0.0.1:${ADMIN_PORT}:8100"
+  memory:
+    ports:
+      - "127.0.0.1:${MEMORY_PORT}:8765"
+EOF
+
+# Seed opencode config
+cat >"${OPENPALM_CONFIG_HOME}/assistant/opencode.json" <<'EOF'
+{
+  "$schema": "https://opencode.ai/config.json"
+}
+EOF
+
+# Seed memory config
+cat >"${OPENPALM_DATA_HOME}/memory/default_config.json" <<'MEMCFG'
+{
+  "mem0": {
+    "llm": {
+      "provider": "openai",
+      "config": {
+        "model": "qwen2.5-coder:3b",
+        "temperature": 0.1,
+        "max_tokens": 2000,
+        "api_key": "ollama",
+        "openai_base_url": "http://host.docker.internal:11434/v1"
+      }
+    },
+    "embedder": {
+      "provider": "openai",
+      "config": {
+        "model": "nomic-embed-text",
+        "api_key": "ollama",
+        "openai_base_url": "http://host.docker.internal:11434/v1"
+      }
+    },
+    "vector_store": {
+      "provider": "qdrant",
+      "config": {
+        "collection_name": "memory",
+        "path": "/data/qdrant",
+        "embedding_model_dims": 768
+      }
+    }
+  },
+  "memory": {
+    "custom_instructions": ""
+  }
+}
+MEMCFG
+
+pass "Directory tree and config files created"
+
+# ── 1d: Build images (if needed) ─────────────────────────────────────
+
+if [[ $SKIP_BUILD -eq 0 && -z "$FROM_VERSION" ]]; then
+  header "Building images from source"
+  npm run admin:build 2>&1 | tail -3
+  docker compose --project-directory "$ROOT_DIR" \
+    -f "${OPENPALM_STATE_HOME}/artifacts/docker-compose.yml" \
+    -f compose.dev.yaml \
+    --env-file "${OPENPALM_STATE_HOME}/artifacts/stack.env" \
+    --env-file "${OPENPALM_STATE_HOME}/artifacts/secrets.env" \
+    --project-name "$PROJECT_NAME" build 2>&1 | tail -5
+  pass "Images built from source"
+fi
+
+# If --from-version is specified, pull that version's images
+if [[ -n "$FROM_VERSION" ]]; then
+  header "Pulling images for from-version: ${FROM_VERSION}"
+  OPENPALM_IMAGE_TAG="$FROM_VERSION"
+  # Update stack.env with the from-version tag
+  sed -i "s/^OPENPALM_IMAGE_TAG=.*/OPENPALM_IMAGE_TAG=${FROM_VERSION}/" \
+    "${OPENPALM_DATA_HOME}/stack.env"
+  sed -i "s/^OPENPALM_IMAGE_TAG=.*/OPENPALM_IMAGE_TAG=${FROM_VERSION}/" \
+    "${OPENPALM_STATE_HOME}/artifacts/stack.env"
+  compose_cmd pull 2>&1 | tail -5
+  pass "Images pulled for ${FROM_VERSION}"
+fi
+
+# ── 1e: Update compose_cmd to include port override ─────────────────
+
+compose_cmd() {
+  docker compose \
+    --project-name "$PROJECT_NAME" \
+    -f "${OPENPALM_STATE_HOME}/artifacts/docker-compose.yml" \
+    -f "${OPENPALM_STATE_HOME}/artifacts/compose-port-override.yml" \
+    --env-file "${OPENPALM_CONFIG_HOME}/secrets.env" \
+    --env-file "${OPENPALM_STATE_HOME}/artifacts/stack.env" \
+    "$@"
+}
+
+# ── 1f: Start the stack ──────────────────────────────────────────────
+
+header "Starting initial stack"
+
+compose_cmd up -d docker-socket-proxy admin 2>&1 | tail -5
+
+echo "  Waiting for admin to become healthy..."
+if wait_for_admin 90; then
+  pass "Admin is healthy"
+else
+  fail "Admin did not become healthy within 90s"
+  echo "Container logs:"
+  compose_cmd logs admin 2>&1 | tail -20
+  exit 1
+fi
+
+# ══════════════════════════════════════════════════════════════════════
+# PHASE 2: Seed test data
+# ══════════════════════════════════════════════════════════════════════
+
+header "Phase 2: Seed test data"
+
+# ── 2a: Run the setup / install to start all services ────────────────
+
+echo "  Calling admin install endpoint..."
+INSTALL_RESULT=$(curl -sf -X POST "${ADMIN_URL}/admin/install" \
+  -H "x-admin-token: ${ADMIN_TOKEN}" \
+  -H "content-type: application/json" \
+  -d '{}' 2>&1 || echo '{"ok":false}')
+
+INSTALL_OK=$(echo "$INSTALL_RESULT" | python3 -c "import sys,json; print(json.load(sys.stdin).get('ok', False))" 2>/dev/null || echo "False")
+
+if [[ "$INSTALL_OK" == "True" ]]; then
+  pass "Install endpoint returned ok"
+else
+  # Install may fail if images aren't available — for dev builds with compose overlay,
+  # we need to start services manually
+  echo "  Install API returned: $INSTALL_RESULT"
+  echo "  Starting services manually via compose..."
+  compose_cmd up -d 2>&1 | tail -5
+fi
+
+echo "  Waiting for all services to become healthy (up to 180s)..."
+if wait_for_healthy 180; then
+  pass "All services healthy after initial install"
+else
+  echo "  Some services not healthy, checking status..."
+  for svc in admin memory assistant guardian docker-socket-proxy; do
+    status=$(docker inspect --format '{{.State.Health.Status}}' "${PROJECT_NAME}-${svc}-1" 2>/dev/null || echo "missing")
+    echo "    ${svc}: ${status}"
+  done
+  # Continue anyway — memory might not be healthy if Ollama models aren't available
+  echo "  Continuing with available services..."
+fi
+
+# ── 2b: Seed a test memory via the memory API ────────────────────────
+
+echo "  Adding test memory via memory API..."
+MEMORY_ADD_RESULT=$(curl -sf -X POST "http://127.0.0.1:${MEMORY_PORT}/api/v1/memories/" \
+  -H "content-type: application/json" \
+  -d '{
+    "messages": [{"role":"user","content":"My favorite programming language is Rust and I have been coding for 15 years."}],
+    "user_id": "upgrade-test-user"
+  }' 2>&1 || echo '{"error":"failed"}')
+
+if echo "$MEMORY_ADD_RESULT" | python3 -c "import sys,json; d=json.load(sys.stdin); sys.exit(0 if 'results' in d or 'id' in d else 1)" 2>/dev/null; then
+  pass "Test memory seeded via memory API"
+else
+  echo "  Memory API response: $MEMORY_ADD_RESULT"
+  echo "  (Memory seeding may fail if Ollama models are not available — this is ok for config-only tests)"
+fi
+
+# ── 2c: Write a custom user file in CONFIG_HOME ─────────────────────
+
+echo "# My custom channel config" > "${OPENPALM_CONFIG_HOME}/channels/my-custom-channel.yml"
+pass "Custom user file written to CONFIG_HOME/channels/"
+
+# ══════════════════════════════════════════════════════════════════════
+# PHASE 3: Record pre-upgrade state
+# ══════════════════════════════════════════════════════════════════════
+
+header "Phase 3: Record pre-upgrade state"
+
+# Checksum secrets.env
+SECRETS_CHECKSUM_BEFORE=$(sha256sum "${OPENPALM_CONFIG_HOME}/secrets.env" | awk '{print $1}')
+echo "  secrets.env checksum: ${SECRETS_CHECKSUM_BEFORE}"
+
+# Checksum stack.env
+STACK_ENV_CHECKSUM_BEFORE=$(sha256sum "${OPENPALM_DATA_HOME}/stack.env" | awk '{print $1}')
+echo "  stack.env checksum:   ${STACK_ENV_CHECKSUM_BEFORE}"
+
+# Memory database size (if it exists)
+MEMORY_DB_SIZE_BEFORE=0
+if [[ -f "${OPENPALM_DATA_HOME}/memory/memory.db" ]]; then
+  MEMORY_DB_SIZE_BEFORE=$(stat --printf='%s' "${OPENPALM_DATA_HOME}/memory/memory.db" 2>/dev/null || echo "0")
+fi
+echo "  memory.db size:       ${MEMORY_DB_SIZE_BEFORE} bytes"
+
+# Record running services
+SERVICES_BEFORE=$(compose_cmd ps --format '{{.Service}}' 2>/dev/null | sort | tr '\n' ',' | sed 's/,$//')
+echo "  Running services:     ${SERVICES_BEFORE}"
+
+# Custom user file checksum
+CUSTOM_FILE_CHECKSUM=$(sha256sum "${OPENPALM_CONFIG_HOME}/channels/my-custom-channel.yml" | awk '{print $1}')
+echo "  Custom file checksum: ${CUSTOM_FILE_CHECKSUM}"
+
+# Record admin token works
+AUTH_CHECK_BEFORE=$(curl -sf -o /dev/null -w '%{http_code}' \
+  "${ADMIN_URL}/admin/containers/list" \
+  -H "x-admin-token: ${ADMIN_TOKEN}" 2>/dev/null || echo "error")
+echo "  Admin auth status:    ${AUTH_CHECK_BEFORE}"
+
+pass "Pre-upgrade state recorded"
+
+# ══════════════════════════════════════════════════════════════════════
+# PHASE 4: Simulate upgrade (re-run setup)
+# ══════════════════════════════════════════════════════════════════════
+
+header "Phase 4: Simulate upgrade"
+
+# The upgrade simulation mirrors what setup.sh does on re-run:
+#   1. Detects existing install (secrets.env exists)
+#   2. Re-creates directory tree (mkdir -p, idempotent)
+#   3. Downloads fresh assets (compose, Caddyfile) to DATA_HOME
+#   4. Copies assets to STATE_HOME staging
+#   5. Does NOT overwrite secrets.env or stack.env
+#   6. Starts services with compose up
+
+echo "  Simulating setup.sh re-run..."
+
+# Step 1: Directory creation (idempotent, same as setup.sh)
+mkdir -p \
+  "${OPENPALM_CONFIG_HOME}" "${OPENPALM_CONFIG_HOME}/channels" \
+  "${OPENPALM_CONFIG_HOME}/assistant" \
+  "${OPENPALM_CONFIG_HOME}/automations" "${OPENPALM_CONFIG_HOME}/stash" \
+  "${OPENPALM_DATA_HOME}" "${OPENPALM_DATA_HOME}/memory" \
+  "${OPENPALM_DATA_HOME}/assistant" \
+  "${OPENPALM_DATA_HOME}/guardian" "${OPENPALM_DATA_HOME}/caddy/data" \
+  "${OPENPALM_DATA_HOME}/caddy/config" \
+  "${OPENPALM_DATA_HOME}/automations" \
+  "${OPENPALM_STATE_HOME}" "${OPENPALM_STATE_HOME}/artifacts" \
+  "${OPENPALM_STATE_HOME}/audit" \
+  "${OPENPALM_STATE_HOME}/artifacts/channels" \
+  "${OPENPALM_WORK_DIR}"
+
+# Step 2: Re-download assets (simulate by copying from source)
+# In a real upgrade, setup.sh downloads from GitHub. We copy from local assets.
+cp "${ROOT_DIR}/core/assets/docker-compose.yml" "${OPENPALM_DATA_HOME}/docker-compose.yml"
+cp "${ROOT_DIR}/core/assets/Caddyfile" "${OPENPALM_DATA_HOME}/caddy/Caddyfile"
+
+# Step 3: Stage artifacts (same as setup.sh)
+cp "${OPENPALM_DATA_HOME}/docker-compose.yml" "${OPENPALM_STATE_HOME}/artifacts/docker-compose.yml"
+cp "${OPENPALM_DATA_HOME}/caddy/Caddyfile" "${OPENPALM_STATE_HOME}/artifacts/Caddyfile"
+
+# Step 4: secrets.env — setup.sh checks if it exists and skips if so
+if [[ -f "${OPENPALM_CONFIG_HOME}/secrets.env" ]]; then
+  echo "  secrets.env exists -- NOT overwriting (same as setup.sh)"
+else
+  echo "  BUG: secrets.env was deleted during upgrade simulation!"
+  fail "secrets.env should still exist"
+fi
+
+# Step 5: stack.env — setup.sh checks if it exists and skips if so
+if [[ -f "${OPENPALM_DATA_HOME}/stack.env" ]]; then
+  echo "  stack.env exists -- NOT overwriting (same as setup.sh)"
+else
+  echo "  BUG: stack.env was deleted during upgrade simulation!"
+  fail "stack.env should still exist"
+fi
+
+# Step 6: If --to-version specified, update image tag
+if [[ -n "$TO_VERSION" ]]; then
+  echo "  Updating image tag to ${TO_VERSION}..."
+  sed -i "s/^OPENPALM_IMAGE_TAG=.*/OPENPALM_IMAGE_TAG=${TO_VERSION}/" \
+    "${OPENPALM_DATA_HOME}/stack.env"
+  sed -i "s/^OPENPALM_IMAGE_TAG=.*/OPENPALM_IMAGE_TAG=${TO_VERSION}/" \
+    "${OPENPALM_STATE_HOME}/artifacts/stack.env"
+  compose_cmd pull 2>&1 | tail -5
+fi
+
+# Step 7: Restart services (same as setup.sh for IS_UPDATE=1)
+echo "  Running compose up (simulating upgrade restart)..."
+compose_cmd up -d 2>&1 | tail -10
+
+echo "  Waiting for admin to become healthy after upgrade..."
+if wait_for_admin 90; then
+  pass "Admin healthy after upgrade"
+else
+  fail "Admin not healthy after upgrade"
+  compose_cmd logs admin 2>&1 | tail -20
+fi
+
+echo "  Waiting for all services after upgrade (up to 180s)..."
+if wait_for_healthy 180; then
+  pass "All services healthy after upgrade"
+else
+  echo "  Some services not healthy after upgrade..."
+  for svc in admin memory assistant guardian docker-socket-proxy; do
+    status=$(docker inspect --format '{{.State.Health.Status}}' "${PROJECT_NAME}-${svc}-1" 2>/dev/null || echo "missing")
+    echo "    ${svc}: ${status}"
+  done
+fi
+
+# ══════════════════════════════════════════════════════════════════════
+# PHASE 5: Verify post-upgrade state
+# ══════════════════════════════════════════════════════════════════════
+
+header "Phase 5: Verification"
+
+# ── 5a: secrets.env unchanged ────────────────────────────────────────
+echo ""
+echo "=== 5a: secrets.env preservation ==="
+
+SECRETS_CHECKSUM_AFTER=$(sha256sum "${OPENPALM_CONFIG_HOME}/secrets.env" | awk '{print $1}')
+if [[ "$SECRETS_CHECKSUM_BEFORE" == "$SECRETS_CHECKSUM_AFTER" ]]; then
+  pass "secrets.env checksum unchanged"
+else
+  fail "secrets.env was modified during upgrade (before: ${SECRETS_CHECKSUM_BEFORE}, after: ${SECRETS_CHECKSUM_AFTER})"
+fi
+
+# Verify specific values in secrets.env
+ADMIN_TOKEN_VALUE=$(grep "^ADMIN_TOKEN=" "${OPENPALM_CONFIG_HOME}/secrets.env" | head -1 | cut -d= -f2-)
+if [[ "$ADMIN_TOKEN_VALUE" == "$ADMIN_TOKEN" ]]; then
+  pass "ADMIN_TOKEN preserved in secrets.env"
+else
+  fail "ADMIN_TOKEN changed (expected '${ADMIN_TOKEN}', got '${ADMIN_TOKEN_VALUE}')"
+fi
+
+CUSTOM_KEY_VALUE=$(grep "^MY_CUSTOM_KEY=" "${OPENPALM_CONFIG_HOME}/secrets.env" | head -1 | cut -d= -f2-)
+if [[ "$CUSTOM_KEY_VALUE" == "my-custom-value-12345" ]]; then
+  pass "Custom user key preserved in secrets.env"
+else
+  fail "Custom user key lost (expected 'my-custom-value-12345', got '${CUSTOM_KEY_VALUE}')"
+fi
+
+MEMORY_USER_VALUE=$(grep "^MEMORY_USER_ID=" "${OPENPALM_CONFIG_HOME}/secrets.env" | head -1 | cut -d= -f2-)
+if [[ "$MEMORY_USER_VALUE" == "upgrade-test-user" ]]; then
+  pass "MEMORY_USER_ID preserved in secrets.env"
+else
+  fail "MEMORY_USER_ID changed (expected 'upgrade-test-user', got '${MEMORY_USER_VALUE}')"
+fi
+
+# ── 5b: stack.env unchanged ──────────────────────────────────────────
+echo ""
+echo "=== 5b: stack.env preservation ==="
+
+STACK_ENV_CHECKSUM_AFTER=$(sha256sum "${OPENPALM_DATA_HOME}/stack.env" | awk '{print $1}')
+if [[ "$STACK_ENV_CHECKSUM_BEFORE" == "$STACK_ENV_CHECKSUM_AFTER" ]]; then
+  pass "stack.env checksum unchanged"
+else
+  # If --to-version was used, stack.env will change (image tag update). That's expected.
+  if [[ -n "$TO_VERSION" ]]; then
+    pass "stack.env changed (expected: image tag updated to ${TO_VERSION})"
+  else
+    fail "stack.env was modified during upgrade (before: ${STACK_ENV_CHECKSUM_BEFORE}, after: ${STACK_ENV_CHECKSUM_AFTER})"
+  fi
+fi
+
+# ── 5c: Memory database preserved ───────────────────────────────────
+echo ""
+echo "=== 5c: Memory data preservation ==="
+
+if [[ -f "${OPENPALM_DATA_HOME}/memory/memory.db" ]]; then
+  MEMORY_DB_SIZE_AFTER=$(stat --printf='%s' "${OPENPALM_DATA_HOME}/memory/memory.db" 2>/dev/null || echo "0")
+  if [[ "$MEMORY_DB_SIZE_AFTER" -ge "$MEMORY_DB_SIZE_BEFORE" && "$MEMORY_DB_SIZE_AFTER" -gt 0 ]]; then
+    pass "memory.db preserved (${MEMORY_DB_SIZE_BEFORE} -> ${MEMORY_DB_SIZE_AFTER} bytes)"
+  elif [[ "$MEMORY_DB_SIZE_BEFORE" -eq 0 && "$MEMORY_DB_SIZE_AFTER" -eq 0 ]]; then
+    pass "memory.db not created (Ollama models likely not available — config-only test)"
+  else
+    fail "memory.db shrunk (${MEMORY_DB_SIZE_BEFORE} -> ${MEMORY_DB_SIZE_AFTER} bytes)"
+  fi
+else
+  if [[ "$MEMORY_DB_SIZE_BEFORE" -eq 0 ]]; then
+    pass "memory.db not present (was not created before upgrade either)"
+  else
+    fail "memory.db was deleted during upgrade"
+  fi
+fi
+
+# Check memory API responds (if memory container is healthy)
+MEMORY_STATUS=$(docker inspect --format '{{.State.Health.Status}}' "${PROJECT_NAME}-memory-1" 2>/dev/null || echo "missing")
+if [[ "$MEMORY_STATUS" == "healthy" ]]; then
+  MEMORY_API_STATUS=$(curl -sf -o /dev/null -w '%{http_code}' \
+    -X POST "http://127.0.0.1:${MEMORY_PORT}/api/v1/memories/filter" \
+    -H 'content-type: application/json' \
+    -d '{"user_id": "upgrade-test-user"}' 2>/dev/null || echo "error")
+  if [[ "$MEMORY_API_STATUS" == "200" ]]; then
+    pass "Memory API responds after upgrade"
+  else
+    fail "Memory API returned HTTP ${MEMORY_API_STATUS} after upgrade"
+  fi
+else
+  echo "  Memory container not healthy (${MEMORY_STATUS}) — skipping API check"
+fi
+
+# ── 5d: Custom user files preserved ─────────────────────────────────
+echo ""
+echo "=== 5d: User file preservation ==="
+
+if [[ -f "${OPENPALM_CONFIG_HOME}/channels/my-custom-channel.yml" ]]; then
+  CUSTOM_FILE_CHECKSUM_AFTER=$(sha256sum "${OPENPALM_CONFIG_HOME}/channels/my-custom-channel.yml" | awk '{print $1}')
+  if [[ "$CUSTOM_FILE_CHECKSUM" == "$CUSTOM_FILE_CHECKSUM_AFTER" ]]; then
+    pass "Custom channel file preserved and unchanged"
+  else
+    fail "Custom channel file was modified"
+  fi
+else
+  fail "Custom channel file was deleted during upgrade"
+fi
+
+# ── 5e: All services running ────────────────────────────────────────
+echo ""
+echo "=== 5e: Service health ==="
+
+HEALTHCHECK_SVCS="admin docker-socket-proxy"
+for svc in $HEALTHCHECK_SVCS; do
+  status=$(docker inspect --format '{{.State.Health.Status}}' "${PROJECT_NAME}-${svc}-1" 2>/dev/null || echo "missing")
+  if [[ "$status" == "healthy" ]]; then
+    pass "${svc} is healthy"
+  else
+    fail "${svc} status: ${status}"
+  fi
+done
+
+# Caddy doesn't have a healthcheck — check if running
+caddy_status=$(docker inspect --format '{{.State.Status}}' "${PROJECT_NAME}-caddy-1" 2>/dev/null || echo "missing")
+if [[ "$caddy_status" == "running" ]]; then
+  pass "caddy is running"
+else
+  fail "caddy status: ${caddy_status}"
+fi
+
+# Optional services (may not be healthy without Ollama)
+OPTIONAL_SVCS="memory assistant guardian"
+for svc in $OPTIONAL_SVCS; do
+  status=$(docker inspect --format '{{.State.Health.Status}}' "${PROJECT_NAME}-${svc}-1" 2>/dev/null || echo "missing")
+  if [[ "$status" == "healthy" ]]; then
+    pass "${svc} is healthy"
+  else
+    echo "  INFO: ${svc} status: ${status} (may require Ollama or LLM provider)"
+  fi
+done
+
+# ── 5f: Admin token still works ─────────────────────────────────────
+echo ""
+echo "=== 5f: Admin authentication ==="
+
+AUTH_CHECK_AFTER=$(curl -sf -o /dev/null -w '%{http_code}' \
+  "${ADMIN_URL}/admin/containers/list" \
+  -H "x-admin-token: ${ADMIN_TOKEN}" 2>/dev/null || echo "error")
+
+if [[ "$AUTH_CHECK_AFTER" == "200" ]]; then
+  pass "Admin token still authenticates (HTTP 200)"
+else
+  fail "Admin token failed after upgrade (HTTP ${AUTH_CHECK_AFTER})"
+fi
+
+# Verify unauthorized requests are rejected
+UNAUTH_CHECK=$(curl -sf -o /dev/null -w '%{http_code}' \
+  "${ADMIN_URL}/admin/containers/list" \
+  -H "x-admin-token: wrong-token" 2>/dev/null || echo "error")
+
+if [[ "$UNAUTH_CHECK" == "401" || "$UNAUTH_CHECK" == "403" ]]; then
+  pass "Unauthorized requests correctly rejected (HTTP ${UNAUTH_CHECK})"
+else
+  fail "Unauthorized request not rejected (HTTP ${UNAUTH_CHECK})"
+fi
+
+# ── 5g: No errors in container logs ─────────────────────────────────
+echo ""
+echo "=== 5g: Container log inspection ==="
+
+# Check admin logs for fatal errors (ignore expected warnings)
+ADMIN_ERRORS=$(compose_cmd logs admin --tail=100 2>&1 | grep -iE 'fatal|panic|unhandled.*exception|ENOENT.*secrets' || true)
+if [[ -z "$ADMIN_ERRORS" ]]; then
+  pass "No fatal errors in admin logs"
+else
+  fail "Errors found in admin logs:"
+  echo "$ADMIN_ERRORS" | head -5 | while read -r line; do echo "    $line"; done
+fi
+
+# Check for container restarts (CrashLoopBackOff indicator)
+RESTART_COUNT=0
+for svc in admin memory assistant guardian docker-socket-proxy caddy; do
+  restarts=$(docker inspect --format '{{.RestartCount}}' "${PROJECT_NAME}-${svc}-1" 2>/dev/null || echo "0")
+  if [[ "$restarts" -gt 2 ]]; then
+    fail "${svc} restarted ${restarts} times (possible crash loop)"
+    RESTART_COUNT=$((RESTART_COUNT + 1))
+  fi
+done
+if [[ $RESTART_COUNT -eq 0 ]]; then
+  pass "No excessive container restarts"
+fi
+
+# ── 5h: Services list matches pre-upgrade ───────────────────────────
+echo ""
+echo "=== 5h: Service list consistency ==="
+
+SERVICES_AFTER=$(compose_cmd ps --format '{{.Service}}' 2>/dev/null | sort | tr '\n' ',' | sed 's/,$//')
+if [[ "$SERVICES_BEFORE" == "$SERVICES_AFTER" ]]; then
+  pass "Same services running after upgrade (${SERVICES_AFTER})"
+else
+  echo "  Before: ${SERVICES_BEFORE}"
+  echo "  After:  ${SERVICES_AFTER}"
+  # Not necessarily a failure — upgrade may add new services
+  if [[ $(echo "$SERVICES_AFTER" | tr ',' '\n' | wc -l) -ge $(echo "$SERVICES_BEFORE" | tr ',' '\n' | wc -l) ]]; then
+    pass "Service count same or increased after upgrade"
+  else
+    fail "Services were lost during upgrade"
+  fi
+fi
+
+# ══════════════════════════════════════════════════════════════════════
+# Summary
+# ══════════════════════════════════════════════════════════════════════
+
+echo ""
+echo "=========================================="
+if [[ -n "$FROM_VERSION" || -n "$TO_VERSION" ]]; then
+  echo "  UPGRADE PATH: ${FROM_VERSION:-current} -> ${TO_VERSION:-current}"
+fi
+echo "  RESULTS: $PASS passed, $FAIL failed (${TESTS} total)"
+echo "=========================================="
+
+if [[ "$FAIL" -gt 0 ]]; then
+  echo ""
+  echo "  FAILED -- $FAIL test(s) did not pass"
+  exit 1
+else
+  echo ""
+  echo "  ALL TESTS PASSED"
+  exit 0
+fi


### PR DESCRIPTION
## Summary

Second batch of release preparation — setup scripts, integration tests, documentation, and Windows compatibility.

### Setup scripts
- Pin setup.sh and setup.ps1 to release tag with CI stamping (#250)
- PowerShell installer parity: checksum verification, Docker detection, Windows-idiomatic paths (#255)

### Security / Privacy
- Remove hardcoded big-pickle default model — operator chooses during wizard (#256)

### Tests
- Channel -> Guardian -> Assistant full integration test with real HMAC signing (#261)
- Scheduler e2e test with real Croner cron firing and execution log verification (#262)
- Release e2e test script for production install flow (#251)
- Upgrade path test script with state preservation verification (#263)

### Documentation
- Architecture diagram (SVG) showing container topology and network boundaries (#277)
- Setup wizard visual walkthrough with screen-by-screen descriptions (#264)
- Updated docs/README.md, setup-guide.md, memory-privacy.md, opencode-configuration.md

### Windows compatibility
- CLI: platform-aware Docker socket path and XDG directory defaults (#276)

Closes #250
Closes #251
Closes #255
Closes #256
Closes #261
Closes #262
Closes #263
Closes #264
Closes #276
Closes #277

## Test plan
- [x] svelte-check: 0 errors, 0 warnings
- [x] Admin server Vitest: 562 pass, 0 fail (includes new scheduler tests)
- [x] Non-admin Bun tests: 112 pass, 0 fail

Generated with Claude Code