### PR TITLE
fix: override stale OPENPALM_IMAGE_TAG env var during install and fix…

### DIFF
--- a/packages/cli/src/commands/install.ts
+++ b/packages/cli/src/commands/install.ts
@@ -3,7 +3,7 @@ import { join } from 'node:path';
 import { rm } from 'node:fs/promises';
 import cliPkg from '../../package.json' with { type: 'json' };
 import { defaultConfigHome, defaultDataHome, defaultStateHome, defaultWorkDir } from '../lib/paths.ts';
-import { ensureSecrets, ensureStackEnv } from '../lib/env.ts';
+import { ensureSecrets, ensureStackEnv, resolveRequestedImageTag } from '../lib/env.ts';
 import { ensureDirectoryTree, fetchAsset, runDockerCompose, openBrowser } from '../lib/docker.ts';
 import {
   ensureOpenCodeConfig, ensureOpenCodeSystemConfig, ensureAdminOpenCodeConfig, FilesystemAssetProvider,
@@ -169,7 +169,10 @@ export async function bootstrapInstall(options: InstallOptions): Promise<void> {
   );
 
   await ensureSecrets(configHome);
-  await ensureStackEnv(configHome, dataHome, stateHome, workDir, options.version);
+  // Derive the image tag from the resolved version so that stale or
+  // architecture-suffixed OPENPALM_IMAGE_TAG env vars don't leak in.
+  const imageTag = resolveRequestedImageTag(options.version) ?? undefined;
+  await ensureStackEnv(configHome, dataHome, stateHome, workDir, options.version, imageTag);
   // Seed OpenCode config — non-fatal since performSetup() also seeds these
   try {
     const fsAssets = new FilesystemAssetProvider(dataHome);

--- a/packages/cli/src/lib/env.ts
+++ b/packages/cli/src/lib/env.ts
@@ -96,6 +96,11 @@ export MEMORY_AUTH_TOKEN=${randomBytes(32).toString('hex')}
 
 /**
  * Creates or updates the stack.env bootstrap file.
+ *
+ * When `imageTagOverride` is provided (e.g. derived from --version during
+ * install), it takes precedence over both the OPENPALM_IMAGE_TAG env var
+ * and the repo-ref heuristic. This prevents stale or architecture-suffixed
+ * env vars (e.g. "latest-arm64") from leaking into the stack.
  */
 export async function ensureStackEnv(
   configHome: string,
@@ -103,10 +108,11 @@ export async function ensureStackEnv(
   stateHome: string,
   workDir: string,
   repoRef: string,
+  imageTagOverride?: string,
 ): Promise<void> {
   const dataStackEnv = join(dataHome, 'stack.env');
   const stagedStackEnv = join(stateHome, 'artifacts', 'stack.env');
-  const explicitImageTag = process.env.OPENPALM_IMAGE_TAG;
+  const explicitImageTag = imageTagOverride ?? process.env.OPENPALM_IMAGE_TAG;
   const hasExplicitImageTag = explicitImageTag !== undefined && explicitImageTag !== '';
   if (!(await Bun.file(dataStackEnv).exists())) {
     const defaultImageTag = hasExplicitImageTag

--- a/packages/cli/src/main.test.ts
+++ b/packages/cli/src/main.test.ts
@@ -151,7 +151,7 @@ describe('cli main', () => {
     }
   });
 
-  it('uses main as the default install ref for bootstrap asset downloads', async () => {
+  it('resolves version-pinned install ref (falls back to CLI package version)', async () => {
     const base = mkdtempSync(join(tmpdir(), 'openpalm-install-'));
     const configHome = join(base, 'config');
     const dataHome = join(base, 'data');
@@ -169,6 +169,12 @@ describe('cli main', () => {
     process.env.OPENPALM_STATE_HOME = stateHome;
     process.env.OPENPALM_WORK_DIR = workDir;
 
+    // Read the CLI package version to verify pinning behaviour
+    const cliPkg = JSON.parse(
+      readFileSync(new URL('../package.json', import.meta.url), 'utf8'),
+    ) as { version: string };
+    const expectedRef = `v${cliPkg.version}`;
+
     mockDockerCli();
     globalThis.fetch = mock(async (input: string | URL) => {
       const url = String(input);
@@ -176,13 +182,14 @@ describe('cli main', () => {
       if (url.endsWith('/health')) {
         throw new TypeError('fetch failed');
       }
-      if (url.includes('/main/assets/docker-compose.yml')) {
+      // Respond to version-pinned asset URLs
+      if (url.includes('/docker-compose.yml')) {
         return new Response('services: {}\n', { status: 200 });
       }
-      if (url.includes('/main/assets/Caddyfile')) {
+      if (url.includes('/Caddyfile')) {
         return new Response(':80 {\n}\n', { status: 200 });
       }
-      if (url.includes('/main/assets/secrets.env.schema') || url.includes('/main/assets/stack.env.schema')) {
+      if (url.includes('/secrets.env.schema') || url.includes('/stack.env.schema')) {
         return new Response('KEY=string\n', { status: 200 });
       }
       return new Response('', { status: 503 });
@@ -193,12 +200,15 @@ describe('cli main', () => {
     try {
       await main(['install', '--no-start', '--force', '--no-open']);
 
-      expect(fetchedUrls).toContain(
-        'https://raw.githubusercontent.com/itlackey/openpalm/main/assets/docker-compose.yml',
-      );
-      expect(fetchedUrls).toContain(
-        'https://raw.githubusercontent.com/itlackey/openpalm/main/assets/Caddyfile',
-      );
+      // Verify that assets were fetched using the version-pinned ref, not 'main'
+      const composeUrl = fetchedUrls.find((u) => u.includes('/docker-compose.yml'));
+      expect(composeUrl).toBeDefined();
+      expect(composeUrl).toContain(expectedRef);
+      expect(composeUrl).not.toContain('/main/');
+
+      const caddyUrl = fetchedUrls.find((u) => u.includes('/Caddyfile'));
+      expect(caddyUrl).toBeDefined();
+      expect(caddyUrl).toContain(expectedRef);
     } finally {
       rmSync(base, { recursive: true, force: true });
     }


### PR DESCRIPTION
… test

- Add imageTagOverride parameter to ensureStackEnv() so the install command can pass the version-derived tag directly, preventing stale or architecture-suffixed env vars (e.g. "latest-arm64") from leaking into stack.env.
- Install command now resolves the image tag from --version and passes it explicitly to ensureStackEnv.
- Update test to expect version-pinned refs instead of 'main'.

https://claude.ai/code/session_01PNX8cN1KWQsc4bA5vYE691