### PR TITLE
docs: add plan to simplify OpenPalm via akm-cli + shared stash

### DIFF
--- a/docs/plans/configuration-simplification.md
+++ b/docs/plans/configuration-simplification.md
@@ -1,0 +1,186 @@
+# Configuration & management simplification
+
+## Context
+
+This document is the next pass after `simplify-via-akm.md` and its upstream-issue drafts. That plan removes whole services (memory, scheduler container, varlock); this one targets the **operational surface** the user and admin actually touch — environment variables, mount points, vault layout, setup wizard, schema files, lifecycle commands, and the small directory tree under `~/.openpalm/`.
+
+Two parallel audits drove this document:
+
+- **Configuration audit** — mapped every env var, every mount, every config file, every install/upgrade hop. Headline: there are 100+ environment variables in flight, ~17 distinct port/bind-address pairs, 4 separate `.env.schema` files (all varlock-shaped), an `init` helper container that exists only to chown directories, and a `config/guardian/` directory that is empty.
+- **Legacy / drift audit** — found the docs that no longer match the code (memory-privacy.md, foundations.md, environment-and-mounts.md, opencode-configuration.md, api-spec.md), the roadmap clutter under `.github/roadmap/0.10.0/`, and a clean blast-radius mapping for what is safe to delete now vs. what waits on the akm migration.
+
+The goal of this pass: **shrink the operator's mental model without changing the security model.** Loopback bindings, HMAC channel boundaries, vault file modes, the admin/assistant/guardian trust split — all stay. What changes is the number of knobs you have to know about to install, upgrade, or extend the stack.
+
+## Today's surface (audit summary)
+
+| Surface | Count | Notes |
+|---|---|---|
+| Environment variables | **~100+** | 5 identity tokens, 9 port + 8 bind-address pairs, ~33 `OP_CAP_*` capability vars, ~14 raw provider keys, ~13 channel vars per channel, owner metadata, paths, OAuth credentials. |
+| Distinct port bindings | 9 services × 2 (port + bind-addr) | Each service that listens on the host has its own `OP_*_PORT` + `OP_*_BIND_ADDRESS` pair. Default everywhere is `127.0.0.1`. |
+| Mount points (core compose) | ~21 | Includes single-file mounts (`auth.json`, `apprise.yml`), shared workspace, vault/{stack,user}, logs/opencode, AKM stash, etc. |
+| Schema files (`.env.schema`) | 4 | `stack.env.schema`, `guardian.env.schema`, `user.env.schema`, `redact.env.schema` — all written for varlock. |
+| Vault directories | 3 | `vault/stack/` (operator), `vault/user/` (user secrets), `vault/redact.env.schema` (varlock). |
+| Helper containers | 2 | `init` (chown), `docker-socket-proxy` (admin only). |
+| Capability layer | `OP_CAP_*` (33 vars) | Derived from `stack.yml` + raw provider keys. The memory service was the main multi-provider consumer; with it gone, only voice addons need this layer. |
+
+Cross-cutting observations from the audits:
+
+1. **Double-bookkeeping**: provider keys are stored as themselves (`OPENAI_API_KEY`) **and** resolved into `OP_CAP_LLM_API_KEY`/`OP_CAP_EMBEDDINGS_API_KEY`. Memory consumed the resolved form; assistant reads either path; voice consumes capabilities. With memory gone, only voice still needs the capability layer.
+2. **Schema files are varlock baggage.** Four `.env.schema` files exist purely to feed `varlock load`/`varlock scan`. Once varlock is gone they have no consumer.
+3. **`config/guardian/`** is created at install but contains nothing today. Either populate it (and document why) or delete it.
+4. **`OP_SETUP_COMPLETE`** is a sentinel env var. The simpler signal is "does `stack.env` exist?" or a stand-alone `vault/stack/.installed` file.
+5. **`OP_OPENCODE_PASSWORD`** is wired through compose but the assistant runs with `OPENCODE_AUTH=false` because it's loopback-only. Currently dead.
+6. **`MEMORY_USER_ID`, `SYSTEM_LLM_*`, `EMBEDDING_*`** all disappear with the memory service.
+7. **Dual setup orchestrators** (CLI wizard + admin UI) both call `performSetup()` — fine; just confirm the path stays single.
+8. **Doc drift** is severe in five technical docs and `README.md`. They still describe the memory service, scheduler service, varlock, and OpenViking as core concepts.
+
+## Debate — perspectives and tensions
+
+The proposals below were stress-tested against four perspectives. Where they disagreed, the resolution is recorded as a compromise rather than a winner.
+
+### Security engineer
+- Trust boundaries are non-negotiable: loopback by default, HMAC for channel inbound, separate guardian stash for HMAC secrets, mode-0600 vault files, separate admin / assistant / memory / channel tokens.
+- Don't merge admin and assistant tokens — different blast radii (admin can mutate the stack; assistant can talk to the LLM).
+- Migrating `vault/user/` into `akm vault` inside the **shared** assistant↔admin stash is acceptable **because** the existing `vault/user/` is already mounted into the assistant container (read-only). Same trust level, fewer files. Operator-only secrets stay in `vault/stack/` regardless.
+- `OP_OPENCODE_PASSWORD` is currently dead but should remain wired for the (rare) deployment that exposes assistant beyond loopback. Keep the compose plumbing; drop the wizard prompt.
+
+### SRE / DevOps
+- The `OP_CAP_*` family is indirection without payoff once memory is gone. Voice keeps a small `TTS_*` / `STT_*` subset; everything else reads provider keys directly.
+- 17 port/bind-address pairs is excessive when ~99% of installs use loopback. One `OP_BIND_ADDRESS=127.0.0.1` global default plus per-service port numbers (left as compose defaults) is enough; document a single override for LAN exposure.
+- The `init` container exists to chown a handful of directories. With fewer services to seed, replace with a `bash` block in the lifecycle command (or a tiny tini-style entrypoint in the assistant container that fixes its own paths).
+- Schema files are dead with varlock — delete them.
+
+### Product / UX
+- Wizard asks too many questions. With OpenCode handling OAuth provider auth (Anthropic, Google, GitHub Models) natively, the only manual entries are raw API-key providers (OpenAI, Groq, etc.) and per-channel credentials.
+- `OWNER_NAME`/`OWNER_EMAIL` are wizard outputs but no service reads them at runtime — they're metadata for the admin UI display. Move to `akm vault` under `vault:owner` or to the user's stash profile; drop the env vars.
+- Drop `OP_SETUP_COMPLETE` — presence of `stack.env` already gates everything.
+- `data/setup-token.txt` is wizard-session-only; keep it in process memory and a temp file under `${XDG_RUNTIME_DIR}` instead of a stash-resident file.
+
+### Maintainer
+- Fewer files written at install = less drift risk. Each new file is a forever-maintenance commitment.
+- Stop maintaining double paths for provider credentials. One canonical name per provider, consumed directly.
+- Doc drift will recur unless docs are short and reference the live compose / schema as the source of truth. Cap each technical doc at a single page.
+- The `.github/roadmap/0.10.0/` directory has a half-dozen items already obsolete; mark them superseded in one batch rather than letting them rot.
+
+### Tensions and how they resolved
+| Tension | Resolution |
+|---|---|
+| SRE wants to drop `OP_CAP_*`; voice still needs capability resolution. | Keep a tiny `TTS_*` / `STT_*` subset (named directly), drop `OP_CAP_LLM_*` / `OP_CAP_EMBEDDINGS_*` / `OP_CAP_RERANKING_*` / `OP_CAP_SLM_*` entirely. |
+| UX wants fewer setup questions; SE notes initial provider choice is hard to defer. | Defer to OpenCode's native auth for OAuth providers; keep one prompt for raw API-key providers. |
+| User vault → akm vault concentrates secrets in the shared stash. | Acceptable because the existing `vault/user/` is *already* mounted into the assistant. The trust boundary doesn't change. |
+| Dropping `OP_SETUP_COMPLETE` means lifecycle code can't ask "is install done?". | Substitute "does `stack.env` exist with the system-token block populated?" — a stronger signal anyway. |
+
+## Recommendations
+
+Each item is sized for an independent change. Numbered for implementation tracking; not all need to land together. Items align with `simplify-via-akm.md` — items already covered there are linked, not repeated.
+
+### Environment variables — drop or collapse
+
+1. **Delete the `OP_CAP_*` family** (~33 vars). Memory was the main consumer; it's going away. Voice keeps a focused `TTS_PROVIDER` / `TTS_MODEL` / `TTS_API_KEY` / `STT_PROVIDER` / `STT_MODEL` / `STT_API_KEY` subset, named directly. Assistant and admin read provider keys natively (OpenCode handles provider routing).
+2. **Delete `SYSTEM_LLM_*`, `EMBEDDING_*`, `MEMORY_USER_ID`, `MEMORY_DATA_DIR`, `MEMORY_CONFIG_PATH`, `MEM0_DIR`, `MEMORY_API_URL`, `MEMORY_AUTH_TOKEN`, `OP_MEMORY_TOKEN`, `OP_MEMORY_PORT`, `OP_MEMORY_BIND_ADDRESS`** — all gone with the memory service. (Already implied by `simplify-via-akm.md`; documented here for completeness.)
+3. **Delete varlock vars** — `OP_VARLOCK_*`, plus the `redact.env.schema`. (Already in `simplify-via-akm.md`.)
+4. **Collapse port + bind-address pairs.** One global `OP_BIND_ADDRESS=127.0.0.1` (advanced override). Per-service port numbers stay as compose defaults that operators rarely touch; the few services that *are* user-touchable on the host (admin) keep their explicit `OP_ADMIN_PORT`. This drops ~12 env vars.
+5. **Drop `OP_SETUP_COMPLETE`.** Presence of populated `vault/stack/stack.env` (or a sibling `.installed` sentinel) is the marker.
+6. **Drop the wizard prompt for `OP_OPENCODE_PASSWORD`.** Keep the compose plumbing for the rare LAN-exposed assistant case but make it operator-edits-stack.env-directly, not a setup question.
+7. **Move `OWNER_NAME` / `OWNER_EMAIL` out of env into `akm vault`** under a `vault:owner` entry. Admin UI reads via `akm vault show owner` — same trust as today (admin can read its own vault).
+8. **`data/setup-token.txt` becomes ephemeral.** Generated in-process during the wizard; written to `${XDG_RUNTIME_DIR}` (cleared on reboot) instead of the stash. No more stale tokens after install.
+
+Net env reduction estimate: **~60–70 vars dropped from the average install**, leaving ~30 actively meaningful ones (provider keys, image tag, admin port + bind, owner-supplied channel creds, OAuth paths).
+
+### Mount points — tighten
+
+9. **Drop the `init` container.** Replace with a small `entrypoint.sh` in the assistant container (it already runs as `OP_UID:OP_GID`); on first boot it `mkdir -p` the few dirs left and chowns them. Fewer compose lines, one fewer image to manage.
+10. **Drop `${OP_HOME}/data/memory`** mount (memory service gone).
+11. **Drop the scheduler service mounts** (folded into assistant per `simplify-via-akm.md`).
+12. **Drop `${OP_HOME}/config/memory/memory.conf.json`** mount (memory config gone).
+13. **Drop `${OP_HOME}/config/guardian/`** (currently empty). If guardian ever needs config, prefer reading it from its own stash (`${OP_HOME}/data/guardian-stash`) rather than recreating a config dir.
+14. **Single-file mounts.** Keep `auth.json` and `apprise.yml` as single-file binds — they're correct as-is; documented here so we don't accidentally collapse them into the dir mount.
+
+### Vault layout — collapse
+
+15. **Migrate `vault/user/` into `akm vault`** inside the shared assistant↔admin stash. (Already in `simplify-via-akm.md` §6.) This pass adds: drop the `vault/user/` host directory entirely after migration; drop the `user.env.schema` file with varlock.
+16. **Delete the four `.env.schema` files** (`stack.env.schema`, `guardian.env.schema`, `user.env.schema`, `redact.env.schema`). Replace runtime validation with a small in-house env-format check (already in `simplify-via-akm.md` for `validate.ts`).
+17. **Keep `vault/stack/` as-is**: HMAC channel secrets, admin / assistant tokens, OAuth `auth.json`. Operator-only.
+
+### Setup wizard — fewer questions
+
+18. **Defer OAuth providers to OpenCode.** OpenCode already handles Anthropic, Google, GitHub Models. The wizard prompts only for raw API-key providers (OpenAI-compatible endpoints, Groq, Mistral, etc.) — single page, one provider chosen at install.
+19. **Drop the capability prompts.** With `OP_CAP_*` gone, the wizard no longer asks "which provider for embeddings vs. LLM vs. SLM vs. reranking" — the assistant's OpenCode config covers it.
+20. **Channel addons stay as-is.** Per-channel credentials are unavoidable.
+21. **Owner-info page** stays (one page) but writes to the akm vault profile, not env.
+
+### Lifecycle — simplify
+
+22. **`openpalm install` becomes**: write `vault/stack/stack.env` (system tokens + provider keys), generate `vault/stack/guardian.env` (HMAC secrets), seed the akm stash (skills, commands, agents, owner profile, user vault), `docker compose up -d`. The bullet count in lifecycle.ts shrinks accordingly.
+23. **`openpalm update`** stays as it is (compose reconcile, no image pull).
+24. **`openpalm upgrade`** stays as it is (image pull + recreate). The `~/.cache/openpalm/rollback/` snapshot continues; `${OP_HOME}/backups/` is verified-and-removed if nothing writes to it.
+25. **The `OP_DOCKER_SOCK` override** stays (some hosts need it) but defaults to `/var/run/docker.sock` and stops being a wizard question.
+
+### Documentation — rewrite the five drift sources
+
+26. **Delete `docs/technical/memory-privacy.md`** — service is gone.
+27. **Rewrite `docs/technical/foundations.md`** — drop memory / scheduler / varlock sections; document the new admin↔assistant↔guardian topology with akm and shared stash.
+28. **Rewrite `docs/technical/environment-and-mounts.md`** — single tables for the surviving env vars and mounts.
+29. **Rewrite `docs/technical/api-spec.md`** — drop scheduler HTTP endpoints, drop varlock validate; add the file-based admin → scheduler control plane.
+30. **Edit `docs/technical/opencode-configuration.md`** — drop the memory env table.
+31. **Edit `docs/technical/core-principles.md`** — drop "varlock as foundational tech".
+32. **Edit `README.md`** — drop the varlock sentence; mention akm.
+33. **Edit `AGENTS.md`** — collapse the memory/scheduler entries.
+34. **Mark superseded** under `.github/roadmap/0.10.0/`: `openviking-integration.md`, `knowledge-system-roadmap.md`, varlock-related items in `cleanup/` and `plans/`.
+
+## What stays — explicit non-changes
+
+These are security- or capability-load-bearing and should **not** be touched in this pass:
+
+- HMAC channel-inbound flow (guardian validates `X-Signature`).
+- Loopback bindings as the default for every host port.
+- `vault/stack/` as operator-owned with mode-0600 files.
+- Separate admin / assistant / guardian / channel-HMAC tokens (different trust scopes).
+- Single-file mounts of `auth.json` and `apprise.yml` (correct as-is).
+- The admin's `${OP_HOME} → /openpalm rw` mount (it manages the stack — by design).
+- The docker-socket-proxy in front of the admin's Docker access.
+- `OP_UID` / `OP_GID` set at install (file ownership correctness).
+
+## Phased implementation order
+
+The phases line up so each leaves the stack bootable:
+
+| Phase | Change | Depends on |
+|---|---|---|
+| **A. Doc rewrite** (#26–#34) | Bring docs into alignment with the post-akm reality. Pure prose; no code risk. | Nothing. |
+| **B. Schema-file deletion** (#16) | Delete the four `.env.schema` files and the redactor schema generator. | varlock removal in `simplify-via-akm.md`. |
+| **C. Capability-layer removal** (#1, #19) | Drop `OP_CAP_*` env vars; rewire voice addon to use direct names; drop wizard pages. | memory removal in `simplify-via-akm.md`. |
+| **D. Vault collapse** (#15) | Migrate `vault/user/` → akm vault; delete the host directory. | akm vault adoption in `simplify-via-akm.md`. |
+| **E. Owner-info migration** (#7) | Move owner name/email out of env into akm vault. | Phase D. |
+| **F. Port-pair collapse** (#4) | Drop the per-service `*_BIND_ADDRESS` vars; introduce `OP_BIND_ADDRESS` global. | Phase A (so docs match). |
+| **G. Init-container removal** (#9) | Replace with entrypoint chown. | Memory & scheduler service deletion. |
+| **H. Sentinel cleanup** (#5, #6, #8) | Drop `OP_SETUP_COMPLETE`, deprecate the wizard's password prompt, move the setup token to runtime. | Phase A. |
+
+Phases A–C are independent and can land first; D–E need akm vault wired; F–H are polish.
+
+## Verification
+
+End-to-end checks per phase:
+
+- **A (docs)**: Spot-check each rewritten doc against the live compose + schema. No grep hit for `core/memory`, `MEMORY_API_URL`, `varlock`, `OpenViking`, `core/scheduler` in `docs/`, `README.md`, `AGENTS.md`.
+- **B (schemas)**: `find .openpalm -name '*.env.schema'` returns nothing. `openpalm install` succeeds. `openpalm validate` is either gone or runs an akm-vault check without invoking varlock.
+- **C (capabilities)**: `grep -r OP_CAP_ packages/` returns no consumers. Voice addon round-trip works using `TTS_*` / `STT_*` only. Memory tests gone.
+- **D (vault)**: `vault/user/` directory absent; `akm vault list` shows the migrated entries; assistant `akm_vault load` populates env for a tool call.
+- **E (owner)**: `akm vault show owner` returns name/email; admin UI reads it; no `OWNER_*` env in any service.
+- **F (ports)**: `OP_BIND_ADDRESS=192.168.1.10 openpalm update` flips every host-bound port to that address; default keeps loopback. `OP_ADMIN_PORT` still overridable per-service.
+- **G (init)**: `docker compose ps` shows no `init` container. Fresh install on a clean directory still creates and chowns `data/`, `logs/`, `data/stash/`, `data/guardian-stash/`.
+- **H (sentinels)**: First-boot detection works without `OP_SETUP_COMPLETE`. `${OP_HOME}/data/setup-token.txt` does not exist after a successful install.
+
+Cross-cutting:
+
+- `bun test` in `packages/lib`, `packages/cli`, `packages/admin`, `packages/scheduler` passes after each phase.
+- Channel HMAC inbound still rejects spoofed messages (negative test).
+- `docker compose -f .openpalm/stack/core.compose.yml config` lints clean throughout.
+
+## Out of scope
+
+- Replacing OpenCode's auth model (`auth.json` mount stays).
+- Replacing the docker-socket-proxy.
+- Changing the trust boundaries between admin / assistant / guardian / channel.
+- Multi-host deployments (this stack is LAN-first by design; keep it that way).
+- Anything that requires upstream akm changes beyond what `docs/plans/upstream-issues/` already lists.

--- a/docs/plans/simplify-via-akm.md
+++ b/docs/plans/simplify-via-akm.md
@@ -23,14 +23,16 @@ Remaining capability gaps (LLM fact inference, multi-user scoping, feedback even
 - **OpenViking.** Mark `.github/roadmap/0.10.0/openviking*` and `.github/roadmap/0.10.0/knowledge-system-roadmap.md` as superseded; remove any registry/addon scaffolding for it. Knowledge browsing is now `akm wiki` + `akm search --type knowledge`.
 - **Varlock.** Delete `packages/cli/src/lib/varlock.ts`, `packages/lib/src/control-plane/redact-schema.ts`, varlock-specific paths in `packages/lib/src/control-plane/secret-backend.ts` and `packages/lib/src/control-plane/validate.ts`, and the `cli` commands `validate` / `scan` (or rewrite them as no-ops / akm-vault-aware checks). Remove `.openpalm/vault/redact.env.schema`, the `VARLOCK_VERSION` constants, and the binary download/cache logic in `packages/cli/src/commands/install.ts`. Remove tests under `packages/lib/src/control-plane/env-schema-validation.test.ts` and `secret-backend.test.ts` for the deleted paths.
 
-### 2. Fold the scheduler into the assistant container
+### 2. Fold the scheduler into the assistant container; drop its HTTP API
 - Delete `core/scheduler/Dockerfile` and the `scheduler` service block from `.openpalm/stack/core.compose.yml`.
 - Add a tiny supervisor entrypoint to the assistant container (e.g., `core/assistant/entrypoint.sh` that uses `dumb-init` or a Bun supervisor script) that starts:
   1. The OpenCode runtime on `:4096`.
-  2. `bun packages/scheduler/src/server.ts` on `:8090`, bound only to the assistant container's loopback.
+  2. `bun packages/scheduler/src/server.ts` as a background process **with no exposed port** — the scheduler runs purely as a file-watching automation engine inside the assistant container.
 - Both processes share `${OP_HOME}/config`, `${OP_HOME}/data`, `${OP_HOME}/logs`, and the stash mount — already mounted into the assistant container today.
-- Admin currently calls `http://scheduler:8090`; rewire to `http://assistant:8090`. Update env/var defaults in `packages/admin/`. The assistant container exposes both `4096` and `8090` on `assistant_net`.
-- Keep `packages/scheduler/` (the package) — only the *service container* and Dockerfile go away. The package is consumed by the supervised subprocess.
+- **Admin no longer talks to the scheduler over HTTP.** Admin already mounts `${OP_HOME}/config` rw and now has direct write access to `${OP_HOME}/config/automations/*.yml`. The scheduler subprocess inside the assistant container watches that directory (already supported via the existing `startWatching` path in `packages/scheduler/src/scheduler.ts`) and picks up adds / edits / removes immediately. No API call, no token, no port mapping.
+- **Manual triggers and execution logs become file-based too.** Admin reads execution logs from the shared `${OP_HOME}/logs/` mount it already has. Manual triggers are expressed by writing a small "trigger" sentinel file (e.g., `${OP_HOME}/data/scheduler/triggers/<automation>.run`) that the scheduler watches; the scheduler executes the named automation and removes the sentinel. This keeps the entire admin → scheduler control plane on the filesystem.
+- The HTTP server in `packages/scheduler/src/server.ts` becomes a no-op (or is deleted): keep `getSchedulerStatus`, `getLoadedAutomations`, `getExecutionLog`, `triggerAutomation` as plain library calls used by the file-watcher and (optionally) the assistant via an OpenCode tool, but stop binding any port.
+- Keep `packages/scheduler/` (the package) — only the *service container*, the Dockerfile, and the HTTP layer go away. The package's croner loop and YAML parser are reused as the supervised subprocess.
 
 ### 3. Install `akm` in the trusted containers; share a stash between admin and assistant; give guardian its own
 Each trusted container — **guardian**, **assistant** (which now also runs scheduler), **admin** — gets `akm-cli` installed at a pinned version in its Dockerfile (`bun add -g akm-cli@<pin>` or equivalent), plus a bind-mount of an appropriate stash with `AKM_STASH_DIR` set accordingly:
@@ -70,15 +72,15 @@ Every capability the deleted memory/scheduler/varlock layers offered is mapped t
 |---|---|---|
 | **LLM fact extraction** (`infer: true` extracted atomic facts from raw text). | **Periodic `akm index` run.** Once enrichment is folded into akm's index process upstream (see Recommended upstream enhancements §1), OpenPalm just needs to run `akm index` on a cadence — akm picks up any memories pending inference and processes them according to its global config. No bespoke OpenPalm prompt or work queue. | `${OP_HOME}/config/automations/akm-index.yml` (new) — small `assistant`-action automation that shells `akm index`. Bundled config in the stash enables enrichment. |
 | **Multi-user / multi-agent / multi-run scoping.** | **Frontmatter-based scoping** written by an OpenCode plugin. Plugin attaches `user`, `agent`, `run`, `channel` to every `akm_remember` call as YAML frontmatter; search filters via `akm search --type memory --filter user=…`. | New `packages/assistant-tools/opencode/plugins/memory-scope.ts`. |
-| **Programmatic / REST API** for non-OpenCode callers. | **Not needed.** Channel adapters never called memory directly — they go through guardian → assistant. The (now in-container) scheduler runs enrichment by shelling `akm index` locally. Admin manages memories through the `akm` CLI inside its own container, against the shared stash. | n/a — removed. |
+| **Programmatic / REST API** for non-OpenCode callers. | **Not needed.** Channel adapters never called memory directly — they go through guardian → assistant. The (now in-container) scheduler runs enrichment by shelling `akm index` locally. Admin manages memories through the `akm` CLI inside its own container, against the shared stash. Admin → scheduler is filesystem-based (write YAML, scheduler watches), not HTTP. | n/a — removed. |
 | **Memory feedback** (`memory-feedback` tool). | **Direct call to `akm feedback`** once it accepts any valid ref upstream (Recommended upstream enhancements §3). The OpenCode plugin wraps it as `akm_feedback` — no custom frontmatter writing. | `akm-opencode` plugin (already loaded); thin call-site in `packages/assistant-tools`. |
 | **Memory events stream** (`memory-events` tool). | **Dropped.** With enrichment running inside `akm index`, OpenPalm no longer needs an event stream as a work queue. No equivalent surface is added. | n/a — removed. |
 | **Automatic session-start retrieval with token budget** (the old `memory-context.ts` plugin). | **Slim plugin** subscribed to `session.created` that runs `akm curate --limit N --for-agent` against the current session's scope and injects results via `experimental.chat.system.transform`. Budget controlled by `OP_CONTEXT_BUDGET_CHARS`. | New `packages/assistant-tools/opencode/plugins/session-start-context.ts` (replaces deleted `memory-context.ts`). |
 | **Entity-relation / graph memory.** | **Periodic `akm index` run, same as enrichment.** Once graph building is folded into akm's index process upstream (Recommended upstream enhancements §7), the same scheduled `akm index` automation builds and refreshes the graph based on akm config. | Same `akm-index.yml` automation as enrichment. |
 | **Varlock validation/scan/redact.** | **Replaced by:** (a) `akm vault` enforces secret hygiene for user secrets at write time (mode-0600 files, never echoed); (b) a small log-redactor in `packages/lib/src/control-plane/logger.ts` masks values for env keys matching `_TOKEN`/`_SECRET`/`_KEY`/`_PASSWORD`; (c) `validate` and `scan` CLI commands either go away or become thin wrappers around `akm vault list` + a name-pattern check. | `packages/lib/src/control-plane/logger.ts` (new redactor); CLI commands edited or removed. |
-| **History / audit trail of mutations** (memory had `history.db`; varlock had schema-driven audits). | **Best-effort via stash filesystem + `akm save` git history.** When the user opts into a git-backed stash, `akm save` produces a per-asset commit history that admin can surface via plain `git log` inside the stash directory. No first-class CLI history is added upstream. | Stash convention; admin UI calls out to `git -C` inside the shared stash. |
+| **History / audit trail of mutations** (memory had `history.db`; varlock had schema-driven audits). | **Direct call to `akm history`** once it lands upstream (Recommended upstream enhancements §5). Admin's history view shells `akm history --since <ts> --format json` against the shared stash. For real-time observers (e.g., notifications on new memories), `akm events tail` (Recommended upstream enhancements §4) is the natural fit. | Admin UI; no OpenPalm-side log to maintain. |
 | **macOS sqlite-vec / varlock binary fragility.** | **Not an issue** — akm runs inside Linux containers on every host. Varlock is gone. | n/a. |
-| **Scheduler triggers from outside** (admin used to POST to `scheduler:8090`). | Same HTTP API, served by the assistant container on port 8090. Admin updates its base URL. | `packages/admin/` env defaults; scheduler subprocess inside assistant container. |
+| **Scheduler triggers from outside** (admin used to POST to `scheduler:8090`). | **No HTTP at all.** Admin writes automation YAML to `${OP_HOME}/config/automations/`; scheduler watches the directory and reloads. Manual triggers happen by dropping a sentinel file in `${OP_HOME}/data/scheduler/triggers/`; execution logs are read from `${OP_HOME}/logs/`. Admin's existing rw mounts on `config/`, `data/`, and `logs/` are sufficient. | `packages/admin/` UI/services switch from HTTP client to filesystem ops; scheduler `startWatching` covers reload; small sentinel-file watcher added. |
 | **Guardian operator data** (HMAC channel secrets, policies). | **Guardian's own persisted stash** at `${OP_HOME}/data/guardian-stash`. Channel secrets live as an `akm vault` inside that stash, loaded at guardian startup; not readable by assistant or admin. | `${OP_HOME}/data/guardian-stash/` (new host directory); bind-mounted only into guardian. |
 
 ## Files to modify
@@ -95,11 +97,11 @@ Delete:
 - OpenViking roadmap PRDs at `.github/roadmap/0.10.0/openviking*` and `.github/roadmap/0.10.0/knowledge-system-roadmap.md` (mark superseded if not deleted).
 
 Modify:
-- `.openpalm/stack/core.compose.yml` — remove `memory` and `scheduler` services; mount `${OP_HOME}/data/stash` (rw) into admin at `/akm` and confirm assistant mount unchanged; mount `${OP_HOME}/data/guardian-stash` (rw) into guardian at `/akm` as a *separate* host directory; set `AKM_STASH_DIR` accordingly in each container; expose `:8090` from assistant on `assistant_net`.
+- `.openpalm/stack/core.compose.yml` — remove `memory` and `scheduler` services; mount `${OP_HOME}/data/stash` (rw) into admin at `/akm` and confirm assistant mount unchanged; mount `${OP_HOME}/data/guardian-stash` (rw) into guardian at `/akm` as a *separate* host directory; set `AKM_STASH_DIR` accordingly in each container. **No port 8090 exposure** — scheduler is purely in-process inside the assistant container.
 - `core/guardian/Dockerfile`, `core/assistant/Dockerfile`, `core/admin/Dockerfile` — install pinned `akm-cli`. Assistant Dockerfile additionally pulls `packages/scheduler/` and adds the supervisor entrypoint.
 - `core/assistant/entrypoint.sh` (new) — supervises OpenCode + scheduler subprocess.
-- `packages/scheduler/src/server.ts` — accept `127.0.0.1` bind for in-container loopback; otherwise unchanged.
-- `packages/admin/` — change scheduler base URL default from `http://scheduler:8090` to `http://assistant:8090`.
+- `packages/scheduler/src/server.ts` — strip the HTTP layer; keep the croner loop, YAML loader, and the file-watcher; add a sentinel-file watcher under `${OP_HOME}/data/scheduler/triggers/` for manual triggers.
+- `packages/admin/` — replace the scheduler HTTP client with filesystem operations: write/edit YAML in `${OP_HOME}/config/automations/`, drop sentinel files for triggers, read logs from `${OP_HOME}/logs/`. Drop the scheduler base URL and admin → scheduler auth token from config.
 - `packages/cli/src/commands/install.ts` — remove varlock download/install path.
 - `packages/cli/src/commands/validate.ts`, `packages/cli/src/commands/scan.ts` — rewrite as akm-vault checks or remove.
 - `packages/lib/src/control-plane/secret-backend.ts` — drop varlock provider; user secrets path runs through akm vault.
@@ -130,7 +132,7 @@ End-to-end checks from a clean `openpalm install` on the simplified stack:
 2. **akm presence.** `docker compose exec guardian akm --version`, `docker compose exec assistant akm --version`, `docker compose exec admin akm --version` all succeed and report the same pinned version.
 3. **Shared admin/assistant stash.** `docker compose exec assistant akm remember "verify-shared-stash"` then `docker compose exec admin akm search verify-shared-stash --type memory --format json` returns the same memory. Repeat write from admin, read from assistant.
 4. **Guardian stash isolation.** `docker compose exec guardian akm search verify-shared-stash` returns no results (different stash). `docker compose exec guardian akm vault list` shows guardian's own HMAC entries. `docker compose exec assistant ls -la /home/opencode/.akm` does not include any guardian-only artifact.
-5. **Co-located scheduler.** Inside the assistant container, both `:4096` (OpenCode) and `:8090` (scheduler) are listening; admin can reach `http://assistant:8090/health`. If either subprocess dies, the supervisor restarts it.
+5. **Co-located scheduler with no HTTP.** Inside the assistant container, only `:4096` (OpenCode) is listening; the scheduler subprocess is running but binds no port. If either subprocess dies, the supervisor restarts it. From admin, write a new YAML into `${OP_HOME}/config/automations/test.yml` and observe (within a couple of seconds) that the scheduler picks it up — visible in `${OP_HOME}/logs/scheduler.log` and in `getLoadedAutomations()`. Drop a sentinel file in `${OP_HOME}/data/scheduler/triggers/test.run` and observe the automation fires once and the sentinel is removed.
 6. **Channel round-trip.** Send a chat message → guardian → assistant → assistant uses `akm_remember` → memory file appears in `${OP_HOME}/data/stash/memories/` with scope frontmatter set by `memory-scope.ts`.
 7. **Index automation.** With akm config enabling enrichment, drop a memory with `inferred: false` into the stash, manually trigger `akm-index` via the in-container scheduler API, observe atomic facts written with `inferred: true` (work done by `akm index`, not OpenPalm).
 8. **Session-start retrieval.** Start a fresh assistant session and inspect the system prompt transform — curated context appears without any user message yet, capped at `OP_CONTEXT_BUDGET_CHARS`.
@@ -165,18 +167,28 @@ Selection criteria:
    - Proposal: allow feedback on **any** valid ref. Vault feedback can store an aggregated count without leaking values. Hybrid ranking already reads frontmatter for boosts, so the wiring is small.
    - General value: closes the relevance-learning loop uniformly across asset types instead of asking consumers to remember which refs are "feedback-eligible".
 
-4. **Pluggable secret backends and rotation for `akm vault`** *(future consideration, not confirmed).*
+4. **`akm events` — read/tail asset-mutation events.**
+   - Today: there is no documented event stream; consumers have to scrape mtimes or build their own log.
+   - Proposal: an append-only `events.jsonl` written by the CLI on every add / update / delete / feedback / index pass, surfaced via `akm events list [--since ts]` and `akm events tail`. Same JSON envelope conventions as the rest of the CLI.
+   - General value: foundational for any external observer (sync, replication, audit, dashboards) that needs to react to stash changes without polling. Pairs naturally with the periodic-`akm index` pattern for downstream consumers.
+
+5. **`akm history` — surface the existing mutation history.**
+   - Today: akm writes mutation history internally; there is no first-class command to read it.
+   - Proposal: `akm history [--ref <ref>] [--since ts]` returning per-asset and stash-wide history with the same JSON envelope.
+   - General value: closes the audit-trail need without forcing every downstream tool to build its own. Distinct from `akm events`: history is per-asset state changes; events is the realtime stream.
+
+6. **Pluggable secret backends and rotation for `akm vault`** *(future consideration, not confirmed).*
    - Today: vault is `.env`-style files only; no rotation, no remote secret-manager integration. Tracks upstream issue #190.
    - Proposal: a backend interface with built-in adapters for the OS keychain and age-encrypted files, plus hooks for external managers (`pass`, 1Password CLI, AWS/GCP Secrets Manager, HashiCorp Vault). `akm vault rotate <key>` and `akm vault backend set <name>`.
    - General value: makes `akm vault` a credible production secret store rather than a developer-laptop convenience.
    - Status: deferred — flagged for evaluation in a future release; not part of the immediate roadmap.
 
-5. **Graph-build as part of `akm index`, controlled by global config.**
+7. **Graph-build as part of `akm index`, controlled by global config.**
    - Today: akm's hybrid search is purely document-level. Graph reasoning across memories is left to consumers.
    - Proposal: same shape as the inference change — extend the index process to optionally extract entities and relations from `memory:` and `knowledge:` assets and persist a queryable graph file under the stash. Toggle via `akm config set index.graph true|false`. Search ranking consults the graph when it exists.
    - General value: covers the gap that motivates separate graph-memory services in many stacks. Folding it into indexing means users don't manage a separate `graph build` cadence — one `akm index` run keeps everything in sync.
 
-6. **Single configurable LLM block reused across index passes.**
+8. **Single configurable LLM block reused across index passes.**
    - Today: the optional LLM is wired for indexing-time metadata enrichment but is not exposed as the engine for the new inference / graph passes above.
    - Proposal: one `akm.llm` config block, reused by every LLM-needing pass inside `akm index`, with explicit per-pass opt-out.
    - General value: one place to configure, consistent behaviour across enrichment, inference, and graph building.
@@ -184,8 +196,6 @@ Selection criteria:
 ### Explicitly **not** proposed for `akm-cli`
 
 These were considered and rejected (per maintainer direction). Documenting them so they aren't reproposed:
-- **`akm events`** — no asset-mutation event stream. Consumers should drive work via scheduled `akm index` runs, not event subscription.
-- **`akm history`** — no first-class history command. Users who want one can rely on `akm save`'s git-backed stash and read history with plain `git log`.
 - **`akm serve` / any HTTP daemon** — akm will not serve HTTP. The CLI is the only programmatic surface; consumers either embed it as a subprocess or share the stash directory.
 - **`akm workflow schedule` / cron triggers** — out of scope for akm. Scheduling stays in the host (cron, systemd, the host app's scheduler).
 

--- a/docs/plans/simplify-via-akm.md
+++ b/docs/plans/simplify-via-akm.md
@@ -118,7 +118,13 @@ Modify:
 - `${OP_HOME}/config/automations/akm-index.yml` — new, installed by setup; runs `akm index` on a cadence so akm's enrichment + graph passes process pending memories.
 - `${OP_HOME}/data/guardian-stash/` — new host directory; seeded by setup with guardian's HMAC-secrets vault.
 - `vault/stack/stack.env` template — drop `MEMORY_API_URL`, `MEMORY_AUTH_TOKEN`, mem0/embedder vars; drop `OP_VARLOCK_*`.
-- `docs/technical/foundations.md`, `environment-and-mounts.md`, `opencode-configuration.md`, `api-spec.md`, `core-principles.md` — refresh mount/service tables; remove memory/scheduler/varlock sections; document `akm` presence in trusted containers.
+- `docs/technical/foundations.md`, `environment-and-mounts.md`, `opencode-configuration.md`, `api-spec.md`, `core-principles.md` — refresh mount/service tables; remove memory/scheduler/varlock sections; document `akm` presence in trusted containers. *(Detailed rewrites and the `docs/technical/memory-privacy.md` deletion are covered in `docs/plans/configuration-simplification.md` §26–§34.)*
+- Top-level `package.json` workspaces — drop `core/memory` and `packages/memory` entries.
+- Test cleanup that follows from the deletions:
+  - Delete `packages/assistant-tools/opencode/viking-context.integration.test.ts`, `packages/assistant-tools/opencode/viking-tools.validation.test.ts`, `packages/assistant-tools/opencode/memory-context.integration.test.ts`.
+  - Delete `packages/admin/e2e/memory-config.pw.ts` and `packages/admin/e2e/openviking-smoke.pw.ts`.
+  - Rewrite `packages/admin/e2e/scheduler.pw.ts` to drive the file-based control plane (write YAML / drop sentinel / read logs) instead of the deleted HTTP API.
+- `.openpalm/vault/README.md` — drop the varlock and `redact.env.schema` mentions.
 
 ## Existing utilities to reuse (no new code)
 
@@ -215,3 +221,9 @@ Documented so they aren't re-proposed:
 - Channel adapters — they keep their current contract (sign + POST to guardian); no akm, no stash mount.
 - Log-redaction inside akm — that is a host-app concern (handled in OpenPalm's `logger.ts`), not something akm should own.
 - Sharing a stash between guardian and the user-facing services — guardian's stash is intentionally isolated; do not collapse them.
+
+## Companion documents
+
+- **`docs/plans/configuration-simplification.md`** — the next pass that targets the operator-facing surface (env vars, mounts, vault layout, schema files, init container, setup wizard, doc drift). Anything in §6 of this plan about user vault → `akm vault`, anything about removing `MEMORY_*` / `OP_CAP_*` env vars, and the doc-rewrite list are all expanded there with a phased execution order.
+- **`docs/plans/upstream-issues/akm-cli-issues.md`** — drafts for `itlackey/akm`. Reduced to three items after the live 0.7.x reality-check: the LLM-proxy hook, vault backends (deferred), and a scope-flag inconsistency bug.
+- **`docs/plans/upstream-issues/akm-plugins-issues.md`** — drafts for `itlackey/akm-plugins`. Four items: the plugin-side LLM proxy shim, two bug fixes, parity meta-issue.

--- a/docs/plans/simplify-via-akm.md
+++ b/docs/plans/simplify-via-akm.md
@@ -4,7 +4,9 @@
 
 OpenPalm today ships a vector **memory** service (`core/memory` + `packages/memory`, sqlite-vec, mem0-style fact extraction), a planned **OpenViking** structured-knowledge addon, a **scheduler** sidecar service, and a **varlock**-backed secret-validation/redaction layer. Several of these predate the maturity of akm-cli.
 
-As of akm 0.5.0 / 0.6.0-rc1 and `akm-opencode` 0.5.x, akm covers exactly the memory/knowledge/skills/vault jobs as first-class asset types — `memory`, `knowledge`, `wiki`, `skill`, `command`, `agent`, `script`, `vault`, `workflow` — with hybrid search, opaque refs, frontmatter on memories, `akm remember`, `akm import`, `akm curate`, `akm wiki`, `akm vault`, and an opencode plugin that auto-harvests memory on `tool.execute.after` / `stop` / `session.idle`. OpenPalm already mounts `${OP_HOME}/data/stash` to `/home/opencode/.akm` and already loads `akm-opencode` as the second OpenCode plugin in the assistant and admin containers.
+As of akm-cli **0.7.4** and `akm-opencode` **0.7.3** (verified against the live repos on 2026-05-06), akm covers exactly the memory/knowledge/skills/vault jobs as first-class asset types — `memory`, `knowledge`, `wiki`, `skill`, `command`, `agent`, `script`, `vault`, `workflow`, `lesson` — with hybrid search, opaque refs, frontmatter on memories (shipped in 0.6.0), `akm remember`, `akm import`, `akm curate`, `akm wiki`, `akm vault`, `akm events list|tail`, `akm history`, and the new `akm proposal | reflect | propose | distill` verbs. The opencode plugin (now 20 tools, hooks `session.created` / `chat.message` / `experimental.chat.system.transform` / `tool.execute.before|after` / `experimental.session.compacting` / `shell.env` / `stop` / `session.idle` / `session.compacted` / `session.deleted` / `permission.ask` / `command.execute.before`) auto-harvests memory and supports `AKM_INDEX_ON_SESSION_END`, `AKM_CONTEXT_BUDGET_CHARS`, `AKM_SCOPE_KEYS`, and `AKM_RETROSPECTIVE_NEGATIVE_PATTERN`. OpenPalm already mounts `${OP_HOME}/data/stash` to `/home/opencode/.akm` and already loads `akm-opencode` as the second OpenCode plugin in the assistant and admin containers.
+
+Crucially: **`akm index --enrich` shipped in 0.7.3** and runs metadata enhancement, memory inference, and graph extraction inside one indexing pass. That single feature absorbs most of what previous revisions of this plan proposed as upstream work. The remaining upstream items are tightened to two real proposals (LLM-fallback hook and vault backends) plus two plugin bug fixes.
 
 The goal is to collapse the stack onto **akm + the shared stash + the assistant container** so OpenPalm carries less code and fewer moving parts:
 
@@ -35,7 +37,7 @@ Remaining capability gaps (LLM fact inference, multi-user scoping, feedback even
 - Keep `packages/scheduler/` (the package) — only the *service container*, the Dockerfile, and the HTTP layer go away. The package's croner loop and YAML parser are reused as the supervised subprocess.
 
 ### 3. Install `akm` in the trusted containers; share a stash between admin and assistant; give guardian its own
-Each trusted container — **guardian**, **assistant** (which now also runs scheduler), **admin** — gets `akm-cli` installed at a pinned version in its Dockerfile (`bun add -g akm-cli@<pin>` or equivalent), plus a bind-mount of an appropriate stash with `AKM_STASH_DIR` set accordingly:
+Each trusted container — **guardian**, **assistant** (which now also runs scheduler), **admin** — gets `akm-cli` installed at a pinned version (target **0.7.4 or newer**) in its Dockerfile (`bun add -g akm-cli@^0.7.4` or equivalent). The akm-opencode plugin no longer auto-installs the CLI as of 0.7.x — it expects `akm` on PATH and errors out with install instructions if missing — so an explicit Dockerfile install is required, not optional. Each container gets a bind-mount of an appropriate stash with `AKM_STASH_DIR` set accordingly:
 
 | Container | Host source | In-container path | Mode | Notes |
 |---|---|---|---|---|
@@ -70,13 +72,15 @@ Every capability the deleted memory/scheduler/varlock layers offered is mapped t
 
 | Gap | Resolution | Where it lives |
 |---|---|---|
-| **LLM fact extraction** (`infer: true` extracted atomic facts from raw text). | **Periodic `akm index` run.** Once enrichment is folded into akm's index process upstream (see Recommended upstream enhancements §1), OpenPalm just needs to run `akm index` on a cadence — akm picks up any memories pending inference and processes them according to its global config. No bespoke OpenPalm prompt or work queue. | `${OP_HOME}/config/automations/akm-index.yml` (new) — small `assistant`-action automation that shells `akm index`. Bundled config in the stash enables enrichment. |
-| **Multi-user / multi-agent / multi-run scoping.** | **Frontmatter-based scoping** written by an OpenCode plugin. Plugin attaches `user`, `agent`, `run`, `channel` to every `akm_remember` call as YAML frontmatter; search filters via `akm search --type memory --filter user=…`. | New `packages/assistant-tools/opencode/plugins/memory-scope.ts`. |
-| **Programmatic / REST API** for non-OpenCode callers. | **Not needed.** Channel adapters never called memory directly — they go through guardian → assistant. The (now in-container) scheduler runs enrichment by shelling `akm index` locally. Admin manages memories through the `akm` CLI inside its own container, against the shared stash. Admin → scheduler is filesystem-based (write YAML, scheduler watches), not HTTP. | n/a — removed. |
-| **Memory feedback** (`memory-feedback` tool). | **Direct call to `akm feedback`** once it accepts any valid ref upstream (Recommended upstream enhancements §3). The OpenCode plugin wraps it as `akm_feedback` — no custom frontmatter writing. | `akm-opencode` plugin (already loaded); thin call-site in `packages/assistant-tools`. |
-| **Memory events stream** (`memory-events` tool). | **Dropped.** With enrichment running inside `akm index`, OpenPalm no longer needs an event stream as a work queue. No equivalent surface is added. | n/a — removed. |
-| **Automatic session-start retrieval with token budget** (the old `memory-context.ts` plugin). | **Slim plugin** subscribed to `session.created` that runs `akm curate --limit N --for-agent` against the current session's scope and injects results via `experimental.chat.system.transform`. Budget controlled by `OP_CONTEXT_BUDGET_CHARS`. | New `packages/assistant-tools/opencode/plugins/session-start-context.ts` (replaces deleted `memory-context.ts`). |
-| **Entity-relation / graph memory.** | **Periodic `akm index` run, same as enrichment.** Once graph building is folded into akm's index process upstream (Recommended upstream enhancements §7), the same scheduled `akm index` automation builds and refreshes the graph based on akm config. | Same `akm-index.yml` automation as enrichment. |
+| **LLM fact extraction** (`infer: true` extracted atomic facts from raw text). | **Periodic `akm index --enrich` run** (already shipped in akm 0.7.3). One scheduled automation runs `akm index --enrich` on the shared stash; akm handles inference, metadata enrichment, and graph extraction in a single pass — no OpenPalm-side prompt or work queue. | `${OP_HOME}/config/automations/akm-index.yml` (new) — small `assistant`-action automation that shells `akm index --enrich`. Configure cadence via cron expression in the YAML. |
+| **Multi-user / multi-agent / multi-run scoping.** | **Direct CLI flags + plugin env config.** akm 0.7.x ships `--user`, `--agent`, `--run`, `--channel` on `akm remember`; `akm search --filter <key>=<value>` and `akm show --scope <key>=<value>` for query-side filtering. The plugin already auto-attaches scope via `AKM_SCOPE_KEYS=user,agent,run,channel`. OpenPalm sets `AKM_SCOPE_KEYS` accordingly and lets the plugin do the work. | Configure `AKM_SCOPE_KEYS` in `core.compose.yml` for assistant; no new code. *(See upstream issue: scope-flag inconsistency on `search`/`show` and the matching plugin bug.)* |
+| **Programmatic / REST API** for non-OpenCode callers. | **Not needed.** Channel adapters never called memory directly — they go through guardian → assistant. The (now in-container) scheduler runs enrichment by shelling `akm index --enrich` locally. Admin manages memories through the `akm` CLI inside its own container, against the shared stash. Admin → scheduler is filesystem-based (write YAML, scheduler watches), not HTTP. | n/a — removed. |
+| **Memory feedback** (`memory-feedback` tool). | **Direct call to `akm feedback memory:<ref>`** — already supported in akm 0.7.x. The plugin's `akm_feedback` tool exposes it; OpenPalm just removes its old `memory-feedback` tool. *(See upstream issue: the akm-opencode plugin still has a stale guard skipping `memory:`/`vault:` refs — that's the only thing blocking it today.)* | `akm-opencode` plugin (already loaded); no OpenPalm-side feedback code. |
+| **Memory events stream** (`memory-events` tool). | **Direct call to `akm events list|tail`** — already shipped in akm 0.7.x as a durable `events.jsonl` with `--since`/`--type`/`--ref` and byte-offset cursors. Admin reads it for activity views; the scheduler can subscribe via `akm events tail`. | No OpenPalm-side stream. Admin shells `akm events`. |
+| **Automatic session-start retrieval with token budget** (the old `memory-context.ts` plugin). | **`akm-opencode` plugin native behaviour.** The plugin already subscribes to `session.created` and respects `AKM_CONTEXT_BUDGET_CHARS` (verified in 0.7.3). OpenPalm sets the env var and the old plugin is deleted. | `core.compose.yml` env for assistant; remove `packages/assistant-tools/opencode/plugins/memory-context.ts`. No replacement plugin needed. |
+| **Entity-relation / graph memory.** | **Periodic `akm index --enrich` run, same as inference.** Graph extraction is part of the enrich pass — same automation, no extra work. | Same `akm-index.yml` automation. |
+| **Asset-mutation history / audit trail.** | **Direct call to `akm history --since <ts> --include-proposals`** — already shipped in akm 0.7.x. Admin's history view shells the CLI and renders the JSON envelope. | Admin UI; no OpenPalm-side log. |
+| **Agent-proposed changes review** *(new capability)*. | **`akm propose` from the assistant + `akm proposal list|show|diff|accept|reject` for admin.** Shipped in akm 0.7.0. The assistant proposes durable stash changes; admin reviews and accepts/rejects via the file-based admin → scheduler control plane (write a YAML, scheduler shells `akm proposal accept <id>`). | Optional follow-up: surface this in admin UI. |
 | **Varlock validation/scan/redact.** | **Replaced by:** (a) `akm vault` enforces secret hygiene for user secrets at write time (mode-0600 files, never echoed); (b) a small log-redactor in `packages/lib/src/control-plane/logger.ts` masks values for env keys matching `_TOKEN`/`_SECRET`/`_KEY`/`_PASSWORD`; (c) `validate` and `scan` CLI commands either go away or become thin wrappers around `akm vault list` + a name-pattern check. | `packages/lib/src/control-plane/logger.ts` (new redactor); CLI commands edited or removed. |
 | **History / audit trail of mutations** (memory had `history.db`; varlock had schema-driven audits). | **Direct call to `akm history`** once it lands upstream (Recommended upstream enhancements §5). Admin's history view shells `akm history --since <ts> --format json` against the shared stash. For real-time observers (e.g., notifications on new memories), `akm events tail` (Recommended upstream enhancements §4) is the natural fit. | Admin UI; no OpenPalm-side log to maintain. |
 | **macOS sqlite-vec / varlock binary fragility.** | **Not an issue** — akm runs inside Linux containers on every host. Varlock is gone. | n/a. |
@@ -134,7 +138,7 @@ End-to-end checks from a clean `openpalm install` on the simplified stack:
 4. **Guardian stash isolation.** `docker compose exec guardian akm search verify-shared-stash` returns no results (different stash). `docker compose exec guardian akm vault list` shows guardian's own HMAC entries. `docker compose exec assistant ls -la /home/opencode/.akm` does not include any guardian-only artifact.
 5. **Co-located scheduler with no HTTP.** Inside the assistant container, only `:4096` (OpenCode) is listening; the scheduler subprocess is running but binds no port. If either subprocess dies, the supervisor restarts it. From admin, write a new YAML into `${OP_HOME}/config/automations/test.yml` and observe (within a couple of seconds) that the scheduler picks it up — visible in `${OP_HOME}/logs/scheduler.log` and in `getLoadedAutomations()`. Drop a sentinel file in `${OP_HOME}/data/scheduler/triggers/test.run` and observe the automation fires once and the sentinel is removed.
 6. **Channel round-trip.** Send a chat message → guardian → assistant → assistant uses `akm_remember` → memory file appears in `${OP_HOME}/data/stash/memories/` with scope frontmatter set by `memory-scope.ts`.
-7. **Index automation.** With akm config enabling enrichment, drop a memory with `inferred: false` into the stash, manually trigger `akm-index` via the in-container scheduler API, observe atomic facts written with `inferred: true` (work done by `akm index`, not OpenPalm).
+7. **Index automation.** Drop a memory into the stash; trigger `akm-index` via the file-based scheduler control plane (sentinel file). Observe `akm index --enrich` runs and produces atomic facts plus graph entries — work done by akm, not OpenPalm. `akm events tail` from any container shows the corresponding events.
 8. **Session-start retrieval.** Start a fresh assistant session and inspect the system prompt transform — curated context appears without any user message yet, capped at `OP_CONTEXT_BUDGET_CHARS`.
 9. **Vault.** `akm vault list` from inside assistant or admin shows entries previously in `${OP_HOME}/vault/user/*.env`. `akm_vault load` populates env for a tool call. Guardian's HMAC secrets are stored as an `akm vault` inside `${OP_HOME}/data/guardian-stash` and loaded at guardian startup; assistant and admin cannot list them.
 10. **No varlock.** `which varlock` fails inside every container; `~/.cache/openpalm/bin/varlock` is gone; `openpalm install` runs end-to-end without downloading any binary; logs containing values for `*_TOKEN`/`*_SECRET`/`*_KEY`/`*_PASSWORD` are masked by the in-house redactor.
@@ -144,89 +148,63 @@ End-to-end checks from a clean `openpalm install` on the simplified stack:
 
 ## Recommended upstream enhancements
 
-The plan above closes every gap inside OpenPalm. Some of those shims are general-purpose and would benefit any akm user — they belong upstream rather than re-invented in every host. The list below splits them by where they should land: **`akm-cli`** for anything that does not require an agent harness, and **`akm-plugins`** (the `opencode/` and `claude/` subdirs of `itlackey/akm-plugins`) for anything that needs lifecycle hooks, tool registration, or prompt-transform APIs.
+After reviewing akm-cli **0.7.4** and akm-opencode **0.7.3** against the previous revision of this plan, **the majority of upstream proposals are already shipped**. What remains is a small focused set: two genuine feature requests, one deferred discussion, and two plugin bug fixes.
 
-Selection criteria:
-- **CLI candidates**: useful outside any specific host, runnable as a one-shot subprocess or daemon, no assumption about an agent loop.
-- **Plugin candidates**: only meaningful inside an agent harness because they hook into session lifecycle, tool execution, or system-prompt transforms.
+### Already shipped — no upstream work needed
 
-### akm-cli (general, no harness required)
+These were proposed in earlier revisions of this plan and have since landed. OpenPalm consumes them directly.
 
-1. **Memory-inference as part of `akm index`, controlled by global config.**
-   - Today: `akm remember "<text>"` stores the input verbatim. Consumers that want atomic recall (RAG pipelines, anyone summarising long inputs) build their own extraction loop.
-   - Proposal: extend the existing index process to detect memories pending inference and run the configured LLM over them, splitting each into atomic memories with frontmatter `inferred: true` and a backref to the source. Toggle via `akm config set index.infer true|false`. When disabled, indexing leaves memories untouched. When enabled, every `akm index` run drains the pending queue.
-   - General value: one configuration switch turns `akm` into a credible substitute for mem0-style fact extractors. Folding the work into the existing indexing pipeline keeps the verb surface small (no new `--infer` flag) and lets users take advantage of it just by scheduling `akm index`.
+| Was proposed | Now lives in |
+|---|---|
+| Memory inference as part of `akm index` | `akm index --enrich` (0.7.3) |
+| Graph-build as part of `akm index` | `akm index --enrich` (0.7.3) |
+| `akm events list|tail` | shipped in 0.7.x |
+| `akm history` | shipped in 0.7.x (`--include-proposals` flag) |
+| `akm feedback` accepting `memory:`/`vault:` refs | shipped in 0.7.x (CLI accepts; plugin still has stale guard — see Bugs §1) |
+| Scope flags on `akm remember` | shipped (`--user`, `--agent`, `--run`, `--channel`) |
+| Plugin `session.created` retrieval with budget | shipped (`AKM_CONTEXT_BUDGET_CHARS`) |
+| Plugin auto-attach scope from session metadata | shipped (`AKM_SCOPE_KEYS=user,agent,run,channel`) |
+| Plugin negative-cue feedback | shipped (`AKM_RETROSPECTIVE_NEGATIVE_PATTERN`) |
+| Plugin session-end `akm index` | shipped (`AKM_INDEX_ON_SESSION_END`) |
 
-2. **First-class memory scoping (`--user`, `--agent`, `--run`, `--channel`).**
-   - Today: scoping is achievable only by setting a different `AKM_STASH_DIR` per scope or by writing custom frontmatter via a host wrapper.
-   - Proposal: native scope flags on `akm remember`, plus matching `--filter` / `--scope` options on `akm search` and `akm show`. Scopes persist as canonical frontmatter and the search index pre-filters by them.
-   - General value: any multi-user / multi-agent / multi-tenant deployment of akm needs this. Today every consumer invents its own scoping convention, which makes stashes non-portable.
+### akm-cli — still proposed
 
-3. **`akm feedback` accepting any valid ref.**
-   - Today: `akm feedback` rejects some ref types (notably `memory:` and `vault:`), and the opencode plugin auto-skips those refs as a result, so relevance signal on memories and vaults has no upstream path.
-   - Proposal: allow feedback on **any** valid ref. Vault feedback can store an aggregated count without leaking values. Hybrid ranking already reads frontmatter for boosts, so the wiring is small.
-   - General value: closes the relevance-learning loop uniformly across asset types instead of asking consumers to remember which refs are "feedback-eligible".
+1. **Harness-LLM passthrough hook** *(see plugin §1 below for the matching plugin half).*
+   - Today: `akm index --enrich` requires an LLM configured at the akm config layer (`akm.llm`). If the host harness already has provider credentials, akm has no way to borrow them.
+   - Proposal: a documented hook — environment variable `AKM_LLM_PROXY_CMD` or config key `akm.llm.proxy` — that akm consults when no native `akm.llm` is configured. akm spawns the shim (stdio JSON in / out) and treats it as the LLM backend.
+   - Why CLI, not plugin: the contract has to live in akm so any harness (opencode, claude, anything new) can implement the shim half.
 
-4. **`akm events` — read/tail asset-mutation events.**
-   - Today: there is no documented event stream; consumers have to scrape mtimes or build their own log.
-   - Proposal: an append-only `events.jsonl` written by the CLI on every add / update / delete / feedback / index pass, surfaced via `akm events list [--since ts]` and `akm events tail`. Same JSON envelope conventions as the rest of the CLI.
-   - General value: foundational for any external observer (sync, replication, audit, dashboards) that needs to react to stash changes without polling. Pairs naturally with the periodic-`akm index` pattern for downstream consumers.
-
-5. **`akm history` — surface the existing mutation history.**
-   - Today: akm writes mutation history internally; there is no first-class command to read it.
-   - Proposal: `akm history [--ref <ref>] [--since ts]` returning per-asset and stash-wide history with the same JSON envelope.
-   - General value: closes the audit-trail need without forcing every downstream tool to build its own. Distinct from `akm events`: history is per-asset state changes; events is the realtime stream.
-
-6. **Pluggable secret backends and rotation for `akm vault`** *(future consideration, not confirmed).*
+2. **Pluggable secret backends and rotation for `akm vault`** *(future consideration, not confirmed).*
    - Today: vault is `.env`-style files only; no rotation, no remote secret-manager integration. Tracks upstream issue #190.
-   - Proposal: a backend interface with built-in adapters for the OS keychain and age-encrypted files, plus hooks for external managers (`pass`, 1Password CLI, AWS/GCP Secrets Manager, HashiCorp Vault). `akm vault rotate <key>` and `akm vault backend set <name>`.
-   - General value: makes `akm vault` a credible production secret store rather than a developer-laptop convenience.
-   - Status: deferred — flagged for evaluation in a future release; not part of the immediate roadmap.
+   - Proposal: a backend interface with built-in adapters (OS keychain, age-encrypted files) plus hooks for external managers (`pass`, 1Password CLI, AWS/GCP Secrets Manager, HashiCorp Vault); `akm vault rotate <key>`; `akm vault backend set <name>`.
+   - Status: deferred — flagged for evaluation in a future release.
 
-7. **Graph-build as part of `akm index`, controlled by global config.**
-   - Today: akm's hybrid search is purely document-level. Graph reasoning across memories is left to consumers.
-   - Proposal: same shape as the inference change — extend the index process to optionally extract entities and relations from `memory:` and `knowledge:` assets and persist a queryable graph file under the stash. Toggle via `akm config set index.graph true|false`. Search ranking consults the graph when it exists.
-   - General value: covers the gap that motivates separate graph-memory services in many stacks. Folding it into indexing means users don't manage a separate `graph build` cadence — one `akm index` run keeps everything in sync.
-
-8. **Single configurable LLM block reused across index passes.**
-   - Today: the optional LLM is wired for indexing-time metadata enrichment but is not exposed as the engine for the new inference / graph passes above.
-   - Proposal: one `akm.llm` config block, reused by every LLM-needing pass inside `akm index`, with explicit per-pass opt-out.
-   - General value: one place to configure, consistent behaviour across enrichment, inference, and graph building.
+3. **Bug fix: scope-flag inconsistency across `remember` / `search` / `show`.**
+   - Today: `akm remember --user X --agent Y` works, but `akm search --user X` is unrecognised — search expects `--filter user=X` and show expects `--scope user=X`.
+   - Proposal: pick one shape (probably accept both), or document the asymmetry prominently. Ground truth confirmed in `src/commands/search.ts` (`parseScopeFilterFlags()`) vs `src/commands/remember.ts` (direct flags).
+   - Why this matters: the akm-opencode plugin currently passes `--user`/`--agent` directly to all three verbs via a single `buildScopedArgs()` helper, which means scope filtering on plugin-issued `search` / `show` calls silently fails. Fixing the CLI fixes the plugin without a plugin release.
 
 ### Explicitly **not** proposed for `akm-cli`
 
-These were considered and rejected (per maintainer direction). Documenting them so they aren't reproposed:
-- **`akm serve` / any HTTP daemon** — akm will not serve HTTP. The CLI is the only programmatic surface; consumers either embed it as a subprocess or share the stash directory.
-- **`akm workflow schedule` / cron triggers** — out of scope for akm. Scheduling stays in the host (cron, systemd, the host app's scheduler).
+Documented so they aren't re-proposed:
+- **`akm serve` / any HTTP daemon** — akm will not serve HTTP. CLI subprocess or shared stash only.
+- **`akm workflow schedule` / cron triggers** — scheduling stays in the host.
 
-### akm-plugins (harness-coupled — `opencode/` and `claude/` subdirs)
+### akm-plugins — still proposed
 
-1. **`session.created` retrieval with token budget.**
-   - Today: akm-opencode injects context on `chat.message` (curate-on-message), not on session start. Cold sessions miss curated context until the user types.
-   - Proposal: subscribe to the harness's session-start hook, run `akm curate --limit N --for-agent` against the session's scope (using the new CLI scope flags above), and inject via the harness's system-prompt transform. Budget configurable via `AKM_CONTEXT_BUDGET_CHARS`.
-   - Why plugin, not CLI: requires harness lifecycle hooks and prompt-transform APIs that only exist inside the agent runtime.
+1. **Harness-LLM passthrough shim** *(opencode/ and claude/).*
+   - Pairs with the CLI hook above. When the harness has provider credentials and akm has no `akm.llm`, the plugin starts a tiny stdio shim, sets `AKM_LLM_PROXY_CMD=<shim path>`, and forwards prompts from akm through the harness's existing provider connection. Returns akm's JSON-shaped result.
+   - Why plugin: only the harness has the user-authenticated provider connection.
 
-2. **Auto-attach scope from harness session metadata.**
-   - Proposal: when the harness exposes session metadata (channel, user id, agent id), the plugin transparently passes those through to the new CLI scope flags on every `akm_remember` / `akm_curate` call. No user action required.
-   - Why plugin: scope sources are harness-specific (OpenCode session ids, Claude Code thread ids, etc.).
+2. **Bug fix: stale `feedback` guard skipping `memory:` / `vault:` refs.**
+   - Today: `akm-plugins/opencode/index.ts` contains `if (ref.startsWith("memory:") || ref.startsWith("vault:")) continue;` with a comment claiming "memories do not accept feedback." That comment is stale relative to akm 0.7.x — the CLI does accept those refs (verified in the CLI docs).
+   - Proposal: remove the guard. Mirror the change in `claude/`.
 
-3. **Conversation-derived feedback.**
-   - Today: akm-opencode has `AKM_RETROSPECTIVE_FEEDBACK_PATTERN` matching positive cues. Could be extended to negative cues, multi-turn confirmation, and explicit "this was wrong" detection, then call `akm feedback <ref>` against any harvested ref once the CLI accepts any valid ref (CLI §3).
-   - Why plugin: needs access to the conversation transcript and the harness's tool-execution timeline.
+3. **Bug fix (depends on CLI §3): plugin sends `--user`/`--agent` to `search`/`show`.**
+   - The `buildScopedArgs()` helper passes scope as direct flags to all verbs, but `search` expects `--filter <k>=<v>` and `show` expects `--scope <k>=<v>`. Either fix is sufficient: (a) wait for CLI §3 to accept both shapes, or (b) update `buildScopedArgs()` to emit the right shape per verb. Mirror in `claude/`.
 
-4. **Session-end optional `akm index`.**
-   - Today: the plugin already flushes a session buffer into a memory artifact on `stop` / `session.idle` / `session.compacted` / `session.deleted`.
-   - Proposal: after the flush, optionally invoke `akm index` (gated by an env toggle, e.g., `AKM_INDEX_ON_SESSION_END=1`). With the new index-pass config (CLI §1, §5), a single `akm index` run handles inference and graph building — no plugin-side extraction logic.
-   - Why plugin: the trigger is the harness lifecycle event; the work itself is now upstream.
-
-5. **Harness-provided LLM fallback for akm passes.**
-   - Today: if no LLM is configured for akm, the new index passes (inference, graph) cannot run.
-   - Proposal: when the harness already has provider credentials configured for the agent, the plugin offers them to akm as the LLM backend for index-time passes. Concretely, the plugin sets a CLI-side env / config (e.g., `AKM_LLM_PROXY_CMD` pointing at a tiny shim the plugin exposes) that akm consults when no native `akm.llm` is configured. The shim forwards prompts through the harness's existing connection.
-   - Why plugin: only the harness has the user-authenticated provider connection; akm itself stays harness-agnostic.
-
-6. **Cross-harness parity.**
-   - Proposal: keep feature parity between `opencode/` and `claude/` as new hooks land — the same scope-attach, session-start retrieval, feedback-inference, session-end-index, and harness-LLM-fallback behaviours should ship in both.
-   - Why plugin: each harness has its own hook surface; parity has to be coded per-harness.
+4. **Cross-harness parity (meta).**
+   - Keep parity between `opencode/` and `claude/` as the two bug fixes and the LLM-passthrough shim land.
 
 ## Out of scope
 

--- a/docs/plans/simplify-via-akm.md
+++ b/docs/plans/simplify-via-akm.md
@@ -12,7 +12,7 @@ The goal is to collapse the stack onto **akm + the shared stash + the assistant 
 2. **Cancel OpenViking.** Replace it with akm wikis + knowledge.
 3. **Delete varlock.** Replace it with `akm vault` for user secrets and a small in-house redactor for stack secrets.
 4. **Fold the scheduler into the assistant container.** Run it as a co-process; no separate image, no separate service.
-5. **Install the `akm` CLI in every trusted container** (guardian, assistant, admin) and **bind-mount the stash from the host** so the three share state through the filesystem — no Unix sockets, no `akm serve`, no native-deps fragility on macOS (Linux-only inside containers).
+5. **Install the `akm` CLI in every trusted container** (guardian, assistant, admin) and **bind-mount stash directories from the host**: assistant and admin share one stash (the user's memory / knowledge / skills); guardian gets its own separate persisted stash for operator-only data. No Unix sockets, no `akm serve`, no native-deps fragility on macOS (Linux-only inside containers).
 
 Remaining capability gaps (LLM fact inference, multi-user scoping, feedback events, session-start retrieval, graph memory) are filled with **scheduled OpenPalm automations** and **assistant OpenCode plugin tools** rather than upstream akm changes.
 
@@ -32,18 +32,20 @@ Remaining capability gaps (LLM fact inference, multi-user scoping, feedback even
 - Admin currently calls `http://scheduler:8090`; rewire to `http://assistant:8090`. Update env/var defaults in `packages/admin/`. The assistant container exposes both `4096` and `8090` on `assistant_net`.
 - Keep `packages/scheduler/` (the package) — only the *service container* and Dockerfile go away. The package is consumed by the supervised subprocess.
 
-### 3. Install `akm` in the trusted containers and share the stash from the host
-Each trusted container — **guardian**, **assistant** (which now also runs scheduler), **admin** — gets:
-- `akm-cli` installed at a pinned version in its Dockerfile (`bun add -g akm-cli@<pin>` or equivalent).
-- A bind-mount of `${OP_HOME}/data/stash` to a consistent in-container path with `AKM_STASH_DIR` set accordingly:
+### 3. Install `akm` in the trusted containers; share a stash between admin and assistant; give guardian its own
+Each trusted container — **guardian**, **assistant** (which now also runs scheduler), **admin** — gets `akm-cli` installed at a pinned version in its Dockerfile (`bun add -g akm-cli@<pin>` or equivalent), plus a bind-mount of an appropriate stash with `AKM_STASH_DIR` set accordingly:
 
-| Container | Stash path | Mode |
-|---|---|---|
-| assistant (and embedded scheduler) | `/home/opencode/.akm` | `rw` (already exists) |
-| admin | `/akm` | `rw` (new) |
-| guardian | `/akm` | `ro` (new — guardian only reads policy/vault) |
+| Container | Host source | In-container path | Mode | Notes |
+|---|---|---|---|---|
+| assistant (+ scheduler subprocess) | `${OP_HOME}/data/stash` | `/home/opencode/.akm` | `rw` | already exists |
+| admin | `${OP_HOME}/data/stash` *(same as assistant)* | `/akm` | `rw` | new — admin and assistant share one stash so admin can browse/edit user memories, knowledge, skills, vaults, etc. |
+| guardian | `${OP_HOME}/data/guardian-stash` *(separate)* | `/akm` | `rw` | new — guardian's own persisted stash for operator-only artifacts (e.g., HMAC vault, channel policies). Guardian cannot read or write the user stash. |
 
-`${OP_HOME}/data/stash` is the **single source of truth** on the host. All three containers read it; assistant and admin write it; guardian is read-only.
+Two stashes, two trust scopes:
+- **`${OP_HOME}/data/stash`** is the user-facing stash — single source of truth for memory, knowledge, skills, commands, agents, workflows, user vault. Shared rw between assistant and admin.
+- **`${OP_HOME}/data/guardian-stash`** is the operator-facing stash for guardian. Holds channel HMAC secrets in `akm vault` form, channel policies, and any guardian-local audit it wants to persist. Not visible to assistant or admin.
+
+This split keeps guardian's blast radius small: a compromised assistant cannot tamper with channel secrets, and a compromised guardian cannot read user memories.
 
 ### 4. Drop overlapping assistant plugin tools
 - Remove `memory-*` and `viking-*` tool registrations from `packages/assistant-tools/src/index.ts`.
@@ -66,17 +68,18 @@ Every capability the deleted memory/scheduler/varlock layers offered is mapped t
 
 | Gap | Resolution | Where it lives |
 |---|---|---|
-| **LLM fact extraction** (`infer: true` extracted atomic facts from raw text). | **Scheduled enrichment automation.** `akm-opencode` writes raw memories with frontmatter `enriched: false`. A new automation runs every N minutes: scheduler invokes the assistant with a deterministic prompt → assistant reads `memories/` entries where `enriched: false`, asks its provider LLM to extract atomic facts, calls `akm remember` per fact with `enriched: true`, deletes the raw entries. | `${OP_HOME}/config/automations/memory-enrich.yml` (new) — `assistant`-action automation. Prompt + tool policy bundled as a stash `agent:memory-enricher`. |
+| **LLM fact extraction** (`infer: true` extracted atomic facts from raw text). | **Periodic `akm index` run.** Once enrichment is folded into akm's index process upstream (see Recommended upstream enhancements §1), OpenPalm just needs to run `akm index` on a cadence — akm picks up any memories pending inference and processes them according to its global config. No bespoke OpenPalm prompt or work queue. | `${OP_HOME}/config/automations/akm-index.yml` (new) — small `assistant`-action automation that shells `akm index`. Bundled config in the stash enables enrichment. |
 | **Multi-user / multi-agent / multi-run scoping.** | **Frontmatter-based scoping** written by an OpenCode plugin. Plugin attaches `user`, `agent`, `run`, `channel` to every `akm_remember` call as YAML frontmatter; search filters via `akm search --type memory --filter user=…`. | New `packages/assistant-tools/opencode/plugins/memory-scope.ts`. |
-| **Programmatic / REST API** for non-OpenCode callers. | **Not needed.** Channel adapters never called memory directly — they go through guardian → assistant. The (now in-container) scheduler runs enrichment by calling the assistant locally. Admin manages memories through the `akm` CLI inside its own container. | n/a — removed. |
-| **Memory feedback** (`memory-feedback` tool). | **Plugin tool** that writes a feedback record to the memory's frontmatter (`feedback: [{positive, note, ts}]`); akm hybrid ranking already reads frontmatter for boosting. | New `memory_feedback` tool in `packages/assistant-tools/src/index.ts`. |
-| **Memory events stream** (`memory-events` tool). | **Append-only events log file in the stash** (`events/memory.jsonl`). Same plugin appends an event line on every `akm_remember`/`memory_feedback`. Used as the work queue for the enrichment automation. | Stash convention; helpers in `packages/assistant-tools/src/lib/`. |
+| **Programmatic / REST API** for non-OpenCode callers. | **Not needed.** Channel adapters never called memory directly — they go through guardian → assistant. The (now in-container) scheduler runs enrichment by shelling `akm index` locally. Admin manages memories through the `akm` CLI inside its own container, against the shared stash. | n/a — removed. |
+| **Memory feedback** (`memory-feedback` tool). | **Direct call to `akm feedback`** once it accepts any valid ref upstream (Recommended upstream enhancements §3). The OpenCode plugin wraps it as `akm_feedback` — no custom frontmatter writing. | `akm-opencode` plugin (already loaded); thin call-site in `packages/assistant-tools`. |
+| **Memory events stream** (`memory-events` tool). | **Dropped.** With enrichment running inside `akm index`, OpenPalm no longer needs an event stream as a work queue. No equivalent surface is added. | n/a — removed. |
 | **Automatic session-start retrieval with token budget** (the old `memory-context.ts` plugin). | **Slim plugin** subscribed to `session.created` that runs `akm curate --limit N --for-agent` against the current session's scope and injects results via `experimental.chat.system.transform`. Budget controlled by `OP_CONTEXT_BUDGET_CHARS`. | New `packages/assistant-tools/opencode/plugins/session-start-context.ts` (replaces deleted `memory-context.ts`). |
-| **Entity-relation / graph memory.** | **Scheduled graph-build automation.** Periodic job invokes assistant to walk recent memories and write `memories/.graph/relations.json`; consumed by `session-start-context.ts` for ranking. Not first-class; can be promoted later. | `${OP_HOME}/config/automations/memory-graph.yml`. |
-| **Varlock validation/scan/redact.** | **Replaced by:** (a) `akm vault` enforces secret hygiene for user secrets at write time (mode-0600 files, never echoed); (b) a small log-redactor in `packages/lib/src/control-plane/logger.ts` masks values for env keys matching `_TOKEN|_SECRET|_KEY|_PASSWORD`; (c) `validate` and `scan` CLI commands either go away or become thin wrappers around `akm vault list` + a name-pattern check. | `packages/lib/src/control-plane/logger.ts` (new redactor); CLI commands edited or removed. |
-| **History / audit trail of mutations** (memory had `history.db`; varlock had schema-driven audits). | akm itself writes a history log when assets change via CLI; combined with the events log above this covers the audit need. Admin UI surfaces it via the `akm` CLI. | Stash convention. |
+| **Entity-relation / graph memory.** | **Periodic `akm index` run, same as enrichment.** Once graph building is folded into akm's index process upstream (Recommended upstream enhancements §7), the same scheduled `akm index` automation builds and refreshes the graph based on akm config. | Same `akm-index.yml` automation as enrichment. |
+| **Varlock validation/scan/redact.** | **Replaced by:** (a) `akm vault` enforces secret hygiene for user secrets at write time (mode-0600 files, never echoed); (b) a small log-redactor in `packages/lib/src/control-plane/logger.ts` masks values for env keys matching `_TOKEN`/`_SECRET`/`_KEY`/`_PASSWORD`; (c) `validate` and `scan` CLI commands either go away or become thin wrappers around `akm vault list` + a name-pattern check. | `packages/lib/src/control-plane/logger.ts` (new redactor); CLI commands edited or removed. |
+| **History / audit trail of mutations** (memory had `history.db`; varlock had schema-driven audits). | **Best-effort via stash filesystem + `akm save` git history.** When the user opts into a git-backed stash, `akm save` produces a per-asset commit history that admin can surface via plain `git log` inside the stash directory. No first-class CLI history is added upstream. | Stash convention; admin UI calls out to `git -C` inside the shared stash. |
 | **macOS sqlite-vec / varlock binary fragility.** | **Not an issue** — akm runs inside Linux containers on every host. Varlock is gone. | n/a. |
-| **History/scheduler triggers from outside** (admin used to POST to `scheduler:8090`). | Same HTTP API, served by the assistant container on port 8090. Admin updates its base URL. | `packages/admin/` env defaults; scheduler subprocess inside assistant container. |
+| **Scheduler triggers from outside** (admin used to POST to `scheduler:8090`). | Same HTTP API, served by the assistant container on port 8090. Admin updates its base URL. | `packages/admin/` env defaults; scheduler subprocess inside assistant container. |
+| **Guardian operator data** (HMAC channel secrets, policies). | **Guardian's own persisted stash** at `${OP_HOME}/data/guardian-stash`. Channel secrets live as an `akm vault` inside that stash, loaded at guardian startup; not readable by assistant or admin. | `${OP_HOME}/data/guardian-stash/` (new host directory); bind-mounted only into guardian. |
 
 ## Files to modify
 
@@ -92,7 +95,7 @@ Delete:
 - OpenViking roadmap PRDs at `.github/roadmap/0.10.0/openviking*` and `.github/roadmap/0.10.0/knowledge-system-roadmap.md` (mark superseded if not deleted).
 
 Modify:
-- `.openpalm/stack/core.compose.yml` — remove `memory` and `scheduler` services; add `/akm` bind-mount + `AKM_STASH_DIR` to guardian (`ro`), admin (`rw`); confirm assistant mount unchanged; expose `:8090` from assistant on `assistant_net`.
+- `.openpalm/stack/core.compose.yml` — remove `memory` and `scheduler` services; mount `${OP_HOME}/data/stash` (rw) into admin at `/akm` and confirm assistant mount unchanged; mount `${OP_HOME}/data/guardian-stash` (rw) into guardian at `/akm` as a *separate* host directory; set `AKM_STASH_DIR` accordingly in each container; expose `:8090` from assistant on `assistant_net`.
 - `core/guardian/Dockerfile`, `core/assistant/Dockerfile`, `core/admin/Dockerfile` — install pinned `akm-cli`. Assistant Dockerfile additionally pulls `packages/scheduler/` and adds the supervisor entrypoint.
 - `core/assistant/entrypoint.sh` (new) — supervises OpenCode + scheduler subprocess.
 - `packages/scheduler/src/server.ts` — accept `127.0.0.1` bind for in-container loopback; otherwise unchanged.
@@ -106,7 +109,8 @@ Modify:
 - `packages/assistant-tools/src/index.ts` — drop `memory-*` and `viking-*` tools; add `memory_feedback`.
 - `packages/assistant-tools/opencode/plugins/` — add `session-start-context.ts` and `memory-scope.ts`.
 - `core/assistant/opencode/system.md` — rewrite memory/knowledge guidance around `akm_*` tools.
-- `${OP_HOME}/config/automations/memory-enrich.yml`, `memory-graph.yml` — new, installed by setup.
+- `${OP_HOME}/config/automations/akm-index.yml` — new, installed by setup; runs `akm index` on a cadence so akm's enrichment + graph passes process pending memories.
+- `${OP_HOME}/data/guardian-stash/` — new host directory; seeded by setup with guardian's HMAC-secrets vault.
 - `vault/stack/stack.env` template — drop `MEMORY_API_URL`, `MEMORY_AUTH_TOKEN`, mem0/embedder vars; drop `OP_VARLOCK_*`.
 - `docs/technical/foundations.md`, `environment-and-mounts.md`, `opencode-configuration.md`, `api-spec.md`, `core-principles.md` — refresh mount/service tables; remove memory/scheduler/varlock sections; document `akm` presence in trusted containers.
 
@@ -124,13 +128,13 @@ End-to-end checks from a clean `openpalm install` on the simplified stack:
 
 1. **Service count.** `docker compose ps` shows two core services (guardian, assistant) plus addons; no `memory`, no `scheduler`.
 2. **akm presence.** `docker compose exec guardian akm --version`, `docker compose exec assistant akm --version`, `docker compose exec admin akm --version` all succeed and report the same pinned version.
-3. **Shared stash.** `docker compose exec assistant akm remember "verify-shared-stash"` then `docker compose exec admin akm search verify-shared-stash --type memory --format json` returns the same memory. Repeat write from admin, read from assistant.
-4. **Guardian RO mount.** `docker compose exec guardian sh -c 'akm remember nope || echo expected-failure'` produces a write error; reads succeed.
+3. **Shared admin/assistant stash.** `docker compose exec assistant akm remember "verify-shared-stash"` then `docker compose exec admin akm search verify-shared-stash --type memory --format json` returns the same memory. Repeat write from admin, read from assistant.
+4. **Guardian stash isolation.** `docker compose exec guardian akm search verify-shared-stash` returns no results (different stash). `docker compose exec guardian akm vault list` shows guardian's own HMAC entries. `docker compose exec assistant ls -la /home/opencode/.akm` does not include any guardian-only artifact.
 5. **Co-located scheduler.** Inside the assistant container, both `:4096` (OpenCode) and `:8090` (scheduler) are listening; admin can reach `http://assistant:8090/health`. If either subprocess dies, the supervisor restarts it.
 6. **Channel round-trip.** Send a chat message → guardian → assistant → assistant uses `akm_remember` → memory file appears in `${OP_HOME}/data/stash/memories/` with scope frontmatter set by `memory-scope.ts`.
-7. **Enrichment automation.** Drop a raw memory with `enriched: false` into the stash, manually trigger `memory-enrich` via the in-container scheduler API, observe atomic facts written with `enriched: true` and the raw entry removed.
+7. **Index automation.** With akm config enabling enrichment, drop a memory with `inferred: false` into the stash, manually trigger `akm-index` via the in-container scheduler API, observe atomic facts written with `inferred: true` (work done by `akm index`, not OpenPalm).
 8. **Session-start retrieval.** Start a fresh assistant session and inspect the system prompt transform — curated context appears without any user message yet, capped at `OP_CONTEXT_BUDGET_CHARS`.
-9. **Vault.** `akm vault list` from inside assistant/admin shows entries previously in `${OP_HOME}/vault/user/*.env`. `akm_vault load` populates env for a tool call. Guardian's HMAC secrets still come from `vault/stack/guardian.env`.
+9. **Vault.** `akm vault list` from inside assistant or admin shows entries previously in `${OP_HOME}/vault/user/*.env`. `akm_vault load` populates env for a tool call. Guardian's HMAC secrets are stored as an `akm vault` inside `${OP_HOME}/data/guardian-stash` and loaded at guardian startup; assistant and admin cannot list them.
 10. **No varlock.** `which varlock` fails inside every container; `~/.cache/openpalm/bin/varlock` is gone; `openpalm install` runs end-to-end without downloading any binary; logs containing values for `*_TOKEN`/`*_SECRET`/`*_KEY`/`*_PASSWORD` are masked by the in-house redactor.
 11. **Knowledge / wiki.** `akm wiki create test`, `akm_search --type knowledge` returns hits; old `viking_*` tools are gone (no missing-tool errors in assistant logs).
 12. **Lifecycle.** `openpalm update` and `openpalm upgrade` succeed without referencing the deleted memory/scheduler/varlock assets.
@@ -146,55 +150,44 @@ Selection criteria:
 
 ### akm-cli (general, no harness required)
 
-1. **`akm remember --infer` — LLM-driven fact extraction.**
-   - Today: `akm remember "<text>"` stores the input verbatim. Consumers that want atomic recall (OpenPalm, RAG pipelines, anyone summarising long inputs) build their own extraction loop.
-   - Proposal: an `--infer` flag that uses akm's already-configured optional LLM (the same one wired for indexing-time metadata enrichment) to split the input into atomic facts and store one memory per fact, with frontmatter `inferred: true` and a backref to the source.
-   - General value: replaces a recurring downstream pattern with one canonical implementation; turns `akm remember` into a credible substitute for mem0-style fact extractors.
+1. **Memory-inference as part of `akm index`, controlled by global config.**
+   - Today: `akm remember "<text>"` stores the input verbatim. Consumers that want atomic recall (RAG pipelines, anyone summarising long inputs) build their own extraction loop.
+   - Proposal: extend the existing index process to detect memories pending inference and run the configured LLM over them, splitting each into atomic memories with frontmatter `inferred: true` and a backref to the source. Toggle via `akm config set index.infer true|false`. When disabled, indexing leaves memories untouched. When enabled, every `akm index` run drains the pending queue.
+   - General value: one configuration switch turns `akm` into a credible substitute for mem0-style fact extractors. Folding the work into the existing indexing pipeline keeps the verb surface small (no new `--infer` flag) and lets users take advantage of it just by scheduling `akm index`.
 
 2. **First-class memory scoping (`--user`, `--agent`, `--run`, `--channel`).**
    - Today: scoping is achievable only by setting a different `AKM_STASH_DIR` per scope or by writing custom frontmatter via a host wrapper.
    - Proposal: native scope flags on `akm remember`, plus matching `--filter` / `--scope` options on `akm search` and `akm show`. Scopes persist as canonical frontmatter and the search index pre-filters by them.
    - General value: any multi-user / multi-agent / multi-tenant deployment of akm needs this. Today every consumer invents its own scoping convention, which makes stashes non-portable.
 
-3. **`akm feedback` accepting `memory:` and `vault:` refs.**
-   - Today: `akm feedback` rejects `memory:` and `vault:` refs (the opencode plugin auto-skips them as a result), so relevance signal on memories has no upstream path.
-   - Proposal: allow feedback on every asset type — vault feedback can store an aggregated count without leaking values. Hybrid ranking already reads frontmatter for boosts, so the wiring is small.
-   - General value: closes the relevance-learning loop on the asset type users actually re-rank most.
+3. **`akm feedback` accepting any valid ref.**
+   - Today: `akm feedback` rejects some ref types (notably `memory:` and `vault:`), and the opencode plugin auto-skips those refs as a result, so relevance signal on memories and vaults has no upstream path.
+   - Proposal: allow feedback on **any** valid ref. Vault feedback can store an aggregated count without leaking values. Hybrid ranking already reads frontmatter for boosts, so the wiring is small.
+   - General value: closes the relevance-learning loop uniformly across asset types instead of asking consumers to remember which refs are "feedback-eligible".
 
-4. **`akm events` — read/tail asset-mutation events.**
-   - Today: there is no documented event stream; consumers have to scrape mtimes or build their own log.
-   - Proposal: an append-only `events.jsonl` written by the CLI on every add/update/delete/feedback, surfaced via `akm events list [--since ts]` and `akm events tail`.
-   - General value: foundational for any background processor (enrichment, sync, replication, audit) running outside the harness — including OpenPalm's enrichment job, but not specific to it.
-
-5. **`akm history` — surface the existing mutation history.**
-   - Today: akm writes mutation history internally; there is no first-class command to read it.
-   - Proposal: `akm history [--ref <ref>] [--since ts]` returning per-asset and stash-wide history.
-   - General value: trivially closes the audit-trail need that any compliance-conscious user has.
-
-6. **`akm serve` — local HTTP daemon over the stash.**
-   - Today: every consumer must shell out to `akm`. Per-call startup cost is real for high-frequency consumers (background workers, automations, cron jobs, remote integrations).
-   - Proposal: optional `akm serve --bind 127.0.0.1:8765` exposing the verb surface with the same JSON contract as the CLI. Concurrent stash access is already handled at the file/sqlite layer.
-   - General value: lets non-shell consumers integrate without spawning processes; enables remote stash access over the LAN. Not required by the in-container OpenPalm model in this plan, but a strict improvement for anyone running akm consumers across machine boundaries.
-
-7. **Pluggable secret backends and rotation for `akm vault`.**
+4. **Pluggable secret backends and rotation for `akm vault`** *(future consideration, not confirmed).*
    - Today: vault is `.env`-style files only; no rotation, no remote secret-manager integration. Tracks upstream issue #190.
    - Proposal: a backend interface with built-in adapters for the OS keychain and age-encrypted files, plus hooks for external managers (`pass`, 1Password CLI, AWS/GCP Secrets Manager, HashiCorp Vault). `akm vault rotate <key>` and `akm vault backend set <name>`.
    - General value: makes `akm vault` a credible production secret store rather than a developer-laptop convenience.
+   - Status: deferred — flagged for evaluation in a future release; not part of the immediate roadmap.
 
-8. **`akm graph build|query` — optional entity/relation index.**
+5. **Graph-build as part of `akm index`, controlled by global config.**
    - Today: akm's hybrid search is purely document-level. Graph reasoning across memories is left to consumers.
-   - Proposal: opt-in `akm graph build` that uses the configured LLM to extract entities and relations from `memory:` and `knowledge:` assets, writing a queryable graph file under the stash; `akm graph query "<entity> -> ?"` for traversal; results feed back into search ranking.
-   - General value: covers the same gap that motivates separate graph-memory services in many stacks, in a form every akm user can opt into.
+   - Proposal: same shape as the inference change — extend the index process to optionally extract entities and relations from `memory:` and `knowledge:` assets and persist a queryable graph file under the stash. Toggle via `akm config set index.graph true|false`. Search ranking consults the graph when it exists.
+   - General value: covers the gap that motivates separate graph-memory services in many stacks. Folding it into indexing means users don't manage a separate `graph build` cadence — one `akm index` run keeps everything in sync.
 
-9. **`akm workflow schedule` — cron-triggered workflows.**
-   - Today: workflows are stateful but invoked manually.
-   - Proposal: `akm workflow schedule <workflow-ref> "<cron>"` registering a schedule alongside the workflow definition; an `akm scheduler tick` (or daemon mode under `akm serve`) fires due workflows.
-   - General value: collapses the common "cron + script" pattern into akm's existing workflow primitive. Useful for any user who wants periodic background tasks without bringing in a separate scheduler.
+6. **Single configurable LLM block reused across index passes.**
+   - Today: the optional LLM is wired for indexing-time metadata enrichment but is not exposed as the engine for the new inference / graph passes above.
+   - Proposal: one `akm.llm` config block, reused by every LLM-needing pass inside `akm index`, with explicit per-pass opt-out.
+   - General value: one place to configure, consistent behaviour across enrichment, inference, and graph building.
 
-10. **Single configurable LLM block reused across enrichment verbs.**
-    - Today: the optional LLM is wired for indexing-time enrichment but not exposed as the engine for `--infer`, `graph build`, or future inference verbs.
-    - Proposal: one `akm.llm` config block, reused by every LLM-needing verb, with explicit per-verb opt-out.
-    - General value: one place to configure, consistent behaviour across enrichment, inference, and graph building.
+### Explicitly **not** proposed for `akm-cli`
+
+These were considered and rejected (per maintainer direction). Documenting them so they aren't reproposed:
+- **`akm events`** — no asset-mutation event stream. Consumers should drive work via scheduled `akm index` runs, not event subscription.
+- **`akm history`** — no first-class history command. Users who want one can rely on `akm save`'s git-backed stash and read history with plain `git log`.
+- **`akm serve` / any HTTP daemon** — akm will not serve HTTP. The CLI is the only programmatic surface; consumers either embed it as a subprocess or share the stash directory.
+- **`akm workflow schedule` / cron triggers** — out of scope for akm. Scheduling stays in the host (cron, systemd, the host app's scheduler).
 
 ### akm-plugins (harness-coupled — `opencode/` and `claude/` subdirs)
 
@@ -208,20 +201,21 @@ Selection criteria:
    - Why plugin: scope sources are harness-specific (OpenCode session ids, Claude Code thread ids, etc.).
 
 3. **Conversation-derived feedback.**
-   - Today: akm-opencode has `AKM_RETROSPECTIVE_FEEDBACK_PATTERN` matching positive cues. Could be extended to negative cues, multi-turn confirmation, and explicit "this was wrong" detection, then call the new `akm feedback memory:…` once the CLI accepts memory refs.
+   - Today: akm-opencode has `AKM_RETROSPECTIVE_FEEDBACK_PATTERN` matching positive cues. Could be extended to negative cues, multi-turn confirmation, and explicit "this was wrong" detection, then call `akm feedback <ref>` against any harvested ref once the CLI accepts any valid ref (CLI §3).
    - Why plugin: needs access to the conversation transcript and the harness's tool-execution timeline.
 
-4. **Session-end consolidation via `akm remember --infer`.**
+4. **Session-end optional `akm index`.**
    - Today: the plugin already flushes a session buffer into a memory artifact on `stop` / `session.idle` / `session.compacted` / `session.deleted`.
-   - Proposal: once `--infer` lands upstream, switch the consolidation step to `akm remember --infer` so the result is atomic facts rather than a single blob — without each plugin reinventing extraction.
-   - Why plugin: the trigger is the harness lifecycle event.
+   - Proposal: after the flush, optionally invoke `akm index` (gated by an env toggle, e.g., `AKM_INDEX_ON_SESSION_END=1`). With the new index-pass config (CLI §1, §5), a single `akm index` run handles inference and graph building — no plugin-side extraction logic.
+   - Why plugin: the trigger is the harness lifecycle event; the work itself is now upstream.
 
-5. **Per-thread / per-conversation stash overlays.**
-   - Proposal: optional plugin mode that points `AKM_STASH_DIR` at a per-thread overlay stash that inherits from the global stash (read-through, write-local) for the duration of a session, then merges back on session end.
-   - Why plugin: scope is the harness's thread/session boundary.
+5. **Harness-provided LLM fallback for akm passes.**
+   - Today: if no LLM is configured for akm, the new index passes (inference, graph) cannot run.
+   - Proposal: when the harness already has provider credentials configured for the agent, the plugin offers them to akm as the LLM backend for index-time passes. Concretely, the plugin sets a CLI-side env / config (e.g., `AKM_LLM_PROXY_CMD` pointing at a tiny shim the plugin exposes) that akm consults when no native `akm.llm` is configured. The shim forwards prompts through the harness's existing connection.
+   - Why plugin: only the harness has the user-authenticated provider connection; akm itself stays harness-agnostic.
 
 6. **Cross-harness parity.**
-   - Proposal: keep feature parity between `opencode/` and `claude/` as new hooks land — the same scope-attach, session-start retrieval, and feedback-inference behaviours should ship in both.
+   - Proposal: keep feature parity between `opencode/` and `claude/` as new hooks land — the same scope-attach, session-start retrieval, feedback-inference, session-end-index, and harness-LLM-fallback behaviours should ship in both.
    - Why plugin: each harness has its own hook surface; parity has to be coded per-harness.
 
 ## Out of scope
@@ -229,6 +223,7 @@ Selection criteria:
 - Replacing the **guardian** HMAC boundary (akm has no equivalent).
 - Replacing the **assistant** runtime (OpenCode stays).
 - Replacing the **scheduler** logic with akm workflows (akm workflows are stateful task chains, not cron — different concept; the scheduler module stays, only its container packaging changes).
-- Building a real graph-memory service (the scheduled graph-build is a pragmatic stand-in until the upstream `akm graph` proposal above lands).
+- Building a real graph-memory service inside OpenPalm (the periodic `akm index` run is the canonical path once upstream index-time graph building lands).
 - Channel adapters — they keep their current contract (sign + POST to guardian); no akm, no stash mount.
 - Log-redaction inside akm — that is a host-app concern (handled in OpenPalm's `logger.ts`), not something akm should own.
+- Sharing a stash between guardian and the user-facing services — guardian's stash is intentionally isolated; do not collapse them.

--- a/docs/plans/simplify-via-akm.md
+++ b/docs/plans/simplify-via-akm.md
@@ -136,10 +136,99 @@ End-to-end checks from a clean `openpalm install` on the simplified stack:
 12. **Lifecycle.** `openpalm update` and `openpalm upgrade` succeed without referencing the deleted memory/scheduler/varlock assets.
 13. **Tests.** `bun test` in `packages/lib`, `packages/assistant-tools`, `packages/scheduler`, `packages/cli` passes; deleted suites are gone with their packages.
 
+## Recommended upstream enhancements
+
+The plan above closes every gap inside OpenPalm. Some of those shims are general-purpose and would benefit any akm user — they belong upstream rather than re-invented in every host. The list below splits them by where they should land: **`akm-cli`** for anything that does not require an agent harness, and **`akm-plugins`** (the `opencode/` and `claude/` subdirs of `itlackey/akm-plugins`) for anything that needs lifecycle hooks, tool registration, or prompt-transform APIs.
+
+Selection criteria:
+- **CLI candidates**: useful outside any specific host, runnable as a one-shot subprocess or daemon, no assumption about an agent loop.
+- **Plugin candidates**: only meaningful inside an agent harness because they hook into session lifecycle, tool execution, or system-prompt transforms.
+
+### akm-cli (general, no harness required)
+
+1. **`akm remember --infer` — LLM-driven fact extraction.**
+   - Today: `akm remember "<text>"` stores the input verbatim. Consumers that want atomic recall (OpenPalm, RAG pipelines, anyone summarising long inputs) build their own extraction loop.
+   - Proposal: an `--infer` flag that uses akm's already-configured optional LLM (the same one wired for indexing-time metadata enrichment) to split the input into atomic facts and store one memory per fact, with frontmatter `inferred: true` and a backref to the source.
+   - General value: replaces a recurring downstream pattern with one canonical implementation; turns `akm remember` into a credible substitute for mem0-style fact extractors.
+
+2. **First-class memory scoping (`--user`, `--agent`, `--run`, `--channel`).**
+   - Today: scoping is achievable only by setting a different `AKM_STASH_DIR` per scope or by writing custom frontmatter via a host wrapper.
+   - Proposal: native scope flags on `akm remember`, plus matching `--filter` / `--scope` options on `akm search` and `akm show`. Scopes persist as canonical frontmatter and the search index pre-filters by them.
+   - General value: any multi-user / multi-agent / multi-tenant deployment of akm needs this. Today every consumer invents its own scoping convention, which makes stashes non-portable.
+
+3. **`akm feedback` accepting `memory:` and `vault:` refs.**
+   - Today: `akm feedback` rejects `memory:` and `vault:` refs (the opencode plugin auto-skips them as a result), so relevance signal on memories has no upstream path.
+   - Proposal: allow feedback on every asset type — vault feedback can store an aggregated count without leaking values. Hybrid ranking already reads frontmatter for boosts, so the wiring is small.
+   - General value: closes the relevance-learning loop on the asset type users actually re-rank most.
+
+4. **`akm events` — read/tail asset-mutation events.**
+   - Today: there is no documented event stream; consumers have to scrape mtimes or build their own log.
+   - Proposal: an append-only `events.jsonl` written by the CLI on every add/update/delete/feedback, surfaced via `akm events list [--since ts]` and `akm events tail`.
+   - General value: foundational for any background processor (enrichment, sync, replication, audit) running outside the harness — including OpenPalm's enrichment job, but not specific to it.
+
+5. **`akm history` — surface the existing mutation history.**
+   - Today: akm writes mutation history internally; there is no first-class command to read it.
+   - Proposal: `akm history [--ref <ref>] [--since ts]` returning per-asset and stash-wide history.
+   - General value: trivially closes the audit-trail need that any compliance-conscious user has.
+
+6. **`akm serve` — local HTTP daemon over the stash.**
+   - Today: every consumer must shell out to `akm`. Per-call startup cost is real for high-frequency consumers (background workers, automations, cron jobs, remote integrations).
+   - Proposal: optional `akm serve --bind 127.0.0.1:8765` exposing the verb surface with the same JSON contract as the CLI. Concurrent stash access is already handled at the file/sqlite layer.
+   - General value: lets non-shell consumers integrate without spawning processes; enables remote stash access over the LAN. Not required by the in-container OpenPalm model in this plan, but a strict improvement for anyone running akm consumers across machine boundaries.
+
+7. **Pluggable secret backends and rotation for `akm vault`.**
+   - Today: vault is `.env`-style files only; no rotation, no remote secret-manager integration. Tracks upstream issue #190.
+   - Proposal: a backend interface with built-in adapters for the OS keychain and age-encrypted files, plus hooks for external managers (`pass`, 1Password CLI, AWS/GCP Secrets Manager, HashiCorp Vault). `akm vault rotate <key>` and `akm vault backend set <name>`.
+   - General value: makes `akm vault` a credible production secret store rather than a developer-laptop convenience.
+
+8. **`akm graph build|query` — optional entity/relation index.**
+   - Today: akm's hybrid search is purely document-level. Graph reasoning across memories is left to consumers.
+   - Proposal: opt-in `akm graph build` that uses the configured LLM to extract entities and relations from `memory:` and `knowledge:` assets, writing a queryable graph file under the stash; `akm graph query "<entity> -> ?"` for traversal; results feed back into search ranking.
+   - General value: covers the same gap that motivates separate graph-memory services in many stacks, in a form every akm user can opt into.
+
+9. **`akm workflow schedule` — cron-triggered workflows.**
+   - Today: workflows are stateful but invoked manually.
+   - Proposal: `akm workflow schedule <workflow-ref> "<cron>"` registering a schedule alongside the workflow definition; an `akm scheduler tick` (or daemon mode under `akm serve`) fires due workflows.
+   - General value: collapses the common "cron + script" pattern into akm's existing workflow primitive. Useful for any user who wants periodic background tasks without bringing in a separate scheduler.
+
+10. **Single configurable LLM block reused across enrichment verbs.**
+    - Today: the optional LLM is wired for indexing-time enrichment but not exposed as the engine for `--infer`, `graph build`, or future inference verbs.
+    - Proposal: one `akm.llm` config block, reused by every LLM-needing verb, with explicit per-verb opt-out.
+    - General value: one place to configure, consistent behaviour across enrichment, inference, and graph building.
+
+### akm-plugins (harness-coupled — `opencode/` and `claude/` subdirs)
+
+1. **`session.created` retrieval with token budget.**
+   - Today: akm-opencode injects context on `chat.message` (curate-on-message), not on session start. Cold sessions miss curated context until the user types.
+   - Proposal: subscribe to the harness's session-start hook, run `akm curate --limit N --for-agent` against the session's scope (using the new CLI scope flags above), and inject via the harness's system-prompt transform. Budget configurable via `AKM_CONTEXT_BUDGET_CHARS`.
+   - Why plugin, not CLI: requires harness lifecycle hooks and prompt-transform APIs that only exist inside the agent runtime.
+
+2. **Auto-attach scope from harness session metadata.**
+   - Proposal: when the harness exposes session metadata (channel, user id, agent id), the plugin transparently passes those through to the new CLI scope flags on every `akm_remember` / `akm_curate` call. No user action required.
+   - Why plugin: scope sources are harness-specific (OpenCode session ids, Claude Code thread ids, etc.).
+
+3. **Conversation-derived feedback.**
+   - Today: akm-opencode has `AKM_RETROSPECTIVE_FEEDBACK_PATTERN` matching positive cues. Could be extended to negative cues, multi-turn confirmation, and explicit "this was wrong" detection, then call the new `akm feedback memory:…` once the CLI accepts memory refs.
+   - Why plugin: needs access to the conversation transcript and the harness's tool-execution timeline.
+
+4. **Session-end consolidation via `akm remember --infer`.**
+   - Today: the plugin already flushes a session buffer into a memory artifact on `stop` / `session.idle` / `session.compacted` / `session.deleted`.
+   - Proposal: once `--infer` lands upstream, switch the consolidation step to `akm remember --infer` so the result is atomic facts rather than a single blob — without each plugin reinventing extraction.
+   - Why plugin: the trigger is the harness lifecycle event.
+
+5. **Per-thread / per-conversation stash overlays.**
+   - Proposal: optional plugin mode that points `AKM_STASH_DIR` at a per-thread overlay stash that inherits from the global stash (read-through, write-local) for the duration of a session, then merges back on session end.
+   - Why plugin: scope is the harness's thread/session boundary.
+
+6. **Cross-harness parity.**
+   - Proposal: keep feature parity between `opencode/` and `claude/` as new hooks land — the same scope-attach, session-start retrieval, and feedback-inference behaviours should ship in both.
+   - Why plugin: each harness has its own hook surface; parity has to be coded per-harness.
+
 ## Out of scope
 
 - Replacing the **guardian** HMAC boundary (akm has no equivalent).
 - Replacing the **assistant** runtime (OpenCode stays).
 - Replacing the **scheduler** logic with akm workflows (akm workflows are stateful task chains, not cron — different concept; the scheduler module stays, only its container packaging changes).
-- Building a real graph-memory service (the scheduled graph-build is a pragmatic stand-in).
+- Building a real graph-memory service (the scheduled graph-build is a pragmatic stand-in until the upstream `akm graph` proposal above lands).
 - Channel adapters — they keep their current contract (sign + POST to guardian); no akm, no stash mount.
+- Log-redaction inside akm — that is a host-app concern (handled in OpenPalm's `logger.ts`), not something akm should own.

--- a/docs/plans/simplify-via-akm.md
+++ b/docs/plans/simplify-via-akm.md
@@ -1,0 +1,145 @@
+# Simplify OpenPalm by leveraging akm-cli and the stash directory
+
+## Context
+
+OpenPalm today ships a vector **memory** service (`core/memory` + `packages/memory`, sqlite-vec, mem0-style fact extraction), a planned **OpenViking** structured-knowledge addon, a **scheduler** sidecar service, and a **varlock**-backed secret-validation/redaction layer. Several of these predate the maturity of akm-cli.
+
+As of akm 0.5.0 / 0.6.0-rc1 and `akm-opencode` 0.5.x, akm covers exactly the memory/knowledge/skills/vault jobs as first-class asset types — `memory`, `knowledge`, `wiki`, `skill`, `command`, `agent`, `script`, `vault`, `workflow` — with hybrid search, opaque refs, frontmatter on memories, `akm remember`, `akm import`, `akm curate`, `akm wiki`, `akm vault`, and an opencode plugin that auto-harvests memory on `tool.execute.after` / `stop` / `session.idle`. OpenPalm already mounts `${OP_HOME}/data/stash` to `/home/opencode/.akm` and already loads `akm-opencode` as the second OpenCode plugin in the assistant and admin containers.
+
+The goal is to collapse the stack onto **akm + the shared stash + the assistant container** so OpenPalm carries less code and fewer moving parts:
+
+1. **Delete the memory service.** Replace it with akm memory in the shared stash.
+2. **Cancel OpenViking.** Replace it with akm wikis + knowledge.
+3. **Delete varlock.** Replace it with `akm vault` for user secrets and a small in-house redactor for stack secrets.
+4. **Fold the scheduler into the assistant container.** Run it as a co-process; no separate image, no separate service.
+5. **Install the `akm` CLI in every trusted container** (guardian, assistant, admin) and **bind-mount the stash from the host** so the three share state through the filesystem — no Unix sockets, no `akm serve`, no native-deps fragility on macOS (Linux-only inside containers).
+
+Remaining capability gaps (LLM fact inference, multi-user scoping, feedback events, session-start retrieval, graph memory) are filled with **scheduled OpenPalm automations** and **assistant OpenCode plugin tools** rather than upstream akm changes.
+
+## Direct changes
+
+### 1. Delete services and dependencies
+- **Memory service.** Remove the `memory` service from `.openpalm/stack/core.compose.yml`. Delete `core/memory/` and `packages/memory/`.
+- **OpenViking.** Mark `.github/roadmap/0.10.0/openviking*` and `.github/roadmap/0.10.0/knowledge-system-roadmap.md` as superseded; remove any registry/addon scaffolding for it. Knowledge browsing is now `akm wiki` + `akm search --type knowledge`.
+- **Varlock.** Delete `packages/cli/src/lib/varlock.ts`, `packages/lib/src/control-plane/redact-schema.ts`, varlock-specific paths in `packages/lib/src/control-plane/secret-backend.ts` and `packages/lib/src/control-plane/validate.ts`, and the `cli` commands `validate` / `scan` (or rewrite them as no-ops / akm-vault-aware checks). Remove `.openpalm/vault/redact.env.schema`, the `VARLOCK_VERSION` constants, and the binary download/cache logic in `packages/cli/src/commands/install.ts`. Remove tests under `packages/lib/src/control-plane/env-schema-validation.test.ts` and `secret-backend.test.ts` for the deleted paths.
+
+### 2. Fold the scheduler into the assistant container
+- Delete `core/scheduler/Dockerfile` and the `scheduler` service block from `.openpalm/stack/core.compose.yml`.
+- Add a tiny supervisor entrypoint to the assistant container (e.g., `core/assistant/entrypoint.sh` that uses `dumb-init` or a Bun supervisor script) that starts:
+  1. The OpenCode runtime on `:4096`.
+  2. `bun packages/scheduler/src/server.ts` on `:8090`, bound only to the assistant container's loopback.
+- Both processes share `${OP_HOME}/config`, `${OP_HOME}/data`, `${OP_HOME}/logs`, and the stash mount — already mounted into the assistant container today.
+- Admin currently calls `http://scheduler:8090`; rewire to `http://assistant:8090`. Update env/var defaults in `packages/admin/`. The assistant container exposes both `4096` and `8090` on `assistant_net`.
+- Keep `packages/scheduler/` (the package) — only the *service container* and Dockerfile go away. The package is consumed by the supervised subprocess.
+
+### 3. Install `akm` in the trusted containers and share the stash from the host
+Each trusted container — **guardian**, **assistant** (which now also runs scheduler), **admin** — gets:
+- `akm-cli` installed at a pinned version in its Dockerfile (`bun add -g akm-cli@<pin>` or equivalent).
+- A bind-mount of `${OP_HOME}/data/stash` to a consistent in-container path with `AKM_STASH_DIR` set accordingly:
+
+| Container | Stash path | Mode |
+|---|---|---|
+| assistant (and embedded scheduler) | `/home/opencode/.akm` | `rw` (already exists) |
+| admin | `/akm` | `rw` (new) |
+| guardian | `/akm` | `ro` (new — guardian only reads policy/vault) |
+
+`${OP_HOME}/data/stash` is the **single source of truth** on the host. All three containers read it; assistant and admin write it; guardian is read-only.
+
+### 4. Drop overlapping assistant plugin tools
+- Remove `memory-*` and `viking-*` tool registrations from `packages/assistant-tools/src/index.ts`.
+- Remove `packages/assistant-tools/opencode/plugins/memory-context.ts` (replaced by `akm-opencode`'s `chat.message` curate-on-message + a slim `session-start-context.ts` plugin — see Gap §6 below).
+- Update `core/assistant/opencode/system.md` to point at `akm_search`, `akm_show`, `akm_remember`, `akm_curate`, `akm_feedback`, `akm_wiki`, `akm_vault`, `akm_workflow`.
+
+### 5. Migrate seeded assets into the stash
+- Move OpenPalm's bundled skills / commands / agents from `core/assistant/opencode/{commands,agents,skills}/` into stash subdirectories with `.stash.json` metadata.
+- Update `packages/lib/src/control-plane/setup.ts` to seed those into `${OP_HOME}/data/stash/` on first install (idempotent — does not overwrite user edits, matching the existing config-ownership rule).
+
+### 6. Move user secrets into `akm vault`; keep stack secrets in plain env files
+- During install, write existing `${OP_HOME}/vault/user/*.env` entries via `akm vault create/set` into a stash-resident vault.
+- Channel HMAC secrets and admin tokens stay in `${OP_HOME}/vault/stack/*.env` (operator-owned, never visible to assistant). Without varlock, redaction in logs is handled by a small in-house allowlist of secret-named env-var prefixes (`*_TOKEN`, `*_SECRET`, `*_KEY`, `*_PASSWORD`) applied in `packages/lib/src/control-plane/logger.ts`.
+- Replace the `load_vault` tool with calls to `akm_vault load`.
+- Stop seeding mem0 config: delete `packages/lib/src/control-plane/memory-config.ts` and its callers; remove `MEMORY_API_URL`, `MEMORY_AUTH_TOKEN`, mem0/embedder vars from `vault/stack/stack.env` template, the assistant container env, channel-adapter env, and admin env.
+
+## Gap → resolution map
+
+Every capability the deleted memory/scheduler/varlock layers offered is mapped to an OpenPalm-side resolution. Nothing here requires upstream akm changes.
+
+| Gap | Resolution | Where it lives |
+|---|---|---|
+| **LLM fact extraction** (`infer: true` extracted atomic facts from raw text). | **Scheduled enrichment automation.** `akm-opencode` writes raw memories with frontmatter `enriched: false`. A new automation runs every N minutes: scheduler invokes the assistant with a deterministic prompt → assistant reads `memories/` entries where `enriched: false`, asks its provider LLM to extract atomic facts, calls `akm remember` per fact with `enriched: true`, deletes the raw entries. | `${OP_HOME}/config/automations/memory-enrich.yml` (new) — `assistant`-action automation. Prompt + tool policy bundled as a stash `agent:memory-enricher`. |
+| **Multi-user / multi-agent / multi-run scoping.** | **Frontmatter-based scoping** written by an OpenCode plugin. Plugin attaches `user`, `agent`, `run`, `channel` to every `akm_remember` call as YAML frontmatter; search filters via `akm search --type memory --filter user=…`. | New `packages/assistant-tools/opencode/plugins/memory-scope.ts`. |
+| **Programmatic / REST API** for non-OpenCode callers. | **Not needed.** Channel adapters never called memory directly — they go through guardian → assistant. The (now in-container) scheduler runs enrichment by calling the assistant locally. Admin manages memories through the `akm` CLI inside its own container. | n/a — removed. |
+| **Memory feedback** (`memory-feedback` tool). | **Plugin tool** that writes a feedback record to the memory's frontmatter (`feedback: [{positive, note, ts}]`); akm hybrid ranking already reads frontmatter for boosting. | New `memory_feedback` tool in `packages/assistant-tools/src/index.ts`. |
+| **Memory events stream** (`memory-events` tool). | **Append-only events log file in the stash** (`events/memory.jsonl`). Same plugin appends an event line on every `akm_remember`/`memory_feedback`. Used as the work queue for the enrichment automation. | Stash convention; helpers in `packages/assistant-tools/src/lib/`. |
+| **Automatic session-start retrieval with token budget** (the old `memory-context.ts` plugin). | **Slim plugin** subscribed to `session.created` that runs `akm curate --limit N --for-agent` against the current session's scope and injects results via `experimental.chat.system.transform`. Budget controlled by `OP_CONTEXT_BUDGET_CHARS`. | New `packages/assistant-tools/opencode/plugins/session-start-context.ts` (replaces deleted `memory-context.ts`). |
+| **Entity-relation / graph memory.** | **Scheduled graph-build automation.** Periodic job invokes assistant to walk recent memories and write `memories/.graph/relations.json`; consumed by `session-start-context.ts` for ranking. Not first-class; can be promoted later. | `${OP_HOME}/config/automations/memory-graph.yml`. |
+| **Varlock validation/scan/redact.** | **Replaced by:** (a) `akm vault` enforces secret hygiene for user secrets at write time (mode-0600 files, never echoed); (b) a small log-redactor in `packages/lib/src/control-plane/logger.ts` masks values for env keys matching `_TOKEN|_SECRET|_KEY|_PASSWORD`; (c) `validate` and `scan` CLI commands either go away or become thin wrappers around `akm vault list` + a name-pattern check. | `packages/lib/src/control-plane/logger.ts` (new redactor); CLI commands edited or removed. |
+| **History / audit trail of mutations** (memory had `history.db`; varlock had schema-driven audits). | akm itself writes a history log when assets change via CLI; combined with the events log above this covers the audit need. Admin UI surfaces it via the `akm` CLI. | Stash convention. |
+| **macOS sqlite-vec / varlock binary fragility.** | **Not an issue** — akm runs inside Linux containers on every host. Varlock is gone. | n/a. |
+| **History/scheduler triggers from outside** (admin used to POST to `scheduler:8090`). | Same HTTP API, served by the assistant container on port 8090. Admin updates its base URL. | `packages/admin/` env defaults; scheduler subprocess inside assistant container. |
+
+## Files to modify
+
+Delete:
+- `core/memory/` (entire directory)
+- `core/scheduler/` (Dockerfile only)
+- `packages/memory/` (entire directory)
+- `packages/cli/src/lib/varlock.ts`
+- `packages/lib/src/control-plane/memory-config.ts`
+- `packages/lib/src/control-plane/redact-schema.ts`
+- `packages/assistant-tools/opencode/plugins/memory-context.ts`
+- `.openpalm/vault/redact.env.schema`
+- OpenViking roadmap PRDs at `.github/roadmap/0.10.0/openviking*` and `.github/roadmap/0.10.0/knowledge-system-roadmap.md` (mark superseded if not deleted).
+
+Modify:
+- `.openpalm/stack/core.compose.yml` — remove `memory` and `scheduler` services; add `/akm` bind-mount + `AKM_STASH_DIR` to guardian (`ro`), admin (`rw`); confirm assistant mount unchanged; expose `:8090` from assistant on `assistant_net`.
+- `core/guardian/Dockerfile`, `core/assistant/Dockerfile`, `core/admin/Dockerfile` — install pinned `akm-cli`. Assistant Dockerfile additionally pulls `packages/scheduler/` and adds the supervisor entrypoint.
+- `core/assistant/entrypoint.sh` (new) — supervises OpenCode + scheduler subprocess.
+- `packages/scheduler/src/server.ts` — accept `127.0.0.1` bind for in-container loopback; otherwise unchanged.
+- `packages/admin/` — change scheduler base URL default from `http://scheduler:8090` to `http://assistant:8090`.
+- `packages/cli/src/commands/install.ts` — remove varlock download/install path.
+- `packages/cli/src/commands/validate.ts`, `packages/cli/src/commands/scan.ts` — rewrite as akm-vault checks or remove.
+- `packages/lib/src/control-plane/secret-backend.ts` — drop varlock provider; user secrets path runs through akm vault.
+- `packages/lib/src/control-plane/validate.ts` — drop varlock subprocess; minimal env-format check only.
+- `packages/lib/src/control-plane/logger.ts` (or new `redactor.ts`) — name-prefix-based secret redactor.
+- `packages/lib/src/control-plane/setup.ts` — seed stash with skills/commands/agents on first install; migrate `vault/user/*.env` → `akm vault`.
+- `packages/assistant-tools/src/index.ts` — drop `memory-*` and `viking-*` tools; add `memory_feedback`.
+- `packages/assistant-tools/opencode/plugins/` — add `session-start-context.ts` and `memory-scope.ts`.
+- `core/assistant/opencode/system.md` — rewrite memory/knowledge guidance around `akm_*` tools.
+- `${OP_HOME}/config/automations/memory-enrich.yml`, `memory-graph.yml` — new, installed by setup.
+- `vault/stack/stack.env` template — drop `MEMORY_API_URL`, `MEMORY_AUTH_TOKEN`, mem0/embedder vars; drop `OP_VARLOCK_*`.
+- `docs/technical/foundations.md`, `environment-and-mounts.md`, `opencode-configuration.md`, `api-spec.md`, `core-principles.md` — refresh mount/service tables; remove memory/scheduler/varlock sections; document `akm` presence in trusted containers.
+
+## Existing utilities to reuse (no new code)
+
+- `${OP_HOME}/data/stash` host directory and `AKM_STASH_DIR` env wiring already exist for the assistant — extend the same convention to the other trusted containers.
+- `akm-opencode` plugin already loaded in both assistant and admin OpenCode containers — no install change.
+- `packages/lib/src/control-plane/` — keep using the same shared library for install/upgrade; only change *what* gets seeded.
+- `packages/scheduler/`'s croner-based loop and YAML automation parser — unchanged; only its container packaging changes.
+- Scheduler's existing `assistant` action type is the right primitive for both enrichment and graph-build automations — no new action kind needed.
+
+## Verification
+
+End-to-end checks from a clean `openpalm install` on the simplified stack:
+
+1. **Service count.** `docker compose ps` shows two core services (guardian, assistant) plus addons; no `memory`, no `scheduler`.
+2. **akm presence.** `docker compose exec guardian akm --version`, `docker compose exec assistant akm --version`, `docker compose exec admin akm --version` all succeed and report the same pinned version.
+3. **Shared stash.** `docker compose exec assistant akm remember "verify-shared-stash"` then `docker compose exec admin akm search verify-shared-stash --type memory --format json` returns the same memory. Repeat write from admin, read from assistant.
+4. **Guardian RO mount.** `docker compose exec guardian sh -c 'akm remember nope || echo expected-failure'` produces a write error; reads succeed.
+5. **Co-located scheduler.** Inside the assistant container, both `:4096` (OpenCode) and `:8090` (scheduler) are listening; admin can reach `http://assistant:8090/health`. If either subprocess dies, the supervisor restarts it.
+6. **Channel round-trip.** Send a chat message → guardian → assistant → assistant uses `akm_remember` → memory file appears in `${OP_HOME}/data/stash/memories/` with scope frontmatter set by `memory-scope.ts`.
+7. **Enrichment automation.** Drop a raw memory with `enriched: false` into the stash, manually trigger `memory-enrich` via the in-container scheduler API, observe atomic facts written with `enriched: true` and the raw entry removed.
+8. **Session-start retrieval.** Start a fresh assistant session and inspect the system prompt transform — curated context appears without any user message yet, capped at `OP_CONTEXT_BUDGET_CHARS`.
+9. **Vault.** `akm vault list` from inside assistant/admin shows entries previously in `${OP_HOME}/vault/user/*.env`. `akm_vault load` populates env for a tool call. Guardian's HMAC secrets still come from `vault/stack/guardian.env`.
+10. **No varlock.** `which varlock` fails inside every container; `~/.cache/openpalm/bin/varlock` is gone; `openpalm install` runs end-to-end without downloading any binary; logs containing values for `*_TOKEN`/`*_SECRET`/`*_KEY`/`*_PASSWORD` are masked by the in-house redactor.
+11. **Knowledge / wiki.** `akm wiki create test`, `akm_search --type knowledge` returns hits; old `viking_*` tools are gone (no missing-tool errors in assistant logs).
+12. **Lifecycle.** `openpalm update` and `openpalm upgrade` succeed without referencing the deleted memory/scheduler/varlock assets.
+13. **Tests.** `bun test` in `packages/lib`, `packages/assistant-tools`, `packages/scheduler`, `packages/cli` passes; deleted suites are gone with their packages.
+
+## Out of scope
+
+- Replacing the **guardian** HMAC boundary (akm has no equivalent).
+- Replacing the **assistant** runtime (OpenCode stays).
+- Replacing the **scheduler** logic with akm workflows (akm workflows are stateful task chains, not cron — different concept; the scheduler module stays, only its container packaging changes).
+- Building a real graph-memory service (the scheduled graph-build is a pragmatic stand-in).
+- Channel adapters — they keep their current contract (sign + POST to guardian); no akm, no stash mount.

--- a/docs/plans/upstream-issues/akm-cli-issues.md
+++ b/docs/plans/upstream-issues/akm-cli-issues.md
@@ -1,0 +1,253 @@
+# Upstream issue drafts — `itlackey/akm`
+
+These are ready to paste into <https://github.com/itlackey/akm/issues/new>. Each block has a suggested **title**, a body, and suggested **labels**. Source plan: `docs/plans/simplify-via-akm.md`.
+
+Selection criteria for this repo: features useful outside any specific host, runnable as a one-shot subprocess, no assumption about an agent loop. Items that need lifecycle hooks live in the akm-plugins repo (see `akm-plugins-issues.md`).
+
+---
+
+## 1. Memory-inference as part of `akm index`, controlled by global config
+
+**Title:** Inference pass inside `akm index`, toggled via global config
+
+**Labels:** `enhancement`, `memory`, `index`, `cli`
+
+**Body:**
+
+### Summary
+Add an opt-in inference pass to `akm index` that uses the configured LLM to split memories pending inference into atomic facts.
+
+### Today
+`akm remember "<text>"` stores the input verbatim. Consumers that want atomic recall (RAG pipelines, anything summarising long inputs) build their own extraction loop.
+
+### Proposal
+Extend the existing index process to detect memories pending inference and run the configured LLM over them, splitting each into atomic memories with frontmatter `inferred: true` and a backref to the source.
+
+- Toggle via `akm config set index.infer true|false`.
+- When disabled: indexing leaves memories untouched.
+- When enabled: every `akm index` run drains the pending queue.
+- No new flag on `akm remember` — the verb surface stays the same.
+
+### Why this shape
+Folding the work into the existing indexing pipeline lets users adopt it just by scheduling `akm index`, with no new flags to remember. It also keeps the extraction logic in one place rather than scattering it across consumers.
+
+### Acceptance
+- [ ] Pending memories are detected by indexer.
+- [ ] When `index.infer=true`, atomic memories are written with `inferred: true` and a `source:` backref.
+- [ ] Re-running indexing is idempotent.
+- [ ] Toggling off via config halts the pass without losing existing inferred memories.
+
+---
+
+## 2. First-class memory scoping (`--user`, `--agent`, `--run`, `--channel`)
+
+**Title:** Native scoping flags on `akm remember` / `akm search` / `akm show`
+
+**Labels:** `enhancement`, `memory`, `cli`
+
+**Body:**
+
+### Summary
+Add canonical scope flags so multi-user / multi-agent deployments stop inventing their own conventions.
+
+### Today
+Scoping is achievable only by setting a different `AKM_STASH_DIR` per scope or by writing custom frontmatter via a host wrapper.
+
+### Proposal
+- `akm remember "<text>" --user <id> --agent <id> --run <id> --channel <name>` — persists the values as canonical frontmatter.
+- `akm search "<query>" --filter user=<id> --filter agent=<id> ...` — pre-filters via the search index.
+- `akm show memory:<ref> --scope user=<id>` — narrows resolution.
+
+### Why
+Any multi-user / multi-agent / multi-tenant deployment of akm needs this. Today every consumer (chatbots, shared dev teams, multi-tenant deployments) invents its own scoping convention, which makes stashes non-portable.
+
+### Acceptance
+- [ ] Scope flags persist as a stable frontmatter shape.
+- [ ] Search index respects the filters at query time.
+- [ ] Existing memories without scope still match unfiltered queries.
+
+---
+
+## 3. `akm feedback` should accept any valid ref
+
+**Title:** Allow `akm feedback` on any valid ref (memory, vault, etc.)
+
+**Labels:** `enhancement`, `feedback`, `cli`
+
+**Body:**
+
+### Summary
+`akm feedback` currently rejects some ref types (notably `memory:` and `vault:`). The opencode plugin auto-skips those refs as a result, so relevance signal on memories and vaults has no upstream path.
+
+### Proposal
+Allow feedback on any valid ref. Vault feedback can store an aggregated count without leaking values (counts, not contents). Hybrid ranking already reads frontmatter for boosts, so the wiring is small.
+
+### Why
+Closes the relevance-learning loop uniformly across asset types instead of asking consumers to remember which refs are "feedback-eligible".
+
+### Acceptance
+- [ ] `akm feedback memory:<ref> --positive` succeeds and is reflected in subsequent ranking.
+- [ ] `akm feedback vault:<ref> --positive` succeeds without surfacing values.
+- [ ] No ref type silently rejects feedback.
+
+---
+
+## 4. `akm events` — read / tail asset-mutation events
+
+**Title:** Append-only events stream + `akm events list|tail`
+
+**Labels:** `enhancement`, `observability`, `cli`
+
+**Body:**
+
+### Summary
+Add a documented event stream so external observers (sync, replication, audit, dashboards) can react to stash changes without polling.
+
+### Today
+There is no documented event stream; consumers have to scrape mtimes or build their own log.
+
+### Proposal
+- An append-only `events.jsonl` written by the CLI on every add / update / delete / feedback / index pass.
+- `akm events list [--since <ts>] [--type <event-type>] [--ref <ref>]` — paged history.
+- `akm events tail [--since <ts>]` — follow mode.
+- Same JSON envelope conventions as the rest of the CLI.
+
+### Why
+Foundational for any external observer that needs to react to stash changes without polling. Pairs naturally with the periodic-`akm index` pattern for downstream consumers, and is a clean primitive even when no harness is involved.
+
+### Acceptance
+- [ ] Every CLI verb that mutates state emits an event.
+- [ ] `--since` is monotonic and durable across processes.
+- [ ] `tail` keeps up with concurrent writers without losing events.
+
+---
+
+## 5. `akm history` — surface the existing mutation history
+
+**Title:** First-class `akm history` command
+
+**Labels:** `enhancement`, `observability`, `cli`
+
+**Body:**
+
+### Summary
+Surface the mutation history akm already writes so downstream tools don't reinvent it.
+
+### Today
+akm writes mutation history internally; there is no first-class command to read it. Consumers wanting an audit trail either scrape filesystem mtimes or build a parallel log.
+
+### Proposal
+`akm history [--ref <ref>] [--since <ts>] [--format json|jsonl|text|yaml]` — returns per-asset and stash-wide history with the same JSON envelope as the rest of the CLI.
+
+Distinct from `akm events`:
+- **history** = per-asset state changes ("this memory was added then edited then deleted").
+- **events** = realtime stream of any mutation across the stash.
+
+### Why
+Closes the audit-trail need without forcing every downstream tool to build its own.
+
+### Acceptance
+- [ ] `akm history --ref memory:<id>` shows full lifecycle of a single asset.
+- [ ] `akm history` (no ref) shows stash-wide history.
+- [ ] JSON envelope matches existing CLI conventions.
+
+---
+
+## 6. Pluggable secret backends and rotation for `akm vault` *(future consideration)*
+
+**Title:** Pluggable secret backends + rotation for `akm vault`
+
+**Labels:** `enhancement`, `vault`, `discussion`
+
+**Body:**
+
+> Status: deferred / future consideration. Filed so the design is captured; not a near-term commitment.
+
+### Summary
+Make `akm vault` a credible production secret store rather than a developer-laptop convenience. Tracks #190.
+
+### Today
+Vault is `.env`-style files only; no rotation, no remote secret-manager integration.
+
+### Proposal
+A backend interface with built-in adapters and hooks for external managers:
+- Built-in: OS keychain, age-encrypted files.
+- External hooks: `pass`, 1Password CLI, AWS / GCP Secrets Manager, HashiCorp Vault.
+- Rotation: `akm vault rotate <key>` (re-keys + re-encrypts in place).
+- Backend selection: `akm vault backend set <name>`.
+
+### Why
+Production deployments need rotation and centralised secret management. Today users either pick `akm vault` and accept dev-only semantics or shell out to a different secret manager entirely.
+
+### Acceptance (when picked up)
+- [ ] Backend interface defined with at least one built-in alternative to `.env`.
+- [ ] Rotation is atomic (no readers see a half-rotated key).
+- [ ] Existing `.env` vaults migrate without breaking refs.
+
+---
+
+## 7. Graph-build as part of `akm index`, controlled by global config
+
+**Title:** Graph-extraction pass inside `akm index`, toggled via global config
+
+**Labels:** `enhancement`, `index`, `graph`, `cli`
+
+**Body:**
+
+### Summary
+Add an opt-in graph pass to `akm index` that extracts entities and relations from `memory:` and `knowledge:` assets.
+
+### Today
+akm's hybrid search is purely document-level. Graph reasoning across memories is left to consumers, which forces every stack with that need to bolt on a separate graph-memory service.
+
+### Proposal
+Same shape as the inference pass (#1):
+- Toggle via `akm config set index.graph true|false`.
+- When enabled, the index process extracts entities and relations using the configured LLM and persists a queryable graph file under the stash.
+- Search ranking consults the graph when it exists; otherwise behaves as today.
+
+### Why
+Folding graph building into indexing means users don't manage a separate `graph build` cadence — one `akm index` run keeps everything in sync. Same on/off-ramp as memory inference.
+
+### Acceptance
+- [ ] Graph file is written under the stash and refreshed on each index run when enabled.
+- [ ] Search ranking improvement is measurable for graph-eligible queries.
+- [ ] Toggling off doesn't remove the graph file (just stops refreshing it).
+
+---
+
+## 8. Single configurable LLM block reused across index passes
+
+**Title:** Unify `akm.llm` config across all index-time passes
+
+**Labels:** `enhancement`, `config`, `cli`
+
+**Body:**
+
+### Summary
+One `akm.llm` config block reused by every LLM-needing pass inside `akm index`.
+
+### Today
+The optional LLM is wired for indexing-time metadata enrichment, but additional passes (memory inference, graph extraction, future passes) would each need their own config wiring.
+
+### Proposal
+- Single `akm.llm` block in config — provider, model, baseUrl, etc.
+- Every LLM-using pass inside `akm index` reads this block by default.
+- Per-pass opt-out via `index.<pass>.llm = false` for users who want enrichment but not graph (or vice versa).
+
+### Why
+One place to configure, consistent behaviour across enrichment, inference, and graph building. Avoids fan-out where each pass has its own provider settings.
+
+### Acceptance
+- [ ] All index passes default to `akm.llm`.
+- [ ] Per-pass opt-out works.
+- [ ] No duplicate provider configuration paths.
+
+---
+
+## Explicitly **not** proposed (documented as non-goals)
+
+For maintainer reference, the following were considered and rejected so they don't get re-proposed:
+
+- **`akm serve` / any HTTP daemon** — akm will not serve HTTP. The CLI is the only programmatic surface; consumers either embed it as a subprocess or share the stash directory.
+- **`akm workflow schedule` / cron triggers** — out of scope for akm. Scheduling stays in the host (cron, systemd, the host app's scheduler).

--- a/docs/plans/upstream-issues/akm-cli-issues.md
+++ b/docs/plans/upstream-issues/akm-cli-issues.md
@@ -2,158 +2,49 @@
 
 These are ready to paste into <https://github.com/itlackey/akm/issues/new>. Each block has a suggested **title**, a body, and suggested **labels**. Source plan: `docs/plans/simplify-via-akm.md`.
 
-Selection criteria for this repo: features useful outside any specific host, runnable as a one-shot subprocess, no assumption about an agent loop. Items that need lifecycle hooks live in the akm-plugins repo (see `akm-plugins-issues.md`).
+> **Reality-checked against akm-cli 0.7.4 on 2026-05-06.** Most earlier proposals (memory inference, graph extraction, `akm events`, `akm history`, `akm feedback` on `memory:`/`vault:`, scope flags on `akm remember`) **already shipped**. Only the items below remain.
+
+Selection criteria: features useful outside any specific host. Plugin-side asks live in `akm-plugins-issues.md`.
 
 ---
 
-## 1. Memory-inference as part of `akm index`, controlled by global config
+## 1. Harness-LLM passthrough hook for `akm index --enrich`
 
-**Title:** Inference pass inside `akm index`, toggled via global config
+**Title:** Pluggable LLM proxy hook so embedding hosts can lend their provider connection to akm
 
-**Labels:** `enhancement`, `memory`, `index`, `cli`
+**Labels:** `enhancement`, `llm`, `index`, `cli`
 
 **Body:**
 
 ### Summary
-Add an opt-in inference pass to `akm index` that uses the configured LLM to split memories pending inference into atomic facts.
+A documented hook that lets a wrapping process (an agent harness, a CI runner, anything) supply an LLM backend to akm without configuring `akm.llm` directly.
 
 ### Today
-`akm remember "<text>"` stores the input verbatim. Consumers that want atomic recall (RAG pipelines, anything summarising long inputs) build their own extraction loop.
+`akm index --enrich` requires an LLM configured at the akm config layer (`akm.llm`). If the host harness — opencode, Claude Code, anything else — already has provider credentials, akm has no way to borrow them. Users either configure providers twice (once for their agent, once for akm) or skip enrichment.
 
 ### Proposal
-Extend the existing index process to detect memories pending inference and run the configured LLM over them, splitting each into atomic memories with frontmatter `inferred: true` and a backref to the source.
+A documented hook akm consults when no native `akm.llm` is configured:
 
-- Toggle via `akm config set index.infer true|false`.
-- When disabled: indexing leaves memories untouched.
-- When enabled: every `akm index` run drains the pending queue.
-- No new flag on `akm remember` — the verb surface stays the same.
+- New env var `AKM_LLM_PROXY_CMD=<path-to-shim>` (and/or config key `akm.llm.proxy = "<path>"`).
+- akm spawns the shim once per LLM call, sending a JSON request on stdin (model, messages, temperature, etc.) and reading a JSON response from stdout.
+- Same JSON envelope conventions as the rest of akm.
+- The shim is the host's responsibility — akm just defines the contract.
 
-### Why this shape
-Folding the work into the existing indexing pipeline lets users adopt it just by scheduling `akm index`, with no new flags to remember. It also keeps the extraction logic in one place rather than scattering it across consumers.
+### Why CLI, not plugin
+The contract has to live in akm so any harness (opencode, Claude Code, anything new) can implement the shim half. Without it, every harness reinvents wiring.
 
 ### Acceptance
-- [ ] Pending memories are detected by indexer.
-- [ ] When `index.infer=true`, atomic memories are written with `inferred: true` and a `source:` backref.
-- [ ] Re-running indexing is idempotent.
-- [ ] Toggling off via config halts the pass without losing existing inferred memories.
+- [ ] Documented JSON request / response shape.
+- [ ] When `AKM_LLM_PROXY_CMD` is set and no `akm.llm` is configured, `akm index --enrich` uses the proxy.
+- [ ] Native `akm.llm` config takes precedence over the proxy when both are set.
+- [ ] Proxy failures surface clearly (don't silently degrade enrichment).
+
+### Pairs with
+A matching shim implementation in `itlackey/akm-plugins/opencode/` and `itlackey/akm-plugins/claude/` (filed as separate issues there).
 
 ---
 
-## 2. First-class memory scoping (`--user`, `--agent`, `--run`, `--channel`)
-
-**Title:** Native scoping flags on `akm remember` / `akm search` / `akm show`
-
-**Labels:** `enhancement`, `memory`, `cli`
-
-**Body:**
-
-### Summary
-Add canonical scope flags so multi-user / multi-agent deployments stop inventing their own conventions.
-
-### Today
-Scoping is achievable only by setting a different `AKM_STASH_DIR` per scope or by writing custom frontmatter via a host wrapper.
-
-### Proposal
-- `akm remember "<text>" --user <id> --agent <id> --run <id> --channel <name>` — persists the values as canonical frontmatter.
-- `akm search "<query>" --filter user=<id> --filter agent=<id> ...` — pre-filters via the search index.
-- `akm show memory:<ref> --scope user=<id>` — narrows resolution.
-
-### Why
-Any multi-user / multi-agent / multi-tenant deployment of akm needs this. Today every consumer (chatbots, shared dev teams, multi-tenant deployments) invents its own scoping convention, which makes stashes non-portable.
-
-### Acceptance
-- [ ] Scope flags persist as a stable frontmatter shape.
-- [ ] Search index respects the filters at query time.
-- [ ] Existing memories without scope still match unfiltered queries.
-
----
-
-## 3. `akm feedback` should accept any valid ref
-
-**Title:** Allow `akm feedback` on any valid ref (memory, vault, etc.)
-
-**Labels:** `enhancement`, `feedback`, `cli`
-
-**Body:**
-
-### Summary
-`akm feedback` currently rejects some ref types (notably `memory:` and `vault:`). The opencode plugin auto-skips those refs as a result, so relevance signal on memories and vaults has no upstream path.
-
-### Proposal
-Allow feedback on any valid ref. Vault feedback can store an aggregated count without leaking values (counts, not contents). Hybrid ranking already reads frontmatter for boosts, so the wiring is small.
-
-### Why
-Closes the relevance-learning loop uniformly across asset types instead of asking consumers to remember which refs are "feedback-eligible".
-
-### Acceptance
-- [ ] `akm feedback memory:<ref> --positive` succeeds and is reflected in subsequent ranking.
-- [ ] `akm feedback vault:<ref> --positive` succeeds without surfacing values.
-- [ ] No ref type silently rejects feedback.
-
----
-
-## 4. `akm events` — read / tail asset-mutation events
-
-**Title:** Append-only events stream + `akm events list|tail`
-
-**Labels:** `enhancement`, `observability`, `cli`
-
-**Body:**
-
-### Summary
-Add a documented event stream so external observers (sync, replication, audit, dashboards) can react to stash changes without polling.
-
-### Today
-There is no documented event stream; consumers have to scrape mtimes or build their own log.
-
-### Proposal
-- An append-only `events.jsonl` written by the CLI on every add / update / delete / feedback / index pass.
-- `akm events list [--since <ts>] [--type <event-type>] [--ref <ref>]` — paged history.
-- `akm events tail [--since <ts>]` — follow mode.
-- Same JSON envelope conventions as the rest of the CLI.
-
-### Why
-Foundational for any external observer that needs to react to stash changes without polling. Pairs naturally with the periodic-`akm index` pattern for downstream consumers, and is a clean primitive even when no harness is involved.
-
-### Acceptance
-- [ ] Every CLI verb that mutates state emits an event.
-- [ ] `--since` is monotonic and durable across processes.
-- [ ] `tail` keeps up with concurrent writers without losing events.
-
----
-
-## 5. `akm history` — surface the existing mutation history
-
-**Title:** First-class `akm history` command
-
-**Labels:** `enhancement`, `observability`, `cli`
-
-**Body:**
-
-### Summary
-Surface the mutation history akm already writes so downstream tools don't reinvent it.
-
-### Today
-akm writes mutation history internally; there is no first-class command to read it. Consumers wanting an audit trail either scrape filesystem mtimes or build a parallel log.
-
-### Proposal
-`akm history [--ref <ref>] [--since <ts>] [--format json|jsonl|text|yaml]` — returns per-asset and stash-wide history with the same JSON envelope as the rest of the CLI.
-
-Distinct from `akm events`:
-- **history** = per-asset state changes ("this memory was added then edited then deleted").
-- **events** = realtime stream of any mutation across the stash.
-
-### Why
-Closes the audit-trail need without forcing every downstream tool to build its own.
-
-### Acceptance
-- [ ] `akm history --ref memory:<id>` shows full lifecycle of a single asset.
-- [ ] `akm history` (no ref) shows stash-wide history.
-- [ ] JSON envelope matches existing CLI conventions.
-
----
-
-## 6. Pluggable secret backends and rotation for `akm vault` *(future consideration)*
+## 2. Pluggable secret backends and rotation for `akm vault` *(future consideration)*
 
 **Title:** Pluggable secret backends + rotation for `akm vault`
 
@@ -161,10 +52,10 @@ Closes the audit-trail need without forcing every downstream tool to build its o
 
 **Body:**
 
-> Status: deferred / future consideration. Filed so the design is captured; not a near-term commitment.
+> Status: deferred / future consideration. Filed so the design is captured; not a near-term commitment. Tracks #190.
 
 ### Summary
-Make `akm vault` a credible production secret store rather than a developer-laptop convenience. Tracks #190.
+Make `akm vault` a credible production secret store rather than a developer-laptop convenience.
 
 ### Today
 Vault is `.env`-style files only; no rotation, no remote secret-manager integration.
@@ -186,68 +77,59 @@ Production deployments need rotation and centralised secret management. Today us
 
 ---
 
-## 7. Graph-build as part of `akm index`, controlled by global config
+## 3. Bug: scope-flag inconsistency across `remember` / `search` / `show`
 
-**Title:** Graph-extraction pass inside `akm index`, toggled via global config
+**Title:** Scope flag shape differs between `akm remember` and `akm search` / `akm show`
 
-**Labels:** `enhancement`, `index`, `graph`, `cli`
-
-**Body:**
-
-### Summary
-Add an opt-in graph pass to `akm index` that extracts entities and relations from `memory:` and `knowledge:` assets.
-
-### Today
-akm's hybrid search is purely document-level. Graph reasoning across memories is left to consumers, which forces every stack with that need to bolt on a separate graph-memory service.
-
-### Proposal
-Same shape as the inference pass (#1):
-- Toggle via `akm config set index.graph true|false`.
-- When enabled, the index process extracts entities and relations using the configured LLM and persists a queryable graph file under the stash.
-- Search ranking consults the graph when it exists; otherwise behaves as today.
-
-### Why
-Folding graph building into indexing means users don't manage a separate `graph build` cadence — one `akm index` run keeps everything in sync. Same on/off-ramp as memory inference.
-
-### Acceptance
-- [ ] Graph file is written under the stash and refreshed on each index run when enabled.
-- [ ] Search ranking improvement is measurable for graph-eligible queries.
-- [ ] Toggling off doesn't remove the graph file (just stops refreshing it).
-
----
-
-## 8. Single configurable LLM block reused across index passes
-
-**Title:** Unify `akm.llm` config across all index-time passes
-
-**Labels:** `enhancement`, `config`, `cli`
+**Labels:** `bug`, `scoping`, `cli`, `dx`
 
 **Body:**
 
 ### Summary
-One `akm.llm` config block reused by every LLM-needing pass inside `akm index`.
+`akm remember` accepts direct scope flags (`--user`, `--agent`, `--run`, `--channel`); `akm search` requires `--filter <key>=<value>` and `akm show` requires `--scope <key>=<value>`. The asymmetry is undocumented and silently breaks integrations that assume a uniform shape.
 
-### Today
-The optional LLM is wired for indexing-time metadata enrichment, but additional passes (memory inference, graph extraction, future passes) would each need their own config wiring.
+### Repro
+```sh
+akm remember "test" --user alice                   # works
+akm search "test" --user alice                     # unknown flag (or silently ignored, depending on argv parser)
+akm show memory:<ref> --user alice                 # same
+akm search "test" --filter user=alice              # works
+akm show memory:<ref> --scope user=alice           # works
+```
 
-### Proposal
-- Single `akm.llm` block in config — provider, model, baseUrl, etc.
-- Every LLM-using pass inside `akm index` reads this block by default.
-- Per-pass opt-out via `index.<pass>.llm = false` for users who want enrichment but not graph (or vice versa).
+### Source pointers
+- `src/commands/remember.ts` — direct flags.
+- `src/commands/search.ts` — `parseScopeFilterFlags()` consuming `--filter <k>=<v>`.
+- `src/commands/show.ts` — `--scope <k>=<v>`.
 
-### Why
-One place to configure, consistent behaviour across enrichment, inference, and graph building. Avoids fan-out where each pass has its own provider settings.
+### Why this matters
+The `akm-opencode` plugin uses a single `buildScopedArgs()` helper that pushes `--user`, `--agent`, etc. into argv for `remember`, `search`, **and** `show`. As a result, scope filtering on plugin-issued `search` / `show` calls silently fails today. Fixing the CLI fixes the plugin without a plugin release.
+
+### Suggested fix
+Pick one of:
+- (a) Accept both shapes on all three verbs (probably easiest — direct flags translate internally to the filter shape).
+- (b) Standardise on direct flags everywhere (simpler to use, harder for users with existing `--filter` callers).
+- (c) Just document the asymmetry prominently; leave shapes alone.
 
 ### Acceptance
-- [ ] All index passes default to `akm.llm`.
-- [ ] Per-pass opt-out works.
-- [ ] No duplicate provider configuration paths.
+- [ ] All three verbs accept the same scope-flag shape, OR the asymmetry is called out in `docs/cli.md` with examples per verb.
+- [ ] The akm-opencode plugin's `buildScopedArgs()` helper works against `search` / `show` after the fix (this can be verified in CI by spawning the CLI).
 
 ---
 
-## Explicitly **not** proposed (documented as non-goals)
+## Already shipped — no longer proposed
 
-For maintainer reference, the following were considered and rejected so they don't get re-proposed:
+For maintainer reference, the following appeared in earlier drafts and have since landed:
 
-- **`akm serve` / any HTTP daemon** — akm will not serve HTTP. The CLI is the only programmatic surface; consumers either embed it as a subprocess or share the stash directory.
-- **`akm workflow schedule` / cron triggers** — out of scope for akm. Scheduling stays in the host (cron, systemd, the host app's scheduler).
+- **`akm index --enrich`** (0.7.3) — covers metadata enrichment, memory inference, graph extraction.
+- **`akm events list|tail`** (0.7.x) — durable `events.jsonl` with `--since`/`--type`/`--ref` and byte-offset cursors.
+- **`akm history --include-proposals`** (0.7.x) — per-asset and stash-wide history.
+- **`akm feedback`** accepting `memory:` and `vault:` refs (0.7.x).
+- **Scope flags on `akm remember`** (`--user`, `--agent`, `--run`, `--channel`).
+- **`akm proposal | reflect | propose | distill`** verbs (0.7.0) — write-staging queue and reflection workflow.
+- **`lesson` asset type** (0.7.0).
+
+## Explicitly **not** proposed
+
+- **`akm serve` / any HTTP daemon** — the CLI is the only programmatic surface.
+- **`akm workflow schedule` / cron triggers** — scheduling stays in the host.

--- a/docs/plans/upstream-issues/akm-plugins-issues.md
+++ b/docs/plans/upstream-issues/akm-plugins-issues.md
@@ -2,180 +2,110 @@
 
 These are ready to paste into <https://github.com/itlackey/akm-plugins/issues/new>. Each block has a suggested **title**, a body, and suggested **labels**. Source plan: `docs/plans/simplify-via-akm.md`.
 
-Selection criteria for this repo: features that need agent-harness lifecycle hooks, tool registration, or system-prompt transforms. CLI-shaped enhancements live in <https://github.com/itlackey/akm/issues> (see `akm-cli-issues.md`).
+> **Reality-checked against akm-opencode 0.7.3 on 2026-05-06.** Most earlier proposals (`session.created` retrieval with budget, scope auto-attach, conversation-derived feedback with negative cues, session-end `akm index`) **already shipped** as env-var-controlled features. Only the items below remain.
 
-Each issue should ship in both the `opencode/` and `claude/` subdirectories (see #6 for the parity meta-issue).
-
----
-
-## 1. `session.created` retrieval with token budget
-
-**Title:** Inject curated context on session start, not just on first message
-
-**Labels:** `enhancement`, `opencode`, `claude`, `context`
-
-**Body:**
-
-### Summary
-Subscribe to the harness's session-start hook and inject curated context before the first user message.
-
-### Today
-The plugin injects context on `chat.message` (curate-on-message), not on session start. Cold sessions miss curated context until the user types.
-
-### Proposal
-On the harness session-start hook:
-- Run `akm curate --limit N --for-agent` against the session's scope (using the new CLI scope flags — see `itlackey/akm` issue "Native scoping flags").
-- Inject results via the harness's system-prompt transform (`experimental.chat.system.transform` for opencode; equivalent for Claude).
-- Budget configurable via `AKM_CONTEXT_BUDGET_CHARS`.
-
-### Why plugin, not CLI
-Requires harness lifecycle hooks and prompt-transform APIs that only exist inside the agent runtime.
-
-### Acceptance
-- [ ] Curated context appears in the system prompt of a fresh session before any user message.
-- [ ] Total injected size respects `AKM_CONTEXT_BUDGET_CHARS`.
-- [ ] Behaviour is parity-matched between `opencode/` and `claude/`.
+Each issue should ship in both the `opencode/` and `claude/` subdirectories (see #4 for the parity meta-issue).
 
 ---
 
-## 2. Auto-attach scope from harness session metadata
+## 1. Harness-LLM passthrough shim
 
-**Title:** Auto-pass `--user`/`--agent`/`--run`/`--channel` from harness session metadata
-
-**Labels:** `enhancement`, `opencode`, `claude`, `scoping`
-
-**Body:**
-
-### Summary
-When the harness exposes session metadata (channel, user id, agent id), the plugin transparently passes those through to the new CLI scope flags on every `akm_remember` / `akm_curate` call. No user action required.
-
-### Today
-There is no automatic scope attachment. Multi-user / multi-tenant deployments either run separate stashes per scope or write custom frontmatter via host wrappers.
-
-### Proposal
-- Read available session metadata from the harness on plugin init / hook fire.
-- Pass through to the CLI as `--user <id> --agent <id> --run <id> --channel <name>` on every `akm_remember`, `akm_curate`, `akm_feedback` call.
-- Configurable via `AKM_SCOPE_KEYS` if the user wants to opt in / out per field.
-
-### Why plugin, not CLI
-Scope sources are harness-specific (OpenCode session ids, Claude Code thread ids, etc.). The CLI provides the flags; the plugin knows how to fill them.
-
-### Depends on
-- `itlackey/akm` issue: "Native scoping flags on `akm remember` / `akm search` / `akm show`".
-
-### Acceptance
-- [ ] Memories created during a session carry the harness-derived scope as frontmatter.
-- [ ] Searching with the same scope returns those memories.
-- [ ] No bleed of scope into manually-invoked CLI calls outside the plugin.
-
----
-
-## 3. Conversation-derived feedback
-
-**Title:** Infer positive/negative feedback from conversation signals
-
-**Labels:** `enhancement`, `opencode`, `claude`, `feedback`
-
-**Body:**
-
-### Summary
-Extend the existing positive-cue matcher to negative cues, multi-turn confirmation, and explicit "this was wrong" detection. Call `akm feedback <ref>` against any harvested ref.
-
-### Today
-`akm-opencode` has `AKM_RETROSPECTIVE_FEEDBACK_PATTERN` matching positive cues only. Negative signal goes nowhere; explicit corrections aren't captured.
-
-### Proposal
-- Add a configurable negative-cue pattern (`AKM_RETROSPECTIVE_NEGATIVE_PATTERN`) and a corrected-fact detector.
-- On match, call `akm feedback <ref>` against the most-recently-used asset(s) for that turn.
-- Works for any ref type, including memories, once the CLI accepts them (see CLI issue "Allow `akm feedback` on any valid ref").
-
-### Why plugin, not CLI
-Needs access to the conversation transcript and the harness's tool-execution timeline.
-
-### Depends on
-- `itlackey/akm` issue: "Allow `akm feedback` on any valid ref".
-
-### Acceptance
-- [ ] Negative cues trigger negative feedback against the right asset(s).
-- [ ] Multi-turn confirmation is required before flipping feedback (avoids false positives on hedging).
-- [ ] Behaviour parity-matched in `opencode/` and `claude/`.
-
----
-
-## 4. Session-end optionally runs `akm index`
-
-**Title:** Optional `akm index` invocation on session end
-
-**Labels:** `enhancement`, `opencode`, `claude`, `index`
-
-**Body:**
-
-### Summary
-After flushing the session buffer to a memory artifact, optionally invoke `akm index` so the new memories are processed (inference, graph) by akm's index passes.
-
-### Today
-The plugin already flushes a session buffer into a memory artifact on `stop` / `session.idle` / `session.compacted` / `session.deleted`. Index-time passes only fire when the host runs `akm index` separately.
-
-### Proposal
-- Gate via `AKM_INDEX_ON_SESSION_END=1` (default off so single-session users don't pay the cost).
-- After the existing flush, run `akm index` once.
-- With the new index-pass config (CLI issues "Inference pass inside `akm index`" and "Graph-extraction pass inside `akm index`"), a single run handles inference and graph passes — no plugin-side extraction logic.
-
-### Why plugin, not CLI
-The trigger is the harness lifecycle event; the work itself is upstream.
-
-### Depends on
-- `itlackey/akm` issue: "Inference pass inside `akm index`, toggled via global config".
-- `itlackey/akm` issue: "Graph-extraction pass inside `akm index`, toggled via global config" (optional).
-
-### Acceptance
-- [ ] When env toggle is set, `akm index` runs once at session end.
-- [ ] Failures are logged and do not abort session cleanup.
-- [ ] Behaviour parity-matched in `opencode/` and `claude/`.
-
----
-
-## 5. Harness-provided LLM fallback for akm passes
-
-**Title:** Lend the harness's provider connection to akm when no `akm.llm` is configured
+**Title:** Implement the `AKM_LLM_PROXY_CMD` shim so akm can borrow the harness's provider connection
 
 **Labels:** `enhancement`, `opencode`, `claude`, `llm`, `index`
 
 **Body:**
 
 ### Summary
-When the harness already has provider credentials configured for the agent, the plugin offers them to akm as the LLM backend for index-time passes (memory inference, graph build).
+When the user has provider credentials configured for the agent harness but no `akm.llm` configured for akm, expose those credentials to akm via a small stdio shim. Pairs with the matching `AKM_LLM_PROXY_CMD` hook proposed in `itlackey/akm` (CLI side).
 
 ### Today
-If no LLM is configured for akm, the new index passes (inference, graph) cannot run.
+`akm index --enrich` requires `akm.llm`. Users either configure providers twice (once for the harness, once for akm) or skip enrichment entirely.
 
 ### Proposal
-- Plugin detects that akm has no `akm.llm` configured.
-- Plugin exposes a small shim (e.g., a local script or socket) and sets a CLI-side env / config such as `AKM_LLM_PROXY_CMD=<shim path>`.
-- akm consults the proxy command when no native LLM is configured; the shim forwards prompts through the harness's existing provider connection and returns the result.
-- No provider credentials cross the plugin / CLI boundary in plaintext — the shim handles invocation.
+- On plugin init, detect that no `akm.llm` is configured.
+- Spawn / register a tiny shim (a Bun script bundled with the plugin) and set `AKM_LLM_PROXY_CMD=<shim path>` for child `akm` invocations.
+- The shim reads the JSON request from stdin (per the upstream CLI hook contract), forwards it through the harness's existing provider connection, and writes the JSON response back to stdout.
+- No provider credentials cross the plugin / CLI boundary in plaintext — the shim handles the call.
 
 ### Why plugin, not CLI
 Only the harness has the user-authenticated provider connection; akm itself stays harness-agnostic.
 
-### Open questions
-- Exact shim contract (stdio / unix socket / file).
-- Streaming vs. one-shot.
-- Per-pass model selection.
-
 ### Depends on
-- `itlackey/akm` issue: "Single configurable LLM block reused across index passes" (the proxy hooks into the same config path).
+- `itlackey/akm` issue: "Pluggable LLM proxy hook so embedding hosts can lend their provider connection to akm" — the CLI defines the contract; the plugin implements one side of it.
 
 ### Acceptance
-- [ ] With no `akm.llm` configured but a harness LLM available, `akm index` passes succeed.
+- [ ] With no `akm.llm` configured but a harness LLM available, `akm index --enrich` succeeds via the plugin shim.
 - [ ] Disabling the harness LLM falls back to no-op (not error) on index passes.
 - [ ] Behaviour parity-matched in `opencode/` and `claude/`.
 
 ---
 
-## 6. Cross-harness parity (meta)
+## 2. Bug: stale `feedback` guard skips `memory:` and `vault:` refs
 
-**Title:** Track feature parity between `opencode/` and `claude/` plugins
+**Title:** Remove stale guard that skips `akm feedback` for `memory:` and `vault:` refs
+
+**Labels:** `bug`, `opencode`, `claude`, `feedback`
+
+**Body:**
+
+### Summary
+The opencode plugin contains a guard that skips feedback for `memory:` and `vault:` refs, with a comment claiming "memories do not accept feedback." That comment is stale — akm-cli 0.7.x **does** accept feedback on those refs.
+
+### Source pointer
+`itlackey/akm-plugins/blob/main/opencode/index.ts` — search for:
+
+```ts
+if (ref.startsWith("memory:") || ref.startsWith("vault:")) continue;
+```
+
+### Today
+Plugin silently drops legitimate feedback on memories and vaults, breaking the relevance-learning loop on the asset types users re-rank most.
+
+### Proposal
+- Remove the guard.
+- Mirror in `claude/` if the same guard exists there.
+- Optionally add a fast-path that reuses the existing feedback batching logic.
+
+### Acceptance
+- [ ] `akm feedback memory:<ref> --positive` issued through the plugin actually runs.
+- [ ] `akm feedback vault:<ref> --positive` issued through the plugin actually runs.
+- [ ] Existing tests (if any) cover the removed branch.
+- [ ] Behaviour parity-matched in `opencode/` and `claude/`.
+
+---
+
+## 3. Bug: `buildScopedArgs()` sends `--user`/`--agent`/etc. to verbs that don't accept them
+
+**Title:** Plugin sends direct scope flags to `search` and `show`, but those verbs expect `--filter`/`--scope`
+
+**Labels:** `bug`, `opencode`, `claude`, `scoping`
+
+**Body:**
+
+### Summary
+A single `buildScopedArgs()` helper pushes `--user X --agent Y --run Z --channel C` into argv for `akm remember`, `akm search`, **and** `akm show`. Only `remember` accepts that shape today — `search` expects `--filter <k>=<v>` and `show` expects `--scope <k>=<v>`. As a result, scope filtering on plugin-issued search/show calls silently fails.
+
+### Source pointer
+`itlackey/akm-plugins/blob/main/opencode/index.ts` — `buildScopedArgs()` and the call sites that route through `akm_search` / `akm_show`.
+
+### Resolution options
+Pick one (mirror in `claude/`):
+- (a) Wait for / depend on the upstream CLI fix (`itlackey/akm` issue: "Scope flag shape differs between `akm remember` and `akm search` / `akm show`") to accept both shapes.
+- (b) Update `buildScopedArgs()` to emit the right shape per verb:
+  - `remember`: `--user X --agent Y ...`
+  - `search`: `--filter user=X --filter agent=Y ...`
+  - `show`: `--scope user=X --scope agent=Y ...`
+
+### Acceptance
+- [ ] Plugin-issued `akm_search` / `akm_show` honour scope.
+- [ ] Behaviour parity-matched in `opencode/` and `claude/`.
+
+---
+
+## 4. Cross-harness parity (meta)
+
+**Title:** Track feature / bug-fix parity between `opencode/` and `claude/`
 
 **Labels:** `meta`, `opencode`, `claude`
 
@@ -184,20 +114,25 @@ Only the harness has the user-authenticated provider connection; akm itself stay
 ### Summary
 Meta-issue to track parity between the two harness plugins as the issues above land.
 
-### Why
-Each harness has its own hook surface; parity has to be coded per-harness. A meta-issue surfaces drift.
-
-### Tracked features
-- [ ] Session-start retrieval (#1)
-- [ ] Auto-attach scope (#2)
-- [ ] Conversation-derived feedback (#3)
-- [ ] Session-end `akm index` (#4)
-- [ ] Harness-provided LLM fallback (#5)
+### Tracked items
+- [ ] Harness-LLM passthrough shim (#1)
+- [ ] `feedback` guard removal (#2)
+- [ ] `buildScopedArgs()` fix (#3)
 
 (Update issue numbers once filed.)
 
 ---
 
+## Already shipped — no longer proposed
+
+For maintainer reference, the following appeared in earlier drafts and have since landed in 0.7.x:
+
+- **Session-start retrieval with token budget** — `AKM_CONTEXT_BUDGET_CHARS` is honoured by the existing `session.created` hook.
+- **Scope auto-attach from session metadata** — `AKM_SCOPE_KEYS` (default `user,agent,run,channel`) is forwarded automatically (modulo the bug in #3).
+- **Conversation-derived feedback (negative cues)** — `AKM_RETROSPECTIVE_NEGATIVE_PATTERN` ships alongside the original positive-cue pattern.
+- **Session-end optional `akm index`** — `AKM_INDEX_ON_SESSION_END=1` triggers `akm index` after the session-end flush.
+
 ## Out of scope for this repo
 
-- **Per-thread / per-conversation stash overlays** — considered, dropped. Scope flags (CLI side) cover the multi-user case without overlay complexity.
+- **Per-thread / per-conversation stash overlays** — considered, dropped. Scope flags + `AKM_SCOPE_KEYS` cover the multi-user case without overlay complexity.
+- **CLI auto-install on plugin load** — explicitly removed in 0.7.x. Hosts must install `akm` on PATH themselves.

--- a/docs/plans/upstream-issues/akm-plugins-issues.md
+++ b/docs/plans/upstream-issues/akm-plugins-issues.md
@@ -1,0 +1,203 @@
+# Upstream issue drafts — `itlackey/akm-plugins`
+
+These are ready to paste into <https://github.com/itlackey/akm-plugins/issues/new>. Each block has a suggested **title**, a body, and suggested **labels**. Source plan: `docs/plans/simplify-via-akm.md`.
+
+Selection criteria for this repo: features that need agent-harness lifecycle hooks, tool registration, or system-prompt transforms. CLI-shaped enhancements live in <https://github.com/itlackey/akm/issues> (see `akm-cli-issues.md`).
+
+Each issue should ship in both the `opencode/` and `claude/` subdirectories (see #6 for the parity meta-issue).
+
+---
+
+## 1. `session.created` retrieval with token budget
+
+**Title:** Inject curated context on session start, not just on first message
+
+**Labels:** `enhancement`, `opencode`, `claude`, `context`
+
+**Body:**
+
+### Summary
+Subscribe to the harness's session-start hook and inject curated context before the first user message.
+
+### Today
+The plugin injects context on `chat.message` (curate-on-message), not on session start. Cold sessions miss curated context until the user types.
+
+### Proposal
+On the harness session-start hook:
+- Run `akm curate --limit N --for-agent` against the session's scope (using the new CLI scope flags — see `itlackey/akm` issue "Native scoping flags").
+- Inject results via the harness's system-prompt transform (`experimental.chat.system.transform` for opencode; equivalent for Claude).
+- Budget configurable via `AKM_CONTEXT_BUDGET_CHARS`.
+
+### Why plugin, not CLI
+Requires harness lifecycle hooks and prompt-transform APIs that only exist inside the agent runtime.
+
+### Acceptance
+- [ ] Curated context appears in the system prompt of a fresh session before any user message.
+- [ ] Total injected size respects `AKM_CONTEXT_BUDGET_CHARS`.
+- [ ] Behaviour is parity-matched between `opencode/` and `claude/`.
+
+---
+
+## 2. Auto-attach scope from harness session metadata
+
+**Title:** Auto-pass `--user`/`--agent`/`--run`/`--channel` from harness session metadata
+
+**Labels:** `enhancement`, `opencode`, `claude`, `scoping`
+
+**Body:**
+
+### Summary
+When the harness exposes session metadata (channel, user id, agent id), the plugin transparently passes those through to the new CLI scope flags on every `akm_remember` / `akm_curate` call. No user action required.
+
+### Today
+There is no automatic scope attachment. Multi-user / multi-tenant deployments either run separate stashes per scope or write custom frontmatter via host wrappers.
+
+### Proposal
+- Read available session metadata from the harness on plugin init / hook fire.
+- Pass through to the CLI as `--user <id> --agent <id> --run <id> --channel <name>` on every `akm_remember`, `akm_curate`, `akm_feedback` call.
+- Configurable via `AKM_SCOPE_KEYS` if the user wants to opt in / out per field.
+
+### Why plugin, not CLI
+Scope sources are harness-specific (OpenCode session ids, Claude Code thread ids, etc.). The CLI provides the flags; the plugin knows how to fill them.
+
+### Depends on
+- `itlackey/akm` issue: "Native scoping flags on `akm remember` / `akm search` / `akm show`".
+
+### Acceptance
+- [ ] Memories created during a session carry the harness-derived scope as frontmatter.
+- [ ] Searching with the same scope returns those memories.
+- [ ] No bleed of scope into manually-invoked CLI calls outside the plugin.
+
+---
+
+## 3. Conversation-derived feedback
+
+**Title:** Infer positive/negative feedback from conversation signals
+
+**Labels:** `enhancement`, `opencode`, `claude`, `feedback`
+
+**Body:**
+
+### Summary
+Extend the existing positive-cue matcher to negative cues, multi-turn confirmation, and explicit "this was wrong" detection. Call `akm feedback <ref>` against any harvested ref.
+
+### Today
+`akm-opencode` has `AKM_RETROSPECTIVE_FEEDBACK_PATTERN` matching positive cues only. Negative signal goes nowhere; explicit corrections aren't captured.
+
+### Proposal
+- Add a configurable negative-cue pattern (`AKM_RETROSPECTIVE_NEGATIVE_PATTERN`) and a corrected-fact detector.
+- On match, call `akm feedback <ref>` against the most-recently-used asset(s) for that turn.
+- Works for any ref type, including memories, once the CLI accepts them (see CLI issue "Allow `akm feedback` on any valid ref").
+
+### Why plugin, not CLI
+Needs access to the conversation transcript and the harness's tool-execution timeline.
+
+### Depends on
+- `itlackey/akm` issue: "Allow `akm feedback` on any valid ref".
+
+### Acceptance
+- [ ] Negative cues trigger negative feedback against the right asset(s).
+- [ ] Multi-turn confirmation is required before flipping feedback (avoids false positives on hedging).
+- [ ] Behaviour parity-matched in `opencode/` and `claude/`.
+
+---
+
+## 4. Session-end optionally runs `akm index`
+
+**Title:** Optional `akm index` invocation on session end
+
+**Labels:** `enhancement`, `opencode`, `claude`, `index`
+
+**Body:**
+
+### Summary
+After flushing the session buffer to a memory artifact, optionally invoke `akm index` so the new memories are processed (inference, graph) by akm's index passes.
+
+### Today
+The plugin already flushes a session buffer into a memory artifact on `stop` / `session.idle` / `session.compacted` / `session.deleted`. Index-time passes only fire when the host runs `akm index` separately.
+
+### Proposal
+- Gate via `AKM_INDEX_ON_SESSION_END=1` (default off so single-session users don't pay the cost).
+- After the existing flush, run `akm index` once.
+- With the new index-pass config (CLI issues "Inference pass inside `akm index`" and "Graph-extraction pass inside `akm index`"), a single run handles inference and graph passes — no plugin-side extraction logic.
+
+### Why plugin, not CLI
+The trigger is the harness lifecycle event; the work itself is upstream.
+
+### Depends on
+- `itlackey/akm` issue: "Inference pass inside `akm index`, toggled via global config".
+- `itlackey/akm` issue: "Graph-extraction pass inside `akm index`, toggled via global config" (optional).
+
+### Acceptance
+- [ ] When env toggle is set, `akm index` runs once at session end.
+- [ ] Failures are logged and do not abort session cleanup.
+- [ ] Behaviour parity-matched in `opencode/` and `claude/`.
+
+---
+
+## 5. Harness-provided LLM fallback for akm passes
+
+**Title:** Lend the harness's provider connection to akm when no `akm.llm` is configured
+
+**Labels:** `enhancement`, `opencode`, `claude`, `llm`, `index`
+
+**Body:**
+
+### Summary
+When the harness already has provider credentials configured for the agent, the plugin offers them to akm as the LLM backend for index-time passes (memory inference, graph build).
+
+### Today
+If no LLM is configured for akm, the new index passes (inference, graph) cannot run.
+
+### Proposal
+- Plugin detects that akm has no `akm.llm` configured.
+- Plugin exposes a small shim (e.g., a local script or socket) and sets a CLI-side env / config such as `AKM_LLM_PROXY_CMD=<shim path>`.
+- akm consults the proxy command when no native LLM is configured; the shim forwards prompts through the harness's existing provider connection and returns the result.
+- No provider credentials cross the plugin / CLI boundary in plaintext — the shim handles invocation.
+
+### Why plugin, not CLI
+Only the harness has the user-authenticated provider connection; akm itself stays harness-agnostic.
+
+### Open questions
+- Exact shim contract (stdio / unix socket / file).
+- Streaming vs. one-shot.
+- Per-pass model selection.
+
+### Depends on
+- `itlackey/akm` issue: "Single configurable LLM block reused across index passes" (the proxy hooks into the same config path).
+
+### Acceptance
+- [ ] With no `akm.llm` configured but a harness LLM available, `akm index` passes succeed.
+- [ ] Disabling the harness LLM falls back to no-op (not error) on index passes.
+- [ ] Behaviour parity-matched in `opencode/` and `claude/`.
+
+---
+
+## 6. Cross-harness parity (meta)
+
+**Title:** Track feature parity between `opencode/` and `claude/` plugins
+
+**Labels:** `meta`, `opencode`, `claude`
+
+**Body:**
+
+### Summary
+Meta-issue to track parity between the two harness plugins as the issues above land.
+
+### Why
+Each harness has its own hook surface; parity has to be coded per-harness. A meta-issue surfaces drift.
+
+### Tracked features
+- [ ] Session-start retrieval (#1)
+- [ ] Auto-attach scope (#2)
+- [ ] Conversation-derived feedback (#3)
+- [ ] Session-end `akm index` (#4)
+- [ ] Harness-provided LLM fallback (#5)
+
+(Update issue numbers once filed.)
+
+---
+
+## Out of scope for this repo
+
+- **Per-thread / per-conversation stash overlays** — considered, dropped. Scope flags (CLI side) cover the multi-user case without overlay complexity.


### PR DESCRIPTION
Captures the proposed simplification: drop the memory service, the
OpenViking addon, and varlock; fold the scheduler into the assistant
container; install akm in guardian/assistant/admin and share the stash
via a host bind-mount. Each capability gap is mapped to a scheduled
automation or an assistant OpenCode plugin tool.

https://claude.ai/code/session_01VEJYgDR6uqCHz8NBoVufqa