### PR TITLE
feat(varlock): implement Varlock schema validation — Phases 1–4

### DIFF
--- a/.plans/varlock-tasks.md
+++ b/.plans/varlock-tasks.md
@@ -543,7 +543,7 @@ Add unit tests for `validateEnvironment()` and e2e tests for the validation endp
 
 | | |
 |---|---|
-| **Status** | `pending` |
+| **Status** | `completed` |
 | **Depends** | P1-T1, P1-T2 |
 | **Agent** | bunjs-typescript-coder |
 | **Files** | `packages/admin/src/lib/server/staging.ts` (edit) |
@@ -563,7 +563,7 @@ During the admin apply flow, copy schema files to `DATA_HOME/assistant/env-schem
 
 | | |
 |---|---|
-| **Status** | `pending` |
+| **Status** | `completed` |
 | **Depends** | P4-T1 |
 | **Agent** | general-purpose |
 | **Files** | `assets/opencode.jsonc` (edit) |
@@ -582,7 +582,7 @@ Add `/etc/opencode/env-schema/**` to the context include patterns in the baked-i
 
 | | |
 |---|---|
-| **Status** | `pending` |
+| **Status** | `completed` |
 | **Depends** | P4-T1 |
 | **Agent** | general-purpose |
 | **Files** | `core/assistant/skills/config-diagnostics.md` (new) |

--- a/assets/opencode.jsonc
+++ b/assets/opencode.jsonc
@@ -1,4 +1,12 @@
 {
   "$schema": "https://opencode.ai/config.json",
-  "plugin": ["@openpalm/assistant-tools", "agentikit-opencode"]
+  "plugin": ["@openpalm/assistant-tools", "agentikit-opencode"],
+  // Env schema files are staged to /etc/opencode/env-schema/ during admin apply.
+  // The assistant can read schema metadata (variable names, types, descriptions)
+  // without ever seeing actual .env values.
+  "context": {
+    "include": [
+      "/etc/opencode/env-schema/**"
+    ]
+  }
 }

--- a/core/assistant/skills/config-diagnostics.md
+++ b/core/assistant/skills/config-diagnostics.md
@@ -1,0 +1,57 @@
+# Config Diagnostics Skill
+
+When a user asks about configuration issues, connection problems, missing API
+keys, or validation errors, use the admin API and schema files to diagnose
+and guide them — without ever exposing actual secret values.
+
+## Procedure
+
+1. **Call `GET /admin/config/validate`** to get the current validation result:
+   ```
+   GET /admin/config/validate
+   x-admin-token: <admin-token>
+   ```
+   Response: `{ ok: boolean, errors: string[], warnings: string[] }`
+
+2. **Read schema files** at `/etc/opencode/env-schema/` to understand variable
+   descriptions, types, and requirements:
+   - `secrets.env.schema` — user secrets (API keys, tokens, credentials)
+   - `stack.env.schema` — system-managed paths and runtime identity
+
+3. **Interpret validation errors** using the schema metadata:
+   - Match error variable names to schema entries for human-readable descriptions
+   - Use `# @type` annotations to explain the expected format
+   - Use `# @required` annotations to explain why the variable is needed
+
+4. **Guide the user to fix issues** via:
+   - The admin UI (Settings > Secrets) for secret variables
+   - Direct editing of `CONFIG_HOME/secrets.env` for advanced users
+   - The admin UI (Settings > Stack) for system configuration
+
+## Critical Rules
+
+- **NEVER read, display, echo, or reference actual `.env` file contents.**
+  Schema files describe variable structure — they contain no real values.
+- **NEVER suggest `cat secrets.env` or any command that exposes secret values.**
+- When referring to a variable, use its name and schema description only.
+  Example: "OPENAI_API_KEY is missing — this is your OpenAI API key (string,
+  sensitive, required when using the openai provider)."
+- Always direct users to fix secrets through the admin UI or direct file edits,
+  never through the assistant terminal.
+
+## Example Responses
+
+**User:** "Why isn't my AI connection working?"
+
+**Assistant:**
+1. Calls `GET /admin/config/validate`
+2. Reads `secrets.env.schema` to find OPENAI_API_KEY description
+3. Responds: "Validation shows OPENAI_API_KEY is not set. This variable holds
+   your OpenAI API key — set it in Settings > Secrets in the admin UI, or add
+   `OPENAI_API_KEY=<your-key>` to `~/.config/openpalm/secrets.env`."
+
+**User:** "Can you show me my secrets.env file?"
+
+**Assistant:** "I don't read actual secret files to protect your credentials.
+Instead, I can check the validation status via the admin API and explain what
+each variable does using the schema. Would you like me to run a validation check?"

--- a/packages/admin/src/lib/server/staging.ts
+++ b/packages/admin/src/lib/server/staging.ts
@@ -5,7 +5,7 @@
  * Caddyfile/compose staging, env staging, channel/automation file staging,
  * and artifact persistence.
  */
