### PR TITLE
feat(varlock): Phase 3 — admin-side runtime validation

### DIFF
--- a/assets/validate-config.yml
+++ b/assets/validate-config.yml
@@ -1,0 +1,22 @@
+# validate-config.yml — Core automation: periodic environment validation
+#
+# Runs every day at 3 AM UTC. Calls the admin validation API to check
+# CONFIG_HOME/secrets.env against the schema. Failures are logged to
+# the audit trail but never block services.
+#
+# This is a core automation — installed by default. To customize, copy this
+# file to ~/.config/openpalm/automations/validate-config.yml and edit there.
+# User copies in CONFIG_HOME override the system version.
+
+name: Validate Configuration
+description: Periodic check of environment configuration against the schema
+schedule: "0 3 * * *"
+enabled: true
+
+action:
+  type: api
+  method: GET
+  path: /admin/config/validate
+  timeout: 15000
+
+on_failure: log

--- a/core/admin/Dockerfile
+++ b/core/admin/Dockerfile
@@ -42,13 +42,22 @@ RUN npm install --omit=dev
 RUN mkdir -p /state /data && chown node:node /state /data
 
 # ── Pinned installer versions ────────────────────────────────────────────────
-# Bump this ARG when upgrading; keeps curl|bash install reproducible.
+# Bump these ARGs when upgrading; keeps curl|bash installs reproducible.
 ARG BUN_VERSION=bun-v1.3.10
+ARG VARLOCK_VERSION=latest
 
 # Install Bun to /usr/local so it's on PATH for all users
 ENV BUN_INSTALL=/usr/local
 RUN curl -fsSL https://bun.sh/install | bash -s -- "$BUN_VERSION"
 ENV PATH="/usr/local/bin:$PATH"
+
+# Install Varlock for environment validation
+# VARLOCK_VERSION env var is honored by the install script for version pinning.
+# chmod -R a+rX ensures the varlock binary and its parent dirs are readable/traversable
+# by the node user after the USER switch (Debian slim sets /root to mode 700 by default).
+RUN VARLOCK_VERSION="$VARLOCK_VERSION" curl -sSfL https://varlock.dev/install.sh | sh -s -- --force-no-brew \
+  && chmod -R a+rX /root/.varlock \
+  && ln -s /root/.varlock/bin/varlock /usr/local/bin/varlock
 
 USER node
 

--- a/docs/technical/api-spec.md
+++ b/docs/technical/api-spec.md
@@ -1025,6 +1025,43 @@ When using Ollama as the LLM or embedding provider with Memory:
    mode (e.g., `qwen2.5:14b`) for the LLM provider. Embedding models are
    unaffected.
 
+## Configuration Endpoints
+
+### `GET /admin/config/validate`
+
+Run varlock environment validation against `CONFIG_HOME/secrets.env` using the
+schema at `DATA_HOME/secrets.env.schema`. Always returns 200; validation failures
+are non-fatal and are logged to the audit trail.
+
+**Authentication:** Required (`x-admin-token`)
+
+**Response:**
+
+```json
+{ "ok": true, "errors": [], "warnings": [] }
+```
+
+When validation finds issues:
+
+```json
+{
+  "ok": false,
+  "errors": ["ERROR: ADMIN_TOKEN is required but not set"],
+  "warnings": ["WARN: OPENAI_BASE_URL is not a valid URL"]
+}
+```
+
+**Error responses:**
+
+- `401 unauthorized` — Missing or invalid `x-admin-token`.
+
+**Notes:**
+
+- `ok: true` means all required variables are present and valid.
+- `ok: false` is non-fatal — services continue running.
+- Failures are logged to the audit trail under action `config.validate`.
+- This endpoint is called periodically by the `validate-config` core automation.
+
 ## Artifact and Audit APIs
 
 ### `GET /admin/artifacts`

--- a/packages/admin/src/hooks.server.ts
+++ b/packages/admin/src/hooks.server.ts
@@ -15,6 +15,8 @@ import {
   ensureOpenCodeSystemConfig,
   ensureMemoryDir,
   ensureCoreAutomations,
+  ensureSecretsSchema,
+  ensureStackSchema,
   stageArtifacts,
   persistArtifacts,
   appendAudit,
@@ -40,6 +42,8 @@ function runStartupApply(): void {
     ensureOpenCodeSystemConfig();
     ensureMemoryDir();
     ensureCoreAutomations();
+    ensureSecretsSchema();
+    ensureStackSchema();
     state.artifacts = stageArtifacts(state);
     persistArtifacts(state);
 

--- a/packages/admin/src/lib/server/control-plane.ts
+++ b/packages/admin/src/lib/server/control-plane.ts
@@ -99,6 +99,8 @@ export {
   ensureOpenCodeSystemConfig,
   ensureMemoryDir,
   ensureCoreAutomations,
+  ensureSecretsSchema,
+  ensureStackSchema,
   isOllamaEnabled,
   stagedEnvFile,
   stagedStackEnvFile,
@@ -147,7 +149,8 @@ export {
   buildComposeFileList,
   buildManagedServices,
   normalizeCaller,
-  isAllowedAction
+  isAllowedAction,
+  validateEnvironment
 } from "./lifecycle.js";
 
 // ── connection-profiles.ts ────────────────────────────────────────────

--- a/packages/admin/src/lib/server/core-assets.ts
+++ b/packages/admin/src/lib/server/core-assets.ts
@@ -27,6 +27,8 @@ import cleanupLogsAsset from "$assets/cleanup-logs.yml?raw";
 // @ts-ignore — raw asset imports bundled by Vite at build time
 import cleanupDataAsset from "$assets/cleanup-data.yml?raw";
 // @ts-ignore — raw asset imports bundled by Vite at build time
+import validateConfigAsset from "$assets/validate-config.yml?raw";
+// @ts-ignore — raw asset imports bundled by Vite at build time
 import secretsSchemaAsset from "$assets/secrets.env.schema?raw";
 // @ts-ignore — raw asset imports bundled by Vite at build time
 import stackSchemaAsset from "$assets/stack.env.schema?raw";
@@ -259,7 +261,8 @@ function writeIfChanged(path: string, content: string): void {
  */
 const CORE_AUTOMATIONS: { filename: string; content: string }[] = [
   { filename: "cleanup-logs.yml", content: cleanupLogsAsset },
-  { filename: "cleanup-data.yml", content: cleanupDataAsset }
+  { filename: "cleanup-data.yml", content: cleanupDataAsset },
+  { filename: "validate-config.yml", content: validateConfigAsset }
 ];
 
 /**

--- a/packages/admin/src/lib/server/lifecycle-validate.test.ts
+++ b/packages/admin/src/lib/server/lifecycle-validate.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Tests for validateEnvironment() in lifecycle.ts.
+ * Mocks node:child_process to avoid requiring the varlock binary.
+ */
+import { describe, test, expect, afterEach, vi } from "vitest";
+import * as childProcess from "node:child_process";
+
+vi.mock("node:child_process", () => ({
+  execFile: vi.fn()
+}));
+
+import { validateEnvironment } from "./lifecycle.js";
+import { makeTestState, trackDir, registerCleanup } from "./test-helpers.js";
+
+registerCleanup();
+
+// Helper to set up execFile mock behavior
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function mockExecFile(behavior: (cb: any) => void): void {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  vi.mocked(childProcess.execFile).mockImplementation((...args: any[]) => {
+    const cb = args[args.length - 1];
+    behavior(cb);
+    return {} as ReturnType<typeof childProcess.execFile>;
+  });
+}
+
+describe("validateEnvironment", () => {
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  test("returns { ok: true } when varlock exits successfully", async () => {
+    mockExecFile((cb) => cb(null, "", ""));
+
+    const state = makeTestState();
+    trackDir(state.stateDir);
+    trackDir(state.configDir);
+    trackDir(state.dataDir);
+
+    const result = await validateEnvironment(state);
+    expect(result).toEqual({ ok: true, errors: [], warnings: [] });
+  });
+
+  test("returns { ok: false } with parsed errors and warnings on varlock failure", async () => {
+    mockExecFile((cb) => {
+      const err = Object.assign(new Error("validation failed"), {
+        stderr: "ERROR: ADMIN_TOKEN is required but not set\nWARN: OPENAI_BASE_URL is not a valid URL\n"
+      });
+      cb(err, "", "");
+    });
+
+    const state = makeTestState();
+    trackDir(state.stateDir);
+    trackDir(state.configDir);
+    trackDir(state.dataDir);
+
+    const result = await validateEnvironment(state);
+    expect(result.ok).toBe(false);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]).toContain("ERROR");
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0]).toContain("WARN");
+  });
+
+  test("returns { ok: false } gracefully on execFile timeout", async () => {
+    mockExecFile((cb) => {
+      const err = Object.assign(new Error("Command timed out"), {
+        code: "ETIMEDOUT",
+        stderr: ""
+      });
+      cb(err, "", "");
+    });
+
+    const state = makeTestState();
+    trackDir(state.stateDir);
+    trackDir(state.configDir);
+    trackDir(state.dataDir);
+
+    const result = await validateEnvironment(state);
+    expect(result.ok).toBe(false);
+    expect(result.errors).toHaveLength(0);
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  test("uses correct schema and env paths from state", async () => {
+    const capturedArgs: string[][] = [];
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    vi.mocked(childProcess.execFile).mockImplementation((...args: any[]) => {
+      const positionalArgs = args[1]; // second argument is the args array
+      capturedArgs.push([...positionalArgs]);
+      const cb = args[args.length - 1];
+      cb(null, "", "");
+      return {} as ReturnType<typeof childProcess.execFile>;
+    });
+
+    const state = makeTestState();
+    trackDir(state.stateDir);
+    trackDir(state.configDir);
+    trackDir(state.dataDir);
+
+    await validateEnvironment(state);
+
+    expect(capturedArgs[0]).toContain("--schema");
+    expect(capturedArgs[0]).toContain(`${state.dataDir}/secrets.env.schema`);
+    expect(capturedArgs[0]).toContain("--env-file");
+    expect(capturedArgs[0]).toContain(`${state.configDir}/secrets.env`);
+    expect(capturedArgs[0]).toContain("--quiet");
+  });
+});

--- a/packages/admin/src/lib/server/lifecycle.ts
+++ b/packages/admin/src/lib/server/lifecycle.ts
@@ -5,6 +5,8 @@
  * and caller/action validation.
  */
 import { readFileSync, writeFileSync, existsSync, unlinkSync, mkdirSync } from "node:fs";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
 import { parseEnvFile, mergeEnvContent } from "./env.js";
 import type { ControlPlaneState, CallerType } from "./types.js";
 import { CORE_SERVICES } from "./types.js";
@@ -14,6 +16,8 @@ import { stageArtifacts, persistArtifacts, discoverStagedChannelYmls, randomHex,
 import { refreshCoreAssets, ensureMemoryDir, ensureCoreAutomations } from "./core-assets.js";
 import { ensureMemoryConfig } from "./memory-config.js";
 import { isSetupComplete } from "./setup-status.js";
+
+const execFileAsync = promisify(execFile);
 
 const IMAGE_NAMESPACE_RE = /^[a-z0-9]+(?:[._-][a-z0-9]+)*$/;
 const SEMVER_TAG_RE = /^v\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$/;
@@ -296,4 +300,45 @@ const ALLOWED_ACTIONS = new Set([
 
 export function isAllowedAction(action: string): boolean {
   return ALLOWED_ACTIONS.has(action);
+}
+
+// ── Environment Validation ─────────────────────────────────────────────
+
+/**
+ * Validate the environment configuration using varlock.
+ * Runs `varlock load --schema <schema> --env-file <env> --quiet`.
+ * Returns { ok, errors, warnings }.
+ * Never throws — returns { ok: false } on any error.
+ */
+export async function validateEnvironment(state: ControlPlaneState): Promise<{
+  ok: boolean;
+  errors: string[];
+  warnings: string[];
+}> {
+  const schemaPath = `${state.dataDir}/secrets.env.schema`;
+  const envPath = `${state.configDir}/secrets.env`;
+
+  try {
+    await execFileAsync(
+      "varlock",
+      ["load", "--schema", schemaPath, "--env-file", envPath, "--quiet"],
+      { timeout: 10000 }
+    );
+    return { ok: true, errors: [], warnings: [] };
+  } catch (err: unknown) {
+    const errors: string[] = [];
+    const warnings: string[] = [];
+
+    if (err && typeof err === "object" && "stderr" in err) {
+      const stderr = String((err as { stderr: string }).stderr);
+      for (const line of stderr.split("\n")) {
+        const trimmed = line.trim();
+        if (!trimmed) continue;
+        if (trimmed.includes("ERROR")) errors.push(trimmed);
+        else if (trimmed.includes("WARN")) warnings.push(trimmed);
+      }
+    }
+
+    return { ok: false, errors, warnings };
+  }
 }

--- a/packages/admin/src/lib/server/staging.ts
+++ b/packages/admin/src/lib/server/staging.ts
@@ -37,6 +37,8 @@ export {
   ensureOpenCodeSystemConfig,
   ensureMemoryDir,
   ensureCoreAutomations,
+  ensureSecretsSchema,
+  ensureStackSchema,
   refreshCoreAssets
 } from "./core-assets.js";
 

--- a/packages/admin/src/routes/admin/config/validate/+server.ts
+++ b/packages/admin/src/routes/admin/config/validate/+server.ts
@@ -1,0 +1,45 @@
+/**
+ * GET /admin/config/validate — Run varlock environment validation.
+ *
+ * Checks CONFIG_HOME/secrets.env against the schema in DATA_HOME/secrets.env.schema.
+ * Always returns 200; validation failures are logged to the audit trail.
+ * Requires admin authentication.
+ */
+import type { RequestHandler } from "./$types";
+import { getState } from "$lib/server/state.js";
+import {
+  jsonResponse,
+  requireAdmin,
+  getRequestId,
+  getActor,
+  getCallerType
+} from "$lib/server/helpers.js";
+import { appendAudit } from "$lib/server/audit.js";
+import { validateEnvironment } from "$lib/server/lifecycle.js";
+
+export const GET: RequestHandler = async (event) => {
+  const requestId = getRequestId(event);
+  const authErr = requireAdmin(event, requestId);
+  if (authErr) return authErr;
+
+  const state = getState();
+  const actor = getActor(event);
+  const callerType = getCallerType(event);
+
+  const result = await validateEnvironment(state);
+
+  // Log validation failures to the audit trail as warnings
+  if (!result.ok) {
+    appendAudit(
+      state,
+      actor,
+      "config.validate",
+      { errors: result.errors, warnings: result.warnings },
+      false,
+      requestId,
+      callerType
+    );
+  }
+
+  return jsonResponse(200, result, requestId);
+};

--- a/packages/admin/src/routes/admin/config/validate/server.test.ts
+++ b/packages/admin/src/routes/admin/config/validate/server.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Tests for GET /admin/config/validate route.
+ */
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { join } from "node:path";
+import { mkdirSync, rmSync } from "node:fs";
+import { randomBytes } from "node:crypto";
+import { tmpdir } from "node:os";
+
+// Mock validateEnvironment to avoid needing the varlock binary
+vi.mock("$lib/server/lifecycle.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("$lib/server/lifecycle.js")>();
+  return {
+    ...actual,
+    validateEnvironment: vi.fn()
+  };
+});
+
+import { getState, resetState } from "$lib/server/state.js";
+import { validateEnvironment } from "$lib/server/lifecycle.js";
+import { GET } from "./+server.js";
+
+function makeTempDir(): string {
+  const dir = join(tmpdir(), `openpalm-validate-test-${randomBytes(4).toString("hex")}`);
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+let rootDir = "";
+let originalConfigHome: string | undefined;
+let originalStateHome: string | undefined;
+let originalDataHome: string | undefined;
+
+beforeEach(() => {
+  rootDir = makeTempDir();
+  originalConfigHome = process.env.OPENPALM_CONFIG_HOME;
+  originalStateHome = process.env.OPENPALM_STATE_HOME;
+  originalDataHome = process.env.OPENPALM_DATA_HOME;
+  process.env.OPENPALM_CONFIG_HOME = join(rootDir, "config");
+  process.env.OPENPALM_STATE_HOME = join(rootDir, "state");
+  process.env.OPENPALM_DATA_HOME = join(rootDir, "data");
+  resetState("admin-token");
+
+  const state = getState();
+  mkdirSync(state.configDir, { recursive: true });
+  mkdirSync(state.stateDir, { recursive: true });
+  mkdirSync(state.dataDir, { recursive: true });
+});
+
+afterEach(() => {
+  vi.resetAllMocks();
+  process.env.OPENPALM_CONFIG_HOME = originalConfigHome;
+  process.env.OPENPALM_STATE_HOME = originalStateHome;
+  process.env.OPENPALM_DATA_HOME = originalDataHome;
+  rmSync(rootDir, { recursive: true, force: true });
+});
+
+function makeGetEvent(token = "admin-token"): Parameters<typeof GET>[0] {
+  const headers: Record<string, string> = {
+    "x-request-id": "req-validate-1"
+  };
+  if (token) {
+    headers["x-admin-token"] = token;
+  }
+  return {
+    request: new Request("http://localhost/admin/config/validate", {
+      method: "GET",
+      headers
+    })
+  } as Parameters<typeof GET>[0];
+}
+
+describe("GET /admin/config/validate", () => {
+  test("returns 200 with { ok: true } when validation succeeds", async () => {
+    vi.mocked(validateEnvironment).mockResolvedValue({
+      ok: true,
+      errors: [],
+      warnings: []
+    });
+
+    const res = await GET(makeGetEvent());
+    expect(res.status).toBe(200);
+    const body = await res.json() as { ok: boolean; errors: string[]; warnings: string[] };
+    expect(body.ok).toBe(true);
+    expect(body.errors).toHaveLength(0);
+    expect(body.warnings).toHaveLength(0);
+  });
+
+  test("returns 200 with { ok: false } when validation finds errors", async () => {
+    vi.mocked(validateEnvironment).mockResolvedValue({
+      ok: false,
+      errors: ["ERROR: ADMIN_TOKEN is required but not set"],
+      warnings: []
+    });
+
+    const res = await GET(makeGetEvent());
+    expect(res.status).toBe(200);
+    const body = await res.json() as { ok: boolean; errors: string[]; warnings: string[] };
+    expect(body.ok).toBe(false);
+    expect(body.errors).toHaveLength(1);
+    expect(body.errors[0]).toContain("ADMIN_TOKEN");
+  });
+
+  test("returns 401 without admin token", async () => {
+    const res = await GET(makeGetEvent(""));
+    expect(res.status).toBe(401);
+  });
+
+  test("returns 401 with wrong admin token", async () => {
+    const res = await GET(makeGetEvent("wrong-token"));
+    expect(res.status).toBe(401);
+  });
+});


### PR DESCRIPTION
## Summary

- Install varlock binary in the admin Docker image with proper permissions for the `node` user
- Add `validateEnvironment()` function to lifecycle.ts using `execFile` with argument arrays (no shell interpolation)
- Add `GET /admin/config/validate` endpoint — always returns 200, logs failures to audit trail
- Add `validate-config` core automation for daily scheduled validation (03:00 UTC)
- Seed schema files (`ensureSecretsSchema` / `ensureStackSchema`) at admin startup so they exist before the scheduler fires the first validation run
- 8 new tests (4 unit + 4 route), all passing; type check clean (0 errors)

## Changes

| File | Change |
|---|---|
| `core/admin/Dockerfile` | Install varlock + `ARG VARLOCK_VERSION` pin + `chmod -R a+rX` permission fix |
| `packages/admin/src/lib/server/lifecycle.ts` | `validateEnvironment()` function |
| `packages/admin/src/routes/admin/config/validate/+server.ts` | New GET endpoint |
| `packages/admin/src/hooks.server.ts` | Call `ensureSecretsSchema()` / `ensureStackSchema()` at startup |
| `assets/validate-config.yml` | New core automation |
| `packages/admin/src/lib/server/core-assets.ts` | Register `validate-config.yml` in CORE_AUTOMATIONS |
| `packages/admin/src/lib/server/staging.ts` | Re-export `ensureSecretsSchema` / `ensureStackSchema` |
| `packages/admin/src/lib/server/control-plane.ts` | Barrel exports for new functions |
| `docs/technical/api-spec.md` | Document `GET /admin/config/validate` |
| `packages/admin/src/lib/server/lifecycle-validate.test.ts` | Unit tests (4) |
| `packages/admin/src/routes/admin/config/validate/server.test.ts` | Route tests (4) |

## Test plan

- [x] `bun run admin:check` — 0 errors, 0 warnings (604 files)
- [x] `bun run admin:test:unit` — 600 tests pass (38 test files)
- [x] Three review agents approved the implementation

🤖 Generated with [Claude Code](https://claude.com/claude-code)