### PR TITLE
docs: align memory docs with current implementation

### DIFF
--- a/core/assistant/README.md
+++ b/core/assistant/README.md
@@ -6,7 +6,7 @@ Containerized [OpenCode](https://opencode.ai) instance that is the AI brain of O
 
 - Process messages forwarded by the guardian
 - Call Admin API endpoints to inspect and manage the stack
-- Maintain persistent memory via the memory service (embedded Qdrant + SQLite)
+- Maintain persistent memory via the memory service (SQLite + `sqlite-vec`)
 - Execute user-defined skills, tools, and plugins
 
 ## Isolation model

--- a/docs/memory-privacy.md
+++ b/docs/memory-privacy.md
@@ -4,7 +4,7 @@ This document describes what the OpenPalm memory service stores, where it stores
 
 ## What is stored
 
-The memory service stores **extracted facts**, not raw conversation transcripts. When the assistant sends a conversation to the memory service, an LLM extracts discrete factual statements (e.g., "User prefers TypeScript over JavaScript") and stores each one individually.
+The memory service stores **extracted facts**, not raw conversation transcripts. When the assistant sends conversation text to the memory service with `infer: true`, an LLM extracts discrete factual statements (for example, "User prefers TypeScript over JavaScript") and stores each one individually. When `infer: false`, the submitted text is stored directly as a single memory.
 
 Each memory record in the SQLite database contains:
 
@@ -37,7 +37,9 @@ Associated WAL and SHM files (`memory.db-wal`, `memory.db-shm`) may also exist a
 The memory configuration file is stored at:
 - `~/.local/share/openpalm/memory/default_config.json` (or `.dev/data/memory/default_config.json` in dev mode)
 
-**No data is synced to any cloud service.** The SQLite database and all memory data remain entirely on the host machine.
+The config file still uses a mem0-shaped JSON structure for compatibility, but the running service is OpenPalm's Bun-based memory API backed by SQLite and `sqlite-vec`.
+
+**No data is synced to any cloud service by OpenPalm itself.** The SQLite database and all memory data remain entirely on the host machine.
 
 ## What is NOT stored
 
@@ -76,18 +78,6 @@ The assistant service (OpenCode) sends conversation messages to the configured c
 OpenPalm does not default to any specific model. The setup wizard requires the operator to choose a provider and model before the stack starts. This ensures the operator makes a conscious decision about where their data is processed.
 
 ## How to view stored memories
-
-### Admin API
-
-List memories for a user (requires admin token):
-
-```bash
-# List all memories
-curl -X POST http://localhost:8100/admin/memory/filter \
-  -H "x-admin-token: YOUR_ADMIN_TOKEN" \
-  -H "Content-Type: application/json" \
-  -d '{"user_id": "default_user"}'
-```
 
 ### Memory service API (direct)
 
@@ -139,7 +129,7 @@ docker compose start memory
 
 ### Option 2: Admin API reset endpoint
 
-The admin API provides a reset endpoint that deletes the SQLite database file and any legacy Qdrant data. The memory container must be restarted afterwards:
+The admin API provides a reset endpoint that deletes the configured SQLite-backed vector store files and any legacy Qdrant data. The memory container must be restarted afterwards:
 
 ```bash
 curl -X POST http://localhost:8100/admin/memory/reset-collection \
@@ -157,6 +147,11 @@ curl -X DELETE http://localhost:8765/api/v1/memories/ \
   -H "Content-Type: application/json" \
   -d '{"memory_id": "MEMORY_UUID"}'
 
+# Delete multiple memories by ID
+curl -X DELETE http://localhost:8765/api/v1/memories/ \
+  -H "Content-Type: application/json" \
+  -d '{"memory_ids": ["UUID1", "UUID2"]}'
+
 # Delete all memories for a user
 curl -X DELETE http://localhost:8765/api/v1/memories/ \
   -H "Content-Type: application/json" \
@@ -170,6 +165,7 @@ The assistant has a `memory-delete` tool that can remove individual memories by 
 ## Data retention
 
 - **No automatic expiry.** Memories persist indefinitely until explicitly deleted.
-- **No automatic cleanup.** The memory service does not prune old or low-confidence memories on its own.
+- **No automatic cleanup inside the memory service.** The storage API does not prune old or low-confidence memories on its own.
+- **Assistant-side hygiene may curate assistant-created memories.** When memory automation is enabled in the assistant plugin, duplicate and stale memories can be reviewed and pruned conservatively.
 - **User controls all data.** The operator has full control over when memories are created, updated, and deleted. The SQLite database is a regular file on disk that can be backed up, inspected, or removed at any time.
 - **History is retained alongside memories.** The mutation history table records all ADD, UPDATE, and DELETE operations. Resetting the collection (Option 2 above) or deleting the database file (Option 1) also removes all history records.

--- a/docs/technical/api-spec.md
+++ b/docs/technical/api-spec.md
@@ -838,7 +838,11 @@ Response:
 
 ### `GET /admin/connections/export/mem0`
 
-Exports the mem0 config derived from current connection profiles and assignments.
+Exports the compatibility-formatted memory config derived from current
+connection profiles and assignments. The route name remains `export/mem0`
+for backward compatibility, but the generated file configures OpenPalm's
+Bun-based memory service.
+
 Returns the config as a downloadable JSON file (`mem0-config.json`).
 
 Auth: admin token or setup token.
@@ -876,9 +880,13 @@ error semantics as their `/admin/connections/*` counterparts.
 
 ## Memory Configuration
 
-Manage the Memory (mem0) LLM and embedding provider configuration stored
-at `DATA_HOME/memory/default_config.json`. Changes are persisted to disk
-and pushed to the running Memory container via its REST API (`PUT /api/v1/config/`).
+Manage the Memory service LLM and embedding provider configuration stored at
+`DATA_HOME/memory/default_config.json`. The persisted file still uses a
+mem0-shaped JSON schema for compatibility, but the running service is the
+OpenPalm Bun-based memory API backed by SQLite and `sqlite-vec`.
+
+Changes are persisted to disk and pushed to the running Memory container via
+its REST API (`PUT /api/v1/config/`).
 
 ### `GET /admin/memory/config`
 
@@ -893,7 +901,7 @@ Response:
     "mem0": {
       "llm": { "provider": "openai", "config": { "model": "gpt-4o-mini", "temperature": 0.1, "max_tokens": 2000, "api_key": "env:OPENAI_API_KEY" } },
       "embedder": { "provider": "openai", "config": { "model": "text-embedding-3-small", "api_key": "env:OPENAI_API_KEY" } },
-      "vector_store": { "provider": "qdrant", "config": { "collection_name": "memory", "path": "/data/qdrant", "embedding_model_dims": 1536 } }
+      "vector_store": { "provider": "sqlite-vec", "config": { "collection_name": "memory", "db_path": "/data/memory.db", "embedding_model_dims": 1536 } }
     },
     "memory": { "custom_instructions": "" }
   },
@@ -929,12 +937,12 @@ Response:
 ```
 
 - `dimensionMismatch` is `true` when the new config's embedding dimensions
-  differ from the previously persisted config. Requires a collection reset.
+  differ from the previously persisted config. Requires a vector-store reset.
 - `dimensionWarning` is a human-readable message when `dimensionMismatch` is `true`.
 
 Error responses:
 
-- `400 bad_request` -- Missing or invalid `mem0` structure.
+- `400 bad_request` -- Missing or invalid memory config structure.
 
 ### `POST /admin/memory/models`
 
@@ -982,9 +990,11 @@ Error responses:
 
 ### `POST /admin/memory/reset-collection`
 
-Deletes the embedded Qdrant vector data so the memory service recreates the
-collection with the correct embedding dimensions on next restart. This is a
-destructive operation that deletes all stored memories.
+Deletes the configured vector store data so the memory service recreates it
+with the correct embedding dimensions on next restart. In the current default
+configuration this removes the SQLite database and companion WAL/SHM files; it
+also removes any legacy Qdrant directory if one exists. This is a destructive
+operation that deletes all stored memories.
 
 Response:
 
@@ -1001,7 +1011,7 @@ collection to be created.
 
 Error responses:
 
-- `502 collection_reset_failed` -- Failed to delete the Qdrant data directory.
+- `502 collection_reset_failed` -- Failed to delete the configured vector-store data.
 
 ### Ollama Integration Notes
 
@@ -1015,7 +1025,7 @@ When using Ollama as the LLM or embedding provider with Memory:
    to reach `http://host.docker.internal:11434`. Docker Desktop (Mac/Windows)
    adds this automatically.
 
-3. **Embedding dimensions**: The Qdrant collection must be created with
+3. **Embedding dimensions**: The configured vector store must use
    `embedding_model_dims` matching the embedding model's output dimensions
    (e.g., 1024 for `qwen3-embedding:0.6b`, 768 for `nomic-embed-text`).
    A dimension mismatch causes silent insert failures.

--- a/docs/technical/directory-structure.md
+++ b/docs/technical/directory-structure.md
@@ -67,7 +67,7 @@ STATE_HOME (~/.local/state/openpalm/)
 DATA_HOME (~/.local/share/openpalm/)
 ├── stack.env                # Source of truth for host-detected infrastructure config
 ├── admin/                   # Admin runtime home (varlock state, future per-admin cache)
-├── memory/              # Memory persistent data (SQLite + embedded Qdrant)
+├── memory/              # Memory persistent data (SQLite + sqlite-vec, legacy Qdrant dir may exist)
 ├── assistant/               # System-managed OpenCode config (opencode.jsonc, AGENTS.md)
 ├── opencode/                # OpenCode data directory
 ├── guardian/                 # Guardian runtime data
@@ -109,7 +109,7 @@ system-managed by admin logic.
 | Host Path | Container Path | Mode | Purpose |
 |-----------|---------------|------|---------|
 | `$DATA_HOME/memory` | `/data` | rw | Memory service data |
-| `$DATA_HOME/memory/default_config.json` | `/app/default_config.json` | ro | mem0 LLM/embedder config |
+| `$DATA_HOME/memory/default_config.json` | `/app/default_config.json` | ro | Memory service LLM/embedder config |
 
 ### Assistant (OpenCode Runtime)
 

--- a/docs/technical/environment-and-mounts.md
+++ b/docs/technical/environment-and-mounts.md
@@ -58,7 +58,7 @@ The source-of-truth core Caddyfile is system-managed at
 | Host Path | Container Path | Mode | Purpose |
 |---|---|---|---|
 | `$DATA_HOME/memory` | `/data` | rw | Memory service persistent data |
-| `$DATA_HOME/memory/default_config.json` | `/app/default_config.json` | ro | mem0 LLM/embedder config |
+| `$DATA_HOME/memory/default_config.json` | `/app/default_config.json` | ro | Memory service LLM/embedder config |
 
 Memory is a Bun.js service (`@openpalm/memory`) using sqlite-vec for vector
 storage — all data is stored within `$DATA_HOME/memory/`.
@@ -238,9 +238,9 @@ They are written into `DATA_HOME/stack.env` and staged to `STATE_HOME/artifacts/
 
 | Variable | Default | Purpose |
 |---|---|---|
-| `MEMORY_DATA_DIR` | `/data` | Base directory for Qdrant data and history DB |
-| `HOME` | `/data` | Home directory used by mem0 for user-scoped defaults |
-| `MEM0_DIR` | `/data/.mem0` | mem0 runtime directory for local state/config |
+| `MEMORY_DATA_DIR` | `/data` | Base directory for memory database and related files |
+| `HOME` | `/data` | Writable home directory inside the memory container |
+| `MEM0_DIR` | `/data/.mem0` | Compatibility directory retained for config/runtime interoperability |
 | `OPENAI_API_KEY` | pass-through | Required for embedding generation |
 | `OPENAI_BASE_URL` | pass-through | Custom OpenAI-compatible base URL |
 

--- a/docs/technical/opencode-configuration.md
+++ b/docs/technical/opencode-configuration.md
@@ -200,18 +200,35 @@ These call the Memory API service at `$MEMORY_API_URL`.
 
 ### memory-context.ts
 
-The memory-context plugin provides "compound memory" — the assistant
-accumulates knowledge over time and recalls it automatically. It hooks into two
-OpenCode lifecycle events:
+The memory-context plugin provides "compound memory" - the assistant
+accumulates knowledge over time and recalls it automatically. The current
+implementation hooks into the full session lifecycle, not just compaction:
 
-**`experimental.session.compacting`** — When the context window is compacted,
-the plugin searches Memory for relevant context (user preferences, project
-decisions) and injects it into the compaction output so that memories survive
-the context window reset.
+- **`session.created`** - retrieves scoped memories in parallel and injects a
+  session context block. Retrieval includes personal semantic and procedural
+  memory, project-scoped context, stack procedural guidance (`user_id=openpalm`),
+  optional global procedures (`user_id=global`), and recent episodic notes.
+- **`command.executed`** - extracts stable preference signals from user commands
+  and stores them as personal semantic memory when novel.
+- **`session.idle`** - periodically consolidates tracked tool outcomes into
+  procedural learnings.
+- **`tool.execute.before`** - injects scoped procedural guidance before admin
+  and project/code tools, then records which memories were injected so outcome
+  feedback can be applied afterward.
+- **`tool.execute.after`** - reinforces or downranks injected memories based on
+  tool success or failure.
+- **`session.deleted`** - stores episodic summaries and cleans up per-session
+  tracking state.
+- **`experimental.session.compacting`** - injects only high-signal semantic and
+  procedural memories plus compact session state so useful context survives
+  window resets.
+- **`shell.env`** - injects `MEMORY_API_URL` and `MEMORY_USER_ID` into the
+  shell environment so child processes and tools can resolve the memory service.
 
-**`shell.env`** — Injects `MEMORY_API_URL` and `MEMORY_USER_ID` into
-the shell environment so that child processes and tools can resolve the memory
-service.
+Memory retrieval is intentionally scope-aware rather than hard-isolated by
+default. Writes include explicit identity (`user_id`, `agent_id`, `app_id`,
+optional `run_id`), while retrieval defaults to broader `user_id` scope unless
+more specific filters are provided.
 
 ---
 

--- a/packages/assistant-tools/opencode/skills/memory/SKILL.md
+++ b/packages/assistant-tools/opencode/skills/memory/SKILL.md
@@ -18,11 +18,11 @@ The memory service runs in the OpenPalm stack:
 
 | Service | Port | Role |
 |---------|------|------|
-| `memory` | 8765 | Lightweight FastAPI wrapper around the mem0 Python SDK with embedded Qdrant (file-based vectors) |
+| `memory` | 8765 | Bun-based OpenPalm memory API backed by SQLite and `sqlite-vec` |
 
 The assistant connects to `http://memory:8765` via REST API. The service
-wraps the mem0 SDK directly — no MCP SSE, no SQLAlchemy ORM.
-Configuration is read from `/app/default_config.json`.
+wraps the local `@openpalm/memory` library and preserves the older REST surface
+for compatibility. Configuration is read from `/app/default_config.json`.
 
 ## Available Tools
 

--- a/packages/assistant-tools/opencode/skills/openpalm-admin/SKILL.md
+++ b/packages/assistant-tools/opencode/skills/openpalm-admin/SKILL.md
@@ -14,7 +14,7 @@ OpenPalm runs as a Docker Compose stack with these services:
 | Service | Role |
 |---------|------|
 | **caddy** | Reverse proxy, TLS termination, access control |
-| **memory** | Memory service — lightweight mem0 SDK wrapper with embedded Qdrant |
+| **memory** | Memory service - Bun-based OpenPalm memory API backed by SQLite and `sqlite-vec` |
 | **assistant** | This OpenCode instance (you) |
 | **guardian** | Message routing with HMAC verification |
 | **admin** | Control plane API (protects Docker socket) |


### PR DESCRIPTION
## Summary
- update memory documentation to reflect the current Bun-based SQLite + sqlite-vec implementation instead of older mem0/Qdrant wording
- document the actual memory-context plugin lifecycle hooks and scoped retrieval behavior used by the assistant
- clarify memory config compatibility, reset behavior, and privacy/retention details across operator-facing docs and assistant skills