### PR TITLE
fix: bump @openpalm/lib to 0.9.8 and chain CLI publish after lib

### DIFF
--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -9,12 +9,20 @@ on:
         description: 'Version to publish (e.g. 1.2.0, minor, prerelease). Leave empty for auto patch bump.'
         required: false
         type: string
+  workflow_run:
+    workflows: ['Publish @openpalm/lib']
+    types: [completed]
+    branches: [main]
 permissions:
   contents: write
   id-token: write
 
 jobs:
   publish:
+    # Run when lib publish succeeds, or on direct triggers (push/dispatch)
+    if: >-
+      github.event_name != 'workflow_run' ||
+      github.event.workflow_run.conclusion == 'success'
     uses: ./.github/workflows/publish-npm-package.yml
     with:
       package-dir: packages/cli

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openpalm/lib",
-  "version": "0.9.6",
+  "version": "0.9.8",
   "license": "MPL-2.0",
   "type": "module",
   "description": "Shared control-plane library for OpenPalm — lifecycle, staging, secrets, channels, connections, scheduler",


### PR DESCRIPTION
The published openpalm@0.9.9 depends on @openpalm/lib@0.9.6, which does NOT export performSetupFromConfig. That export was only added in @openpalm/lib@0.9.7. This causes a SyntaxError on `bunx openpalm@latest`.

Root cause: the CLI and lib publish workflows run concurrently with no ordering guarantee, so the CLI can be published before lib is updated.

Fix:
- Bump @openpalm/lib to 0.9.8 to ensure next publish includes all current exports (performSetupFromConfig, stack-spec, etc.)
- Add workflow_run trigger to publish-cli.yml so the CLI automatically republishes whenever lib is published, ensuring version alignment.

https://claude.ai/code/session_01PNX8cN1KWQsc4bA5vYE691