### PR TITLE
Use latest release tag instead of main for default install ref

### DIFF
--- a/core/assistant/Dockerfile
+++ b/core/assistant/Dockerfile
@@ -92,7 +92,7 @@ ENV BUN_INSTALL=/usr/local
 RUN curl -fsSL https://bun.sh/install | bash -s -- "$BUN_VERSION"
 ENV BUN_INSTALL=/home/opencode/.bun
 ENV BUN_INSTALL_CACHE_DIR=/home/opencode/.cache/bun/install
-ENV PATH="/home/opencode/.bun/bin:/usr/local/bin:$PATH"
+ENV PATH="/home/opencode/.local/bin:/home/opencode/.bun/bin:/usr/local/bin:$PATH"
 
 # Install agentikit CLI; fix permissions so bun-compiled binary is readable
 # by unprivileged users (bun-compiled binaries read themselves at runtime).

--- a/core/assistant/entrypoint.sh
+++ b/core/assistant/entrypoint.sh
@@ -41,6 +41,7 @@ ensure_home_layout() {
     /home/opencode \
     /home/opencode/.cache \
     /home/opencode/.config/opencode \
+    /home/opencode/.local/bin \
     /home/opencode/.local/state/opencode \
     /home/opencode/.local/share/opencode \
     /work \

--- a/packages/cli/src/commands/install.ts
+++ b/packages/cli/src/commands/install.ts
@@ -16,8 +16,30 @@ import { ensureStagedState, fullComposeArgs, buildManagedServiceNames } from '..
 import { createSetupServer } from '../setup-wizard/server.ts';
 import { buildInstallServiceNames, buildDeployStatusEntries } from './install-services.ts';
 
-const DEFAULT_INSTALL_REF = 'main';
 const SETUP_WIZARD_PORT = Number(process.env.OPENPALM_SETUP_PORT) || 8100;
+
+const REPO_OWNER = 'itlackey';
+const REPO_NAME = 'openpalm';
+
+/**
+ * Resolves the latest release tag from GitHub. Falls back to the CLI package
+ * version (prefixed with 'v') so the install never silently defaults to 'main'
+ * which produces an un-pinned 'latest' image tag.
+ */
+async function resolveDefaultInstallRef(): Promise<string> {
+  try {
+    const res = await fetch(
+      `https://github.com/${REPO_OWNER}/${REPO_NAME}/releases/latest`,
+      { redirect: 'manual', signal: AbortSignal.timeout(10000) },
+    );
+    const location = res.headers.get('location') ?? '';
+    const match = location.match(/\/tag\/(v[0-9]+\.[0-9]+\.[0-9]+[^\s]*)$/);
+    if (match?.[1]) return match[1];
+  } catch {
+    // Network error — fall through to package version
+  }
+  return cliPkg.version ? `v${cliPkg.version}` : 'main';
+}
 
 export default defineCommand({
   meta: {
@@ -32,8 +54,7 @@ export default defineCommand({
     },
     version: {
       type: 'string',
-      description: 'Install specific repository ref (default: main)',
-      default: DEFAULT_INSTALL_REF,
+      description: 'Install specific repository ref (default: latest release)',
     },
     start: {
       type: 'boolean',
@@ -52,9 +73,10 @@ export default defineCommand({
     },
   },
   async run({ args }) {
+    const version = args.version || await resolveDefaultInstallRef();
     await bootstrapInstall({
       force: args.force,
-      version: args.version,
+      version,
       noStart: !args.start,
       noOpen: !args.open,
       file: args.file,


### PR DESCRIPTION
## Summary
This PR updates the install command to default to the latest GitHub release tag instead of the hardcoded 'main' branch, ensuring installations use pinned release versions rather than unpredictable 'latest' image tags.

## Key Changes
- **Dynamic release resolution**: Replaced static `DEFAULT_INSTALL_REF = 'main'` with a new `resolveDefaultInstallRef()` function that:
  - Fetches the latest release from GitHub using the releases/latest redirect
  - Extracts the version tag from the redirect location header
  - Falls back to the CLI package version (prefixed with 'v') if the network request fails
  - Only uses 'main' as a last resort if no version is available
  
- **Updated CLI help text**: Changed the `--version` flag description from "Install specific repository ref (default: main)" to "Install specific repository ref (default: latest release)"

- **PATH environment variable fix**: Added `/home/opencode/.local/bin` to the Docker PATH in the assistant container to ensure locally installed binaries are discoverable

- **Directory initialization**: Added `/home/opencode/.local/bin` to the list of directories created during container startup to support local binary installations

## Implementation Details
- The `resolveDefaultInstallRef()` function uses a 10-second timeout on the GitHub API request to prevent hanging installations
- The function gracefully handles network errors and falls back to the package version, ensuring the install command never silently defaults to 'main'
- The version resolution happens asynchronously in the command's run handler, maintaining backward compatibility with explicit `--version` arguments

https://claude.ai/code/session_01PNX8cN1KWQsc4bA5vYE691