-import { mkdirSync, writeFileSync, readFileSync, existsSync, readdirSync, rmSync } from "node:fs";
+import { mkdirSync, writeFileSync, readFileSync, existsSync, readdirSync, rmSync, copyFileSync } from "node:fs";
 import { join } from "node:path";
 import { createHash, randomBytes } from "node:crypto";
 import adminPkg from "../../../package.json" with { type: "json" };
@@ -18,6 +18,8 @@ import {
   readCoreCaddyfile,
   readCoreCompose,
   readOllamaCompose,
+  ensureSecretsSchema,
+  ensureStackSchema,
   PUBLIC_ACCESS_IMPORT,
   LAN_ONLY_IMPORT
 } from "./core-assets.js";
@@ -366,6 +368,26 @@ function stageAutomationFiles(state: ControlPlaneState): void {
   }
 }
 
+// ── Env Schema Staging ────────────────────────────────────────────────
+
+/**
+ * Stage schema files to DATA_HOME/assistant/env-schema/ so the assistant
+ * container can read them for configuration reasoning.
+ *
+ * The assistant reads schema files to understand variable types and
+ * descriptions — it never reads actual .env values.
+ */
+function stageEnvSchemas(state: ControlPlaneState): void {
+  const destDir = `${state.dataDir}/assistant/env-schema`;
+  mkdirSync(destDir, { recursive: true });
+
+  const secretsSchemaPath = ensureSecretsSchema();
+  const stackSchemaPath = ensureStackSchema();
+
+  copyFileSync(secretsSchemaPath, `${destDir}/secrets.env.schema`);
+  copyFileSync(stackSchemaPath, `${destDir}/stack.env.schema`);
+}
+
 // ── Top-Level Staging ─────────────────────────────────────────────────
 
 export function stageArtifacts(state: ControlPlaneState): {
@@ -430,6 +452,7 @@ export function persistArtifacts(state: ControlPlaneState): void {
   stageChannelYmlFiles(state);
   stageChannelCaddyfiles(state);
   stageAutomationFiles(state);
+  stageEnvSchemas(state);
 
   state.artifactMeta = buildArtifactMeta(state.artifacts);
   writeFileSync(


### PR DESCRIPTION
## Summary

Implements the Varlock schema validation system across Phases 1–4 of the varlock-tasks plan:

- **Phase 1**: Add `assets/secrets.env.schema` and `assets/stack.env.schema` — machine-parseable schema files documenting all env variables with `@type`, `@sensitive`, and `@required` annotations. Update docs with Schema Reference section.
- **Phase 2**: CLI-centric validation (`ensureVarlock()`, `openpalm validate` command, bootstrap integration, schema staging), host detection (`detectHostInfo()`/`host.json`), GitHub Actions CLI release workflow, thin wrapper scripts for bash and PowerShell.
- **Phase 3**: Admin-side runtime validation — install Varlock in admin Docker image, `validateEnvironment()` in lifecycle module, `GET /admin/config/validate` endpoint, maintenance cron integration, API docs, and unit/e2e tests.
- **Phase 4**: AI-safe config — stage schema files to `DATA_HOME/assistant/env-schema/` during apply flow, add context include to `assets/opencode.jsonc`, and create `config-diagnostics.md` skill with explicit prohibition against reading actual `.env` values.

## Test plan

- [x] `cd packages/admin && npm run check` — 0 errors, 0 warnings
- [x] `bun run guardian:test` — 12 tests pass
- [x] `bun run admin:test:unit` — 600 tests pass
- [x] Three independent code reviewers approved Phase 4 implementation
- [x] All P4-T1, P4-T2, P4-T3 acceptance criteria verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)