### PR TITLE
Add Azure Container Apps deployment plan for simplified architecture

### DIFF
--- a/deploy/azure/PLAN.md
+++ b/deploy/azure/PLAN.md
@@ -6,7 +6,7 @@
 - Keep only assistant and guardian.
 - Expose the assistant's OpenCode webserver as the default ACA ingress, restricted to an explicit IP allowlist.
 - Eliminate the VM entirely — deploy purely on Azure Container Apps.
-- Add an hourly AKM database backup that safely snapshots the SQLite database in `$HOME/.local/state` to an Azure File Share and retains 7 days of rolling copies. The backup runs as a sidecar container inside the assistant app so it has direct filesystem access and can use SQLite's online backup API without raw file copying.
+- Add an hourly AKM database backup that safely snapshots the SQLite database in `$HOME/.local/state` to an Azure File Share and retains 7 days of rolling copies. The backup runs as a sidecar container inside the assistant app sharing an emptyDir volume, and uses SQLite's online backup API to write consistent snapshots to Azure Files.
 
 ## Architecture
 
@@ -21,16 +21,25 @@ ACA Ingress — openpalm-assistant
     ▼
 openpalm-guardian  :8080  (internal-only ingress)
     HMAC validation, audit logging
-    ↔ routes to openpalm-assistant:4096
 
 akm-backup  (sidecar in openpalm-assistant)
-    runs every hour inside the assistant app
-    reads $HOME/.local/state/*.db via shared home volume
-    writes to openpalm-akm-backups share
+    shares emptyDir volume with the opencode container
+    runs sqlite3 .backup every hour: emptyDir → Azure Files backup share
+    restores from latest backup share snapshot on container cold start
     retains 7 days of timestamped snapshots
 ```
 
-Guardian has no external ingress in this deployment. It remains internal for any channel integrations added later. The OpenCode web server on the assistant is the only publicly reachable endpoint and is guarded by an ACA IP security restriction allowlist.
+Guardian has no external ingress in this deployment. It remains internal for future channel integrations. The OpenCode web server on the assistant is the only publicly reachable endpoint, guarded by an ACA IP security restriction allowlist.
+
+## Why the home directory cannot go on Azure Files
+
+Azure Files uses the SMB protocol. SMB does not correctly implement POSIX advisory file locks (`fcntl`/`flock`). SQLite relies on these locks for all write serialisation and WAL-mode coordination. Running a live SQLite database on an SMB mount produces "database is locked" errors, torn writes, and eventual corruption.
+
+**Consequence:** no path that contains an active SQLite database can be mounted from Azure Files. The AKM database at `$HOME/.local/state/` must live on a local, POSIX-compliant filesystem inside the container.
+
+**Solution:** use an ACA `emptyDir` volume for `/home/opencode/.local/state/`. An emptyDir is provisioned from the ACA host's local disk, has full POSIX lock semantics, and is shared between all containers in the same app revision. The sidecar reads the live database from this emptyDir and writes consistent snapshots to Azure Files using `sqlite3 .backup` (the SQLite Online Backup API, which is safe for concurrent write activity).
+
+The emptyDir is ephemeral — it is cleared when the app revision is replaced or the container restarts. Durability is provided by the hourly backup cycle: on each cold start the assistant entrypoint checks whether the state directory is empty and, if so, copies the latest snapshot from the Azure Files backup share before OpenCode starts. The maximum data loss window is the interval between the last successful backup and the crash (at most one hour).
 
 ## Azure Resources
 
@@ -44,37 +53,178 @@ Guardian has no external ingress in this deployment. It remains internal for any
 | `kv-openpalm-<suffix>` | Key Vault | All runtime secrets; no inline secrets in YAML |
 | `id-openpalm` | User-assigned Managed Identity | Grants apps Key Vault Secrets User role |
 
-### Azure Files Shares
+## Volume Layout
 
-| Share name | Mounted in | Container path | Access |
-|---|---|---|---|
-| `openpalm-assistant-home` | opencode (main), akm-backup (sidecar) | `/home/opencode` | rw (main), ro (sidecar) |
-| `openpalm-config` | opencode (main) | `/etc/openpalm` | ro |
-| `openpalm-work` | opencode (main) | `/work` | rw |
-| `openpalm-logs` | opencode (main) | `/home/opencode/.local/state/opencode` | rw |
-| `openpalm-stash` | opencode (main) | `/home/opencode/.akm` | rw |
-| `openpalm-guardian-data` | guardian | `/app/data` | rw |
-| `openpalm-guardian-logs` | guardian | `/app/audit` | rw |
-| `openpalm-akm-backups` | akm-backup (sidecar) | `/backup` | rw |
+### Azure Files shares
 
-The AKM SQLite database lives under `$HOME/.local/state/` inside the main opencode container, which is part of the `openpalm-assistant-home` share. The sidecar mounts that same share read-only so it can never write to or corrupt the live database. Backups are written to the separate `openpalm-akm-backups` share.
+Mounted only at paths that never contain SQLite databases. All shares use SMB.
 
-The `openpalm-logs` share overlays a subdirectory of the home share (`/home/opencode/.local/state/opencode`). The AKM database is NOT inside that subdirectory; it sits directly under `.local/state/` and is therefore visible to the sidecar through the home share mount.
+| Share name | Container | Mount path | Mode | Purpose |
+|---|---|---|---|---|
+| `openpalm-opencode-config` | opencode | `/home/opencode/.config/opencode` | rw | OpenCode config files |
+| `openpalm-opencode-share` | opencode | `/home/opencode/.local/share/opencode` | rw | auth.json and OpenCode shared data |
+| `openpalm-stash` | opencode | `/home/opencode/.akm` | rw | AKM stash artifacts (files, not the db) |
+| `openpalm-config` | opencode | `/etc/openpalm` | ro | Operator config |
+| `openpalm-work` | opencode | `/work` | rw | Assistant workspace |
+| `openpalm-guardian-data` | guardian | `/app/data` | rw | Guardian state |
+| `openpalm-guardian-logs` | guardian | `/app/audit` | rw | Guardian audit log |
+| `openpalm-akm-backups` | opencode (ro), akm-backup (rw) | `/mnt/akm-restore` (opencode), `/backup` (sidecar) | ro / rw | Backup snapshots; opencode mounts read-only for restore on cold start |
 
-## Key Vault Secrets
+### ACA emptyDir volume
 
-All secrets are written to Key Vault during `setup` before any apps are deployed. The managed identity is attached to every app and job; no inline secret values appear in any YAML or script log.
+| Volume name | Containers | Mount path | Mode | Purpose |
+|---|---|---|---|---|
+| `state-vol` | opencode (rw), akm-backup (ro) | `/home/opencode/.local/state` | rw / ro | AKM SQLite database; proper POSIX locks on local disk |
 
-| Secret name | Consumer | Description |
+The emptyDir is created fresh on each container start. It is shared between containers in the same app revision but is not shared across revisions or app restarts. Durability is provided by the backup/restore cycle described below.
+
+### What is not mounted
+
+The rest of `/home/opencode` (`.cache/`, `.bun/`, `.local/bin/`, etc.) lives on the container's layer filesystem. These are either reinstalled at startup by the entrypoint or are truly ephemeral caches. The entrypoint already calls `ensure_home_layout` to create required directories.
+
+OpenCode logs (previously at `/home/opencode/.local/state/opencode`) are now inside the emptyDir and are ephemeral. This is acceptable — logs are a debug aid, not durable state. If persistent logs are required, mount an additional Azure Files share at `/home/opencode/.local/state/opencode` (this subdirectory path does not contain SQLite files and is SMB-safe).
+
+## Restore-on-Start and Backup Cycle
+
+### Cold start restore (entrypoint change)
+
+The assistant's `entrypoint.sh` requires one new function added before `start_opencode`:
+
+```sh
+maybe_restore_akm_db() {
+  local db_path="${AKM_DB_PATH:-/home/opencode/.local/state/akm.db}"
+  local restore_mount="/mnt/akm-restore"
+
+  # emptyDir is freshly created; restore from latest backup if the db is absent.
+  if [ -f "${db_path}" ]; then
+    return 0
+  fi
+
+  local latest
+  latest="$(find "${restore_mount}" -maxdepth 1 -name 'snapshot-*' -type d 2>/dev/null \
+    | sort | tail -1)"
+
+  if [ -n "${latest}" ] && [ -f "${latest}/akm.db" ]; then
+    mkdir -p "$(dirname "${db_path}")"
+    cp "${latest}/akm.db" "${db_path}"
+    echo "Restored AKM db from ${latest}"
+  else
+    echo "No AKM backup found; starting with empty database"
+  fi
+}
+```
+
+This function is safe to call on every start: it is a no-op if the db already exists. On a container restart the emptyDir is cleared by ACA so the restore path always runs.
+
+`AKM_DB_PATH` must be passed as an environment variable on the assistant container with the exact path to the database file. The `openpalm-akm-backups` share is mounted read-only at `/mnt/akm-restore` in the main container for this purpose only.
+
+### Hourly backup (sidecar)
+
+The sidecar reads the live database via the shared emptyDir and writes a consistent snapshot to the Azure Files backup share using `sqlite3 .backup`.
+
+```sh
+#!/bin/sh
+set -eu
+
+AKM_DB_PATH="${AKM_DB_PATH:-/home/opencode/.local/state/akm.db}"
+BACKUP_ROOT="/backup"
+INTERVAL="${BACKUP_INTERVAL_SECONDS:-3600}"
+
+run_backup() {
+  if [ ! -f "${AKM_DB_PATH}" ]; then
+    echo "AKM db not found at ${AKM_DB_PATH}, skipping"
+    return 0
+  fi
+
+  local snapshot="${BACKUP_ROOT}/snapshot-$(date -u +%Y%m%dT%H%M%SZ)"
+  mkdir -p "${snapshot}"
+
+  # SQLite Online Backup API. Produces a consistent copy even under concurrent
+  # write activity. WAL-aware: the WAL is checkpointed into the backup file.
+  # No exclusive lock is taken on the source database.
+  sqlite3 "${AKM_DB_PATH}" ".backup '${snapshot}/akm.db'"
+
+  # Prune snapshots older than 7 days.
+  find "${BACKUP_ROOT}" -maxdepth 1 -name 'snapshot-*' -type d -mtime +7 \
+    -exec rm -rf {} +
+
+  echo "Backup complete: ${snapshot}"
+}
+
+# Backup immediately on sidecar start (captures state before first hourly tick),
+# then repeat every INTERVAL seconds.
+run_backup
+while true; do
+  sleep "${INTERVAL}"
+  run_backup
+done
+```
+
+### Sidecar volume mounts
+
+| Volume | Mount path | Mode |
 |---|---|---|
-| `opencode-password` | assistant | `OPENCODE_PASSWORD` — required when `OPENCODE_AUTH=true` |
-| `assistant-token` | assistant, guardian | `OP_ASSISTANT_TOKEN` / guardian's outbound auth |
-| `guardian-channel-secrets` | guardian | `guardian.env` content or per-channel secrets |
-| `openai-api-key` | assistant | Primary LLM provider key |
-| `anthropic-api-key` | assistant | Alternate provider key |
-| `<additional provider keys>` | assistant | Any other active provider keys |
+| `state-vol` (emptyDir) | `/home/opencode/.local/state` | ro |
+| `openpalm-akm-backups` (Azure Files) | `/backup` | rw |
 
-Token scoping rule: guardian receives only the secrets it needs to validate and forward requests. Assistant receives only the LLM provider key for the configured `SYSTEM_LLM_PROVIDER`; unused provider keys are unset at startup by the existing `maybe_unset_unused_provider_keys` logic in `entrypoint.sh`.
+The sidecar mounts the emptyDir **read-only** — it has no write access to the live database directory. All write activity goes to the separate backup share.
+
+## Sidecar Container Definition (within assistant.yaml)
+
+```yaml
+volumes:
+  - name: state-vol
+    storageType: EmptyDir
+  - name: akm-backups
+    storageType: AzureFile
+    storageName: openpalm-akm-backups
+
+containers:
+  - name: opencode
+    image: <registry>/assistant:<tag>
+    env:
+      - name: AKM_DB_PATH
+        value: /home/opencode/.local/state/akm.db
+      # ... other env vars ...
+    volumeMounts:
+      - volumeName: state-vol
+        mountPath: /home/opencode/.local/state
+      - volumeName: akm-backups
+        mountPath: /mnt/akm-restore
+        readOnly: true
+      # ... other mounts (config, share, stash, work) ...
+
+  - name: akm-backup
+    image: <registry>/akm-backup-sidecar:<tag>
+    env:
+      - name: AKM_DB_PATH
+        value: /home/opencode/.local/state/akm.db
+      - name: BACKUP_INTERVAL_SECONDS
+        value: "3600"
+    volumeMounts:
+      - volumeName: state-vol
+        mountPath: /home/opencode/.local/state
+        readOnly: true
+      - volumeName: akm-backups
+        mountPath: /backup
+    resources:
+      cpu: 0.25
+      memory: 0.5Gi
+```
+
+The emptyDir volume is scoped to the app revision — it is shared between the two containers in the same revision and cleared when the revision is replaced.
+
+## Sidecar Image
+
+`alpine:3` with `sqlite3` installed:
+
+```dockerfile
+FROM alpine:3
+RUN apk add --no-cache sqlite
+COPY backup.sh /usr/local/bin/backup.sh
+RUN chmod +x /usr/local/bin/backup.sh
+ENTRYPOINT ["/usr/local/bin/backup.sh"]
+```
 
 ## Container App: assistant
 
@@ -92,20 +242,17 @@ ingress:
     # repeat for each allowed CIDR
 ```
 
-ACA's allowlist behaviour: when any `Allow` rules are present, all traffic not matching a listed CIDR is automatically denied. No explicit `Deny 0.0.0.0/0` rule is needed.
+When any `Allow` rules are present, ACA denies all traffic not matching a listed CIDR automatically. No explicit `Deny 0.0.0.0/0` rule is needed.
 
 The allowed IP list is supplied to the deploy script as `OP_ALLOWED_IPS`, a comma-separated list of CIDRs (e.g. `1.2.3.4/32,5.6.7.8/32`). The script emits one `ipSecurityRestrictions` entry per CIDR.
 
-### Environment Changes vs. core.compose.yml
+### Environment changes vs. core.compose.yml
 
-- `OPENCODE_AUTH=true` — **required**; the server is externally reachable, authentication must be on.
+- `OPENCODE_AUTH=true` — **required**; the server is externally reachable.
 - `OPENCODE_PASSWORD` — sourced from Key Vault secret `opencode-password`.
-- Remove `MEMORY_API_URL` and `MEMORY_AUTH_TOKEN` — memory container is not deployed.
-- Remove `MEMORY_USER_ID` — unused without memory.
-- Remove `depends_on: memory` — no longer applicable.
-- `OP_ADMIN_API_URL` — leave empty; assistant admin tools already fail gracefully when Admin is absent.
-
-All other env vars (LLM provider keys, AKM paths, Google/Microsoft credential paths) are unchanged. Provider credential files that live in `vault/user/` in self-hosted deployments are handled in ACA via Key Vault secrets or operator-seeded files on the `openpalm-config` share.
+- `AKM_DB_PATH` — set to the exact db file path, e.g. `/home/opencode/.local/state/akm.db`.
+- Remove `MEMORY_API_URL`, `MEMORY_AUTH_TOKEN`, `MEMORY_USER_ID` — memory container is not deployed.
+- `OP_ADMIN_API_URL` — leave empty; assistant admin tools fail gracefully when Admin is absent.
 
 ### Sizing
 
@@ -118,11 +265,9 @@ scale:
   maxReplicas: 1
 ```
 
-Single replica enforced: OpenCode maintains per-session state in the mounted home volume. Multi-replica would require session affinity and is out of scope.
+Single replica enforced. The emptyDir is revision-scoped; multiple replicas would each have their own independent emptyDir and db state.
 
 ### Health probe
-
-Existing healthcheck maps directly to an ACA HTTP probe:
 
 ```yaml
 probes:
@@ -144,9 +289,7 @@ probes:
 
 ## Container App: guardian
 
-### Ingress
-
-Internal only — no `external: true`. Guardian is reachable within the ACA environment at `https://openpalm-guardian.internal.<env-domain>:443`.
+Internal only — no external ingress. Reachable within the ACA environment at its internal FQDN.
 
 ```yaml
 ingress:
@@ -155,17 +298,11 @@ ingress:
   transport: http
 ```
 
-### Environment
-
-`OP_ASSISTANT_URL` is set to the internal FQDN of the assistant app, resolved at deploy time from `az containerapp show`:
+`OP_ASSISTANT_URL` is set to the assistant app's internal FQDN, resolved at deploy time:
 
 ```
 OP_ASSISTANT_URL=https://openpalm-assistant.internal.<env-domain>
 ```
-
-All channel HMAC secrets come from Key Vault via managed identity references.
-
-### Sizing
 
 ```yaml
 resources:
@@ -176,104 +313,18 @@ scale:
   maxReplicas: 1
 ```
 
-## Sidecar Container: akm-backup
+## Key Vault Secrets
 
-### Why a sidecar, not a separate ACA job
-
-The AKM database is a live SQLite file inside the assistant container's filesystem. A separate ACA job can only see it via an Azure Files share mount, which means the job would be doing a raw file copy of a potentially open database — guaranteed to produce a corrupt snapshot if a write is in flight.
-
-Running the backup as a sidecar container inside the same ACA app gives it two things a separate job cannot have:
-
-1. **SQLite's online backup API** — `sqlite3 source.db ".backup 'dest.db'"` uses the SQLite Online Backup API, which creates a consistent snapshot even under concurrent write activity, respects WAL mode checkpointing, and never requires an exclusive lock.
-2. **Shared volume mount** — the sidecar mounts `openpalm-assistant-home` read-only, giving it direct access to the live database path without any intermediate copy step.
-
-### Image
-
-`alpine:3` with `apk add sqlite` added at build time, or any image that provides the `sqlite3` CLI. No custom image is required; a Dockerfile for the sidecar lives at `deploy/azure/sidecar/Dockerfile`.
-
-### Volume mounts (sidecar only)
-
-| Share | Mount path | Mode |
+| Secret name | Consumer | Description |
 |---|---|---|
-| `openpalm-assistant-home` | `/home/opencode` | ro |
-| `openpalm-akm-backups` | `/backup` | rw |
+| `opencode-password` | assistant | `OPENCODE_PASSWORD` — required when `OPENCODE_AUTH=true` |
+| `assistant-token` | assistant, guardian | `OP_ASSISTANT_TOKEN` / guardian outbound auth |
+| `guardian-channel-secrets` | guardian | Per-channel HMAC secrets |
+| `openai-api-key` | assistant | Primary LLM provider key |
+| `anthropic-api-key` | assistant | Alternate provider key |
+| `<additional provider keys>` | assistant | Any other active provider keys |
 
-### Backup script
-
-```sh
-#!/bin/sh
-set -eu
-
-# Operator sets AKM_DB_PATH to the exact SQLite file path.
-# Default assumes a single db directly under .local/state/.
-AKM_DB_PATH="${AKM_DB_PATH:-/home/opencode/.local/state/akm.db}"
-BACKUP_ROOT="/backup"
-INTERVAL="${BACKUP_INTERVAL_SECONDS:-3600}"
-
-run_backup() {
-  if [ ! -f "${AKM_DB_PATH}" ]; then
-    echo "AKM db not found at ${AKM_DB_PATH}, skipping"
-    return 0
-  fi
-
-  SNAPSHOT="${BACKUP_ROOT}/snapshot-$(date -u +%Y%m%dT%H%M%SZ)"
-  mkdir -p "${SNAPSHOT}"
-
-  # SQLite online backup API. Creates a consistent snapshot of a live,
-  # potentially write-active database without requiring an exclusive lock.
-  # Works correctly with WAL mode — the WAL is checkpointed into the copy.
-  sqlite3 "${AKM_DB_PATH}" ".backup '${SNAPSHOT}/akm.db'"
-
-  # Prune snapshots older than 7 days.
-  find "${BACKUP_ROOT}" -maxdepth 1 -name 'snapshot-*' -type d -mtime +7 \
-    -exec rm -rf {} +
-
-  echo "Backup complete: ${SNAPSHOT}"
-}
-
-# Run once immediately on startup, then every INTERVAL seconds.
-run_backup
-while true; do
-  sleep "${INTERVAL}"
-  run_backup
-done
-```
-
-`AKM_DB_PATH` is passed as an environment variable on the sidecar container so the path can be overridden without rebuilding the image. The operator should confirm the exact filename; if AKM creates multiple database files under `.local/state/`, extend the script to iterate over `*.db` files in that directory.
-
-### Sidecar container definition (within assistant.yaml)
-
-```yaml
-containers:
-  - name: opencode
-    image: <registry>/assistant:<tag>
-    # ... main container config ...
-    volumeMounts:
-      - volumeName: assistant-home
-        mountPath: /home/opencode
-      # ... other mounts ...
-
-  - name: akm-backup
-    image: <registry>/akm-backup-sidecar:<tag>
-    env:
-      - name: AKM_DB_PATH
-        value: /home/opencode/.local/state/akm.db
-    volumeMounts:
-      - volumeName: assistant-home
-        mountPath: /home/opencode
-        readOnly: true
-      - volumeName: akm-backups
-        mountPath: /backup
-    resources:
-      cpu: 0.25
-      memory: 0.5Gi
-```
-
-Volumes are defined at the app level and shared across both containers; only the mount mode (readOnly) differs.
-
-### Sidecar lifecycle
-
-The sidecar starts and stops with the assistant app revision. If the sidecar crashes, ACA restarts only the sidecar container, not the main opencode process — this is the standard ACA multi-container behaviour. The sidecar has no liveness probe; a failed backup logs an error and retries on the next hourly cycle rather than killing the container.
+Unused provider keys are unset at startup by the existing `maybe_unset_unused_provider_keys` logic in `entrypoint.sh`.
 
 ## Deployment Script: deploy/azure/deploy-aca.sh
 
@@ -281,14 +332,14 @@ The sidecar starts and stops with the assistant app revision. If the sidecar cra
 
 | Subcommand | Action |
 |---|---|
-| `setup` | Provision resource group, storage account, file shares, Key Vault, managed identity; write all secrets to Key Vault; seed directory structure on shares |
-| `deploy` | Generate and apply ACA app YAML for assistant (including akm-backup sidecar) and guardian |
+| `setup` | Provision resource group, storage account, file shares, Key Vault, managed identity; write all secrets to Key Vault; seed share directory structure |
+| `deploy` | Build sidecar image; generate and apply ACA app YAML for assistant (with sidecar) and guardian |
 | `all` | `setup` then `deploy` |
-| `update-ips` | Update the IP allowlist on the assistant ingress without redeploying the full app |
+| `update-ips` | Update the IP allowlist on the assistant ingress without a full redeploy |
 | `status` | Print running state of both apps and last backup log from the akm-backup sidecar |
 | `teardown` | Delete the resource group and all contained resources |
 
-### Required inputs (environment variables or flags)
+### Required inputs
 
 | Variable | Description |
 |---|---|
@@ -298,31 +349,38 @@ The sidecar starts and stops with the assistant app revision. If the sidecar cra
 | `OP_IMAGE_TAG` | Image tag to deploy (default: `latest`) |
 | `OP_IMAGE_NAMESPACE` | Registry namespace/prefix (default: `openpalm`) |
 | `OP_ALLOWED_IPS` | Comma-separated list of allowed CIDRs for assistant ingress |
-| `OP_OPENCODE_PASSWORD` | Password for OpenCode web UI (will be stored in Key Vault) |
+| `OP_OPENCODE_PASSWORD` | Password for OpenCode web UI (stored in Key Vault) |
 | `OP_ASSISTANT_TOKEN` | Assistant token for guardian→assistant auth |
+| `AKM_DB_PATH` | Exact path to AKM SQLite database inside the container |
 | `SYSTEM_LLM_PROVIDER` | Active LLM provider name |
 | `<PROVIDER>_API_KEY` | API key for the active provider |
 
 ### Script conventions
 
-- Use `az` CLI argument arrays, not inline interpolation, for any value that could contain special characters or secrets.
-- Generate per-app YAML to `deploy/azure/apps/` (gitignored rendered output; checked-in templates only).
+- Use `az` CLI argument arrays, not inline interpolation, for values that could contain special characters or secrets.
+- Generate per-app YAML to `deploy/azure/apps/` (gitignored rendered output; templates are checked in).
 - Validate with `shellcheck` before committing.
-- Print all provisioned resource names and the assistant ingress URL on successful `deploy`; never print secret values.
+- Print provisioned resource names and the assistant ingress URL on successful `deploy`; never print secret values.
+
+## Required Code Change
+
+This deployment requires one addition to `core/assistant/entrypoint.sh`: the `maybe_restore_akm_db` function described in the restore-on-start section above, called immediately before `start_opencode`. This is the only required change to the core runtime. All other changes are deployment artifacts.
 
 ## Deliverables
 
 ```
+core/assistant/entrypoint.sh         (add maybe_restore_akm_db)
+
 deploy/azure/
-├── PLAN.md                        (this file)
-├── README.md                      (operator guide)
-├── deploy-aca.sh                  (main deployment script)
+├── PLAN.md                          (this file)
+├── README.md                        (operator guide)
+├── deploy-aca.sh                    (main deployment script)
 ├── apps/
-│   ├── assistant.yaml             (ACA app template — includes akm-backup sidecar)
-│   └── guardian.yaml              (ACA app template)
+│   ├── assistant.yaml               (ACA app template — includes akm-backup sidecar)
+│   └── guardian.yaml                (ACA app template)
 └── sidecar/
-    ├── Dockerfile                 (alpine + sqlite3 for akm-backup sidecar)
-    └── backup.sh                  (backup script baked into sidecar image)
+    ├── Dockerfile                   (alpine + sqlite3)
+    └── backup.sh                    (backup loop script)
 ```
 
 ## What This Removes vs. Issue #315
@@ -331,31 +389,33 @@ deploy/azure/
 |---|---|
 | `memory` container | Removed |
 | `scheduler` container | Removed |
-| `channel-chat` container and add-channel flow | Removed (no channels in simplified deployment) |
+| `channel-chat` and add-channel flow | Removed (no channels in simplified deployment) |
 | Guardian as the only external ingress | Changed — assistant is the external ingress |
-| Admin-less runtime with memory persistence | Memory dropped; AKM stash on Azure Files is the primary persistence |
-
-Guardian is retained as an internal service available for future channel additions. The `add-channel` workflow is deferred until channel support is re-introduced.
+| Single monolithic home share on Azure Files | Replaced with granular mounts; SQLite paths on emptyDir |
 
 ## Deviations from Self-Hosted Model
 
 | Self-hosted | ACA |
 |---|---|
 | `~/.openpalm/vault/stack/stack.env` | Key Vault secrets via managed identity |
-| `~/.openpalm/data/stash` | `openpalm-stash` Azure Files share (AKM stash artifacts, not the db) |
-| Init service creates data dirs | `setup` subcommand seeds shares before first deploy |
-| Guardian is LAN-only by network topology | Guardian has internal ACA ingress; no external route |
+| `~/.openpalm/data/stash` | `openpalm-stash` Azure Files share (AKM file artifacts) |
+| `~/openpalm/data/assistant` (full home bind-mount) | Granular share mounts per subdirectory; `.local/state` on emptyDir |
+| AKM db on host filesystem (POSIX locks) | AKM db on emptyDir (POSIX locks on local ACA disk) |
+| AKM db always durable | AKM db ephemeral on emptyDir; durable via hourly backup + restore-on-start |
+| Init service creates data dirs | `setup` seeds shares; entrypoint creates emptyDir subdirs |
 | No inbound authentication on assistant (127.0.0.1 only) | `OPENCODE_AUTH=true` mandatory; IP allowlist on ACA ingress |
-| Memory service provides vector persistence | No memory service; AKM SQLite in `$HOME/.local/state` (on home share) is sole persistence |
+| Memory service provides vector persistence | No memory service; AKM SQLite is sole persistence |
 
 ## Risks and Mitigations
 
 | Risk | Mitigation |
 |---|---|
-| OpenCode auth disabled by default | Plan mandates `OPENCODE_AUTH=true`; deploy script validates this and refuses to proceed without a password |
-| IP allowlist misconfiguration locks out operator | `update-ips` subcommand for safe updates; `setup` documents how to add the operator's current IP |
-| AKM db corruption during backup | SQLite `.backup` command uses the online backup API — no raw file copy, no exclusive lock required, WAL-safe |
-| Sidecar crashes and disrupts assistant | ACA restarts only the crashed sidecar container; the main opencode process is unaffected |
-| AKM_DB_PATH wrong at first deploy | Sidecar logs "db not found" and skips gracefully; operator corrects the env var and restarts the revision |
-| Azure Files SMB lock contention | Home share: main container rw, sidecar ro — SMB read-only mounts never block concurrent writes |
-| Single replica constraint | Documented explicitly; `maxReplicas: 1` enforced in YAML; scale-out requires session affinity work outside this plan's scope |
+| Data loss on unexpected container restart | Backup interval is configurable via `BACKUP_INTERVAL_SECONDS`; default 1 hour; set to 300s (5 min) to reduce window |
+| OpenCode auth disabled | Plan mandates `OPENCODE_AUTH=true`; deploy script validates and refuses to proceed without a password |
+| IP allowlist misconfiguration locks out operator | `update-ips` subcommand for safe updates; README documents adding operator's current IP during setup |
+| AKM db corruption during backup | `sqlite3 .backup` uses the SQLite Online Backup API — no raw file copy, no exclusive lock, WAL-safe |
+| Sidecar crashes | ACA restarts only the sidecar; the opencode process is unaffected; next backup runs after restart |
+| `AKM_DB_PATH` wrong on first deploy | Sidecar logs "db not found" and skips gracefully; operator corrects the env var and restarts the revision |
+| Restore reads a corrupt backup snapshot | `maybe_restore_akm_db` uses `cp` not `sqlite3`, so a corrupt backup is copied as-is; add a `sqlite3 dest.db "PRAGMA integrity_check"` validation step before the first OpenCode start if hard safety is needed |
+| emptyDir cleared on revision update | Expected behaviour; entrypoint restore runs automatically on every cold start |
+| Single replica constraint | Documented explicitly; `maxReplicas: 1` enforced in YAML; multi-replica requires session affinity and shared db, out of scope |

--- a/deploy/azure/PLAN.md
+++ b/deploy/azure/PLAN.md
@@ -6,7 +6,7 @@
 - Keep only assistant and guardian.
 - Expose the assistant's OpenCode webserver as the default ACA ingress, restricted to an explicit IP allowlist.
 - Eliminate the VM entirely — deploy purely on Azure Container Apps.
-- Add an hourly AKM database backup that safely snapshots the SQLite database in `$HOME/.local/state` to an Azure File Share and retains 7 days of rolling copies. The backup runs as a sidecar container inside the assistant app sharing an emptyDir volume, and uses SQLite's online backup API to write consistent snapshots to Azure Files.
+- Add an hourly AKM database backup that safely snapshots the SQLite database in `$HOME/.local/state` to an Azure File Share and retains 7 days of rolling copies.
 
 ## Architecture
 
@@ -14,88 +14,59 @@
 Internet
     │
     ▼ (HTTPS, IP-allowlisted)
-ACA Ingress — openpalm-assistant
+ACA Ingress — openpalm-assistant  (single container)
     OpenCode web UI  :4096
+    background: backup loop writes sqlite3 .backup → Azure Files every hour
+    startup:    restore loop seeds db from latest Azure Files snapshot
     │
-    │ internal ACA DNS (assistant_net equivalent)
+    │ internal ACA DNS
     ▼
 openpalm-guardian  :8080  (internal-only ingress)
     HMAC validation, audit logging
-
-akm-backup  (sidecar in openpalm-assistant)
-    shares emptyDir volume with the opencode container
-    runs sqlite3 .backup every hour: emptyDir → Azure Files backup share
-    restores from latest backup share snapshot on container cold start
-    retains 7 days of timestamped snapshots
 ```
-
-Guardian has no external ingress in this deployment. It remains internal for future channel integrations. The OpenCode web server on the assistant is the only publicly reachable endpoint, guarded by an ACA IP security restriction allowlist.
 
 ## Why the home directory cannot go on Azure Files
 
-Azure Files uses the SMB protocol. SMB does not correctly implement POSIX advisory file locks (`fcntl`/`flock`). SQLite relies on these locks for all write serialisation and WAL-mode coordination. Running a live SQLite database on an SMB mount produces "database is locked" errors, torn writes, and eventual corruption.
+Azure Files uses SMB. SMB does not correctly implement POSIX advisory file locks (`fcntl`/`flock`). SQLite relies on these locks for write serialisation and WAL-mode coordination. Running a live SQLite database on an SMB mount produces "database is locked" errors, torn writes, and eventual corruption.
 
 **Consequence:** no path that contains an active SQLite database can be mounted from Azure Files. The AKM database at `$HOME/.local/state/` must live on a local, POSIX-compliant filesystem inside the container.
 
-**Solution:** use an ACA `emptyDir` volume for `/home/opencode/.local/state/`. An emptyDir is provisioned from the ACA host's local disk, has full POSIX lock semantics, and is shared between all containers in the same app revision. The sidecar reads the live database from this emptyDir and writes consistent snapshots to Azure Files using `sqlite3 .backup` (the SQLite Online Backup API, which is safe for concurrent write activity).
+**Solution:** use an ACA `emptyDir` volume for `/home/opencode/.local/state/`. An emptyDir is provisioned from the ACA host's local disk with full POSIX lock semantics. The emptyDir is cleared on container restart; durability comes from the backup/restore cycle baked into `entrypoint.sh`.
 
-The emptyDir is ephemeral — it is cleared when the app revision is replaced or the container restarts. Durability is provided by the hourly backup cycle: on each cold start the assistant entrypoint checks whether the state directory is empty and, if so, copies the latest snapshot from the Azure Files backup share before OpenCode starts. The maximum data loss window is the interval between the last successful backup and the crash (at most one hour).
+## Why no sidecar
 
-## Azure Resources
+The backup can run as a background subshell started in `entrypoint.sh` before the `exec gosu opencode...` call. When `exec` replaces the shell process, the background subshell is orphaned to Tini (PID 1, already the container init). Tini adopts and reaps orphans correctly, so the backup loop runs for the full container lifetime with no second container needed.
 
-| Resource | Type | Notes |
-|---|---|---|
-| `rg-openpalm` | Resource Group | All resources in one group for easy teardown |
-| `openpalm-env` | ACA Environment | Shared environment; enables internal DNS between apps |
-| `openpalm-assistant` | Container App | External ingress, IP-restricted, single replica; includes `akm-backup` sidecar |
-| `openpalm-guardian` | Container App | Internal ingress only |
-| `openpalmstore<suffix>` | Storage Account | Azure Files backend for all shares |
-| `kv-openpalm-<suffix>` | Key Vault | All runtime secrets; no inline secrets in YAML |
-| `id-openpalm` | User-assigned Managed Identity | Grants apps Key Vault Secrets User role |
+This keeps the ACA app definition to a single container, removes the need to build and maintain a separate sidecar image, and avoids the shared-emptyDir complexity of multi-container apps.
 
-## Volume Layout
+## Required Image Change
 
-### Azure Files shares
+`sqlite3` CLI is not in the assistant image. Add it to the existing `apt-get install` line in `core/assistant/Dockerfile`:
 
-Mounted only at paths that never contain SQLite databases. All shares use SMB.
+```diff
+-    && apt-get install -y --no-install-recommends tini curl git ca-certificates bash openssh-server gosu sudo socat unzip \
++    && apt-get install -y --no-install-recommends tini curl git ca-certificates bash openssh-server gosu sudo socat unzip sqlite3 \
+```
 
-| Share name | Container | Mount path | Mode | Purpose |
-|---|---|---|---|---|
-| `openpalm-opencode-config` | opencode | `/home/opencode/.config/opencode` | rw | OpenCode config files |
-| `openpalm-opencode-share` | opencode | `/home/opencode/.local/share/opencode` | rw | auth.json and OpenCode shared data |
-| `openpalm-stash` | opencode | `/home/opencode/.akm` | rw | AKM stash artifacts (files, not the db) |
-| `openpalm-config` | opencode | `/etc/openpalm` | ro | Operator config |
-| `openpalm-work` | opencode | `/work` | rw | Assistant workspace |
-| `openpalm-guardian-data` | guardian | `/app/data` | rw | Guardian state |
-| `openpalm-guardian-logs` | guardian | `/app/audit` | rw | Guardian audit log |
-| `openpalm-akm-backups` | opencode (ro), akm-backup (rw) | `/mnt/akm-restore` (opencode), `/backup` (sidecar) | ro / rw | Backup snapshots; opencode mounts read-only for restore on cold start |
+No other image changes are required.
 
-### ACA emptyDir volume
+## Required Entrypoint Changes
 
-| Volume name | Containers | Mount path | Mode | Purpose |
-|---|---|---|---|---|
-| `state-vol` | opencode (rw), akm-backup (ro) | `/home/opencode/.local/state` | rw / ro | AKM SQLite database; proper POSIX locks on local disk |
+Two new functions in `core/assistant/entrypoint.sh`, called in order before `start_opencode`:
 
-The emptyDir is created fresh on each container start. It is shared between containers in the same app revision but is not shared across revisions or app restarts. Durability is provided by the backup/restore cycle described below.
+### maybe_restore_akm_db
 
-### What is not mounted
-
-The rest of `/home/opencode` (`.cache/`, `.bun/`, `.local/bin/`, etc.) lives on the container's layer filesystem. These are either reinstalled at startup by the entrypoint or are truly ephemeral caches. The entrypoint already calls `ensure_home_layout` to create required directories.
-
-OpenCode logs (previously at `/home/opencode/.local/state/opencode`) are now inside the emptyDir and are ephemeral. This is acceptable — logs are a debug aid, not durable state. If persistent logs are required, mount an additional Azure Files share at `/home/opencode/.local/state/opencode` (this subdirectory path does not contain SQLite files and is SMB-safe).
-
-## Restore-on-Start and Backup Cycle
-
-### Cold start restore (entrypoint change)
-
-The assistant's `entrypoint.sh` requires one new function added before `start_opencode`:
+Runs on every cold start. If the emptyDir is empty (no db file) and a backup snapshot exists on the mounted Azure Files backup share, copies the latest snapshot into place before OpenCode starts.
 
 ```sh
 maybe_restore_akm_db() {
-  local db_path="${AKM_DB_PATH:-/home/opencode/.local/state/akm.db}"
-  local restore_mount="/mnt/akm-restore"
+  local db_path="${AKM_DB_PATH:-}"
+  local restore_mount="/mnt/akm-backups"
 
-  # emptyDir is freshly created; restore from latest backup if the db is absent.
+  if [ -z "${db_path}" ]; then
+    return 0
+  fi
+
   if [ -f "${db_path}" ]; then
     return 0
   fi
@@ -114,117 +85,98 @@ maybe_restore_akm_db() {
 }
 ```
 
-This function is safe to call on every start: it is a no-op if the db already exists. On a container restart the emptyDir is cleared by ACA so the restore path always runs.
+### start_backup_loop
 
-`AKM_DB_PATH` must be passed as an environment variable on the assistant container with the exact path to the database file. The `openpalm-akm-backups` share is mounted read-only at `/mnt/akm-restore` in the main container for this purpose only.
-
-### Hourly backup (sidecar)
-
-The sidecar reads the live database via the shared emptyDir and writes a consistent snapshot to the Azure Files backup share using `sqlite3 .backup`.
+Starts a background subshell before the `exec`. The subshell is orphaned to Tini when `exec` replaces the shell; it then runs for the lifetime of the container.
 
 ```sh
-#!/bin/sh
-set -eu
+start_backup_loop() {
+  local db_path="${AKM_DB_PATH:-}"
+  local backup_root="/mnt/akm-backups"
+  local interval="${BACKUP_INTERVAL_SECONDS:-3600}"
 
-AKM_DB_PATH="${AKM_DB_PATH:-/home/opencode/.local/state/akm.db}"
-BACKUP_ROOT="/backup"
-INTERVAL="${BACKUP_INTERVAL_SECONDS:-3600}"
-
-run_backup() {
-  if [ ! -f "${AKM_DB_PATH}" ]; then
-    echo "AKM db not found at ${AKM_DB_PATH}, skipping"
+  if [ -z "${db_path}" ] || ! command -v sqlite3 >/dev/null 2>&1; then
     return 0
   fi
 
-  local snapshot="${BACKUP_ROOT}/snapshot-$(date -u +%Y%m%dT%H%M%SZ)"
-  mkdir -p "${snapshot}"
+  (
+    # Wait for AKM to create the db (it may be created lazily after first use).
+    while [ ! -f "${db_path}" ]; do
+      sleep 10
+    done
 
-  # SQLite Online Backup API. Produces a consistent copy even under concurrent
-  # write activity. WAL-aware: the WAL is checkpointed into the backup file.
-  # No exclusive lock is taken on the source database.
-  sqlite3 "${AKM_DB_PATH}" ".backup '${snapshot}/akm.db'"
+    while true; do
+      local snapshot="${backup_root}/snapshot-$(date -u +%Y%m%dT%H%M%SZ)"
+      mkdir -p "${snapshot}"
 
-  # Prune snapshots older than 7 days.
-  find "${BACKUP_ROOT}" -maxdepth 1 -name 'snapshot-*' -type d -mtime +7 \
-    -exec rm -rf {} +
+      # SQLite Online Backup API: consistent copy under concurrent write activity,
+      # WAL-aware, no exclusive lock required.
+      sqlite3 "${db_path}" ".backup '${snapshot}/akm.db'"
 
-  echo "Backup complete: ${snapshot}"
+      # Prune snapshots older than 7 days.
+      find "${backup_root}" -maxdepth 1 -name 'snapshot-*' -type d -mtime +7 \
+        -exec rm -rf {} +
+
+      sleep "${interval}"
+    done
+  ) &
 }
-
-# Backup immediately on sidecar start (captures state before first hourly tick),
-# then repeat every INTERVAL seconds.
-run_backup
-while true; do
-  sleep "${INTERVAL}"
-  run_backup
-done
 ```
 
-### Sidecar volume mounts
+### Call order in entrypoint.sh
 
-| Volume | Mount path | Mode |
+```sh
+maybe_adjust_uid_gid
+ensure_home_layout
+maybe_set_memory_user_id
+maybe_enable_ssh
+maybe_proxy_lmstudio
+maybe_unset_unused_provider_keys
+maybe_restore_akm_db    # new
+start_backup_loop       # new — must be before start_opencode
+start_opencode          # exec replaces shell; backup loop orphaned to tini
+```
+
+## Azure Resources
+
+| Resource | Type | Notes |
 |---|---|---|
-| `state-vol` (emptyDir) | `/home/opencode/.local/state` | ro |
-| `openpalm-akm-backups` (Azure Files) | `/backup` | rw |
+| `rg-openpalm` | Resource Group | All resources in one group for easy teardown |
+| `openpalm-env` | ACA Environment | Shared environment; enables internal DNS between apps |
+| `openpalm-assistant` | Container App | External ingress, IP-restricted, single container, single replica |
+| `openpalm-guardian` | Container App | Internal ingress only |
+| `openpalmstore<suffix>` | Storage Account | Azure Files backend for all shares |
+| `kv-openpalm-<suffix>` | Key Vault | All runtime secrets; no inline secrets in YAML |
+| `id-openpalm` | User-assigned Managed Identity | Grants apps Key Vault Secrets User role |
 
-The sidecar mounts the emptyDir **read-only** — it has no write access to the live database directory. All write activity goes to the separate backup share.
+## Volume Layout
 
-## Sidecar Container Definition (within assistant.yaml)
+### Azure Files shares (SMB-safe paths only)
 
-```yaml
-volumes:
-  - name: state-vol
-    storageType: EmptyDir
-  - name: akm-backups
-    storageType: AzureFile
-    storageName: openpalm-akm-backups
+| Share name | Mount path | Mode | Purpose |
+|---|---|---|---|
+| `openpalm-opencode-config` | `/home/opencode/.config/opencode` | rw | OpenCode config |
+| `openpalm-opencode-share` | `/home/opencode/.local/share/opencode` | rw | auth.json and OpenCode shared data |
+| `openpalm-stash` | `/home/opencode/.akm` | rw | AKM file artifacts (not the db) |
+| `openpalm-config` | `/etc/openpalm` | ro | Operator config |
+| `openpalm-work` | `/work` | rw | Assistant workspace |
+| `openpalm-akm-backups` | `/mnt/akm-backups` | rw | Backup snapshots (restore reads here; backup loop writes here) |
+| `openpalm-guardian-data` | `/app/data` | rw | Guardian state |
+| `openpalm-guardian-logs` | `/app/audit` | rw | Guardian audit log |
 
-containers:
-  - name: opencode
-    image: <registry>/assistant:<tag>
-    env:
-      - name: AKM_DB_PATH
-        value: /home/opencode/.local/state/akm.db
-      # ... other env vars ...
-    volumeMounts:
-      - volumeName: state-vol
-        mountPath: /home/opencode/.local/state
-      - volumeName: akm-backups
-        mountPath: /mnt/akm-restore
-        readOnly: true
-      # ... other mounts (config, share, stash, work) ...
+### ACA emptyDir volume
 
-  - name: akm-backup
-    image: <registry>/akm-backup-sidecar:<tag>
-    env:
-      - name: AKM_DB_PATH
-        value: /home/opencode/.local/state/akm.db
-      - name: BACKUP_INTERVAL_SECONDS
-        value: "3600"
-    volumeMounts:
-      - volumeName: state-vol
-        mountPath: /home/opencode/.local/state
-        readOnly: true
-      - volumeName: akm-backups
-        mountPath: /backup
-    resources:
-      cpu: 0.25
-      memory: 0.5Gi
-```
+| Volume | Mount path | Mode | Purpose |
+|---|---|---|---|
+| `state-vol` | `/home/opencode/.local/state` | rw | AKM SQLite database; POSIX locks on local ACA disk |
 
-The emptyDir volume is scoped to the app revision — it is shared between the two containers in the same revision and cleared when the revision is replaced.
+The emptyDir is cleared on container restart. The backup/restore cycle in `entrypoint.sh` provides durability. Maximum data loss on crash = time since last successful backup (default: up to 1 hour; set `BACKUP_INTERVAL_SECONDS=300` to reduce to 5 minutes).
 
-## Sidecar Image
+### What is not mounted
 
-`alpine:3` with `sqlite3` installed:
+The rest of `/home/opencode` (`.cache/`, `.bun/`, `.local/bin/`, etc.) lives on the container layer filesystem. These are either reinstalled at startup or are ephemeral caches.
 
-```dockerfile
-FROM alpine:3
-RUN apk add --no-cache sqlite
-COPY backup.sh /usr/local/bin/backup.sh
-RUN chmod +x /usr/local/bin/backup.sh
-ENTRYPOINT ["/usr/local/bin/backup.sh"]
-```
+OpenCode logs (`/home/opencode/.local/state/opencode`) are inside the emptyDir and are ephemeral. If persistent logs are needed, add a separate Azure Files share mounted at `/home/opencode/.local/state/opencode` — this subdirectory contains only log files (no SQLite) and is SMB-safe.
 
 ## Container App: assistant
 
@@ -239,20 +191,43 @@ ingress:
     - name: allow-<label>
       ipAddressRange: "<CIDR>"
       action: Allow
-    # repeat for each allowed CIDR
+    # one entry per CIDR in OP_ALLOWED_IPS
 ```
 
-When any `Allow` rules are present, ACA denies all traffic not matching a listed CIDR automatically. No explicit `Deny 0.0.0.0/0` rule is needed.
+When any `Allow` rules are present, ACA denies all other traffic automatically.
 
-The allowed IP list is supplied to the deploy script as `OP_ALLOWED_IPS`, a comma-separated list of CIDRs (e.g. `1.2.3.4/32,5.6.7.8/32`). The script emits one `ipSecurityRestrictions` entry per CIDR.
+The allowed IP list is supplied to the deploy script as `OP_ALLOWED_IPS`, a comma-separated list of CIDRs. The script emits one `ipSecurityRestrictions` entry per CIDR.
 
 ### Environment changes vs. core.compose.yml
 
 - `OPENCODE_AUTH=true` — **required**; the server is externally reachable.
 - `OPENCODE_PASSWORD` — sourced from Key Vault secret `opencode-password`.
-- `AKM_DB_PATH` — set to the exact db file path, e.g. `/home/opencode/.local/state/akm.db`.
-- Remove `MEMORY_API_URL`, `MEMORY_AUTH_TOKEN`, `MEMORY_USER_ID` — memory container is not deployed.
+- `AKM_DB_PATH` — exact path to the AKM SQLite file, e.g. `/home/opencode/.local/state/akm.db`.
+- `BACKUP_INTERVAL_SECONDS` — backup frequency in seconds (default `3600`).
+- Remove `MEMORY_API_URL`, `MEMORY_AUTH_TOKEN`, `MEMORY_USER_ID` — memory not deployed.
 - `OP_ADMIN_API_URL` — leave empty; assistant admin tools fail gracefully when Admin is absent.
+
+### Volumes (in ACA YAML)
+
+```yaml
+volumes:
+  - name: state-vol
+    storageType: EmptyDir
+  - name: openpalm-akm-backups
+    storageType: AzureFile
+    storageName: openpalm-akm-backups
+  # ... other Azure Files volumes ...
+
+containers:
+  - name: opencode
+    image: <registry>/assistant:<tag>
+    volumeMounts:
+      - volumeName: state-vol
+        mountPath: /home/opencode/.local/state
+      - volumeName: openpalm-akm-backups
+        mountPath: /mnt/akm-backups
+      # ... other mounts ...
+```
 
 ### Sizing
 
@@ -265,7 +240,7 @@ scale:
   maxReplicas: 1
 ```
 
-Single replica enforced. The emptyDir is revision-scoped; multiple replicas would each have their own independent emptyDir and db state.
+Single replica enforced. The emptyDir is per-replica; multiple replicas would each have independent db state.
 
 ### Health probe
 
@@ -289,7 +264,7 @@ probes:
 
 ## Container App: guardian
 
-Internal only — no external ingress. Reachable within the ACA environment at its internal FQDN.
+Internal only — no external ingress.
 
 ```yaml
 ingress:
@@ -298,11 +273,7 @@ ingress:
   transport: http
 ```
 
-`OP_ASSISTANT_URL` is set to the assistant app's internal FQDN, resolved at deploy time:
-
-```
-OP_ASSISTANT_URL=https://openpalm-assistant.internal.<env-domain>
-```
+`OP_ASSISTANT_URL` is set to the assistant app's internal FQDN, resolved at deploy time from `az containerapp show`.
 
 ```yaml
 resources:
@@ -333,10 +304,10 @@ Unused provider keys are unset at startup by the existing `maybe_unset_unused_pr
 | Subcommand | Action |
 |---|---|
 | `setup` | Provision resource group, storage account, file shares, Key Vault, managed identity; write all secrets to Key Vault; seed share directory structure |
-| `deploy` | Build sidecar image; generate and apply ACA app YAML for assistant (with sidecar) and guardian |
+| `deploy` | Generate and apply ACA app YAML for assistant and guardian |
 | `all` | `setup` then `deploy` |
 | `update-ips` | Update the IP allowlist on the assistant ingress without a full redeploy |
-| `status` | Print running state of both apps and last backup log from the akm-backup sidecar |
+| `status` | Print running state of both apps |
 | `teardown` | Delete the resource group and all contained resources |
 
 ### Required inputs
@@ -362,25 +333,26 @@ Unused provider keys are unset at startup by the existing `maybe_unset_unused_pr
 - Validate with `shellcheck` before committing.
 - Print provisioned resource names and the assistant ingress URL on successful `deploy`; never print secret values.
 
-## Required Code Change
+## Required Changes Summary
 
-This deployment requires one addition to `core/assistant/entrypoint.sh`: the `maybe_restore_akm_db` function described in the restore-on-start section above, called immediately before `start_opencode`. This is the only required change to the core runtime. All other changes are deployment artifacts.
+| File | Change |
+|---|---|
+| `core/assistant/Dockerfile` | Add `sqlite3` to the `apt-get install` line |
+| `core/assistant/entrypoint.sh` | Add `maybe_restore_akm_db` and `start_backup_loop` functions; call them before `start_opencode` |
 
 ## Deliverables
 
 ```
-core/assistant/entrypoint.sh         (add maybe_restore_akm_db)
+core/assistant/Dockerfile            (add sqlite3)
+core/assistant/entrypoint.sh        (add restore + backup loop)
 
 deploy/azure/
 ├── PLAN.md                          (this file)
 ├── README.md                        (operator guide)
 ├── deploy-aca.sh                    (main deployment script)
-├── apps/
-│   ├── assistant.yaml               (ACA app template — includes akm-backup sidecar)
-│   └── guardian.yaml                (ACA app template)
-└── sidecar/
-    ├── Dockerfile                   (alpine + sqlite3)
-    └── backup.sh                    (backup loop script)
+└── apps/
+    ├── assistant.yaml               (ACA app template)
+    └── guardian.yaml                (ACA app template)
 ```
 
 ## What This Removes vs. Issue #315
@@ -391,31 +363,29 @@ deploy/azure/
 | `scheduler` container | Removed |
 | `channel-chat` and add-channel flow | Removed (no channels in simplified deployment) |
 | Guardian as the only external ingress | Changed — assistant is the external ingress |
-| Single monolithic home share on Azure Files | Replaced with granular mounts; SQLite paths on emptyDir |
+| Monolithic home share on Azure Files | Replaced with granular mounts; SQLite path on emptyDir |
 
 ## Deviations from Self-Hosted Model
 
 | Self-hosted | ACA |
 |---|---|
 | `~/.openpalm/vault/stack/stack.env` | Key Vault secrets via managed identity |
-| `~/.openpalm/data/stash` | `openpalm-stash` Azure Files share (AKM file artifacts) |
-| `~/openpalm/data/assistant` (full home bind-mount) | Granular share mounts per subdirectory; `.local/state` on emptyDir |
-| AKM db on host filesystem (POSIX locks) | AKM db on emptyDir (POSIX locks on local ACA disk) |
-| AKM db always durable | AKM db ephemeral on emptyDir; durable via hourly backup + restore-on-start |
-| Init service creates data dirs | `setup` seeds shares; entrypoint creates emptyDir subdirs |
-| No inbound authentication on assistant (127.0.0.1 only) | `OPENCODE_AUTH=true` mandatory; IP allowlist on ACA ingress |
+| `~/.openpalm/data/stash` | `openpalm-stash` Azure Files share (file artifacts only) |
+| Full home bind-mount on host filesystem | Granular share mounts per subdirectory; `.local/state` on emptyDir |
+| AKM db always durable (host filesystem) | AKM db ephemeral on emptyDir; durable via hourly backup + restore-on-start |
+| No inbound auth on assistant (127.0.0.1 only) | `OPENCODE_AUTH=true` mandatory; IP allowlist on ACA ingress |
 | Memory service provides vector persistence | No memory service; AKM SQLite is sole persistence |
 
 ## Risks and Mitigations
 
 | Risk | Mitigation |
 |---|---|
-| Data loss on unexpected container restart | Backup interval is configurable via `BACKUP_INTERVAL_SECONDS`; default 1 hour; set to 300s (5 min) to reduce window |
-| OpenCode auth disabled | Plan mandates `OPENCODE_AUTH=true`; deploy script validates and refuses to proceed without a password |
-| IP allowlist misconfiguration locks out operator | `update-ips` subcommand for safe updates; README documents adding operator's current IP during setup |
+| Data loss on unexpected container restart | Configurable via `BACKUP_INTERVAL_SECONDS`; default 1 hour; set to 300 for 5-minute window |
+| OpenCode auth disabled | Deploy script validates `OP_OPENCODE_PASSWORD` is set and refuses to proceed without it |
+| IP allowlist misconfiguration locks out operator | `update-ips` subcommand; README documents adding operator's current IP during setup |
 | AKM db corruption during backup | `sqlite3 .backup` uses the SQLite Online Backup API — no raw file copy, no exclusive lock, WAL-safe |
-| Sidecar crashes | ACA restarts only the sidecar; the opencode process is unaffected; next backup runs after restart |
-| `AKM_DB_PATH` wrong on first deploy | Sidecar logs "db not found" and skips gracefully; operator corrects the env var and restarts the revision |
-| Restore reads a corrupt backup snapshot | `maybe_restore_akm_db` uses `cp` not `sqlite3`, so a corrupt backup is copied as-is; add a `sqlite3 dest.db "PRAGMA integrity_check"` validation step before the first OpenCode start if hard safety is needed |
-| emptyDir cleared on revision update | Expected behaviour; entrypoint restore runs automatically on every cold start |
-| Single replica constraint | Documented explicitly; `maxReplicas: 1` enforced in YAML; multi-replica requires session affinity and shared db, out of scope |
+| Backup loop dies silently | Loop runs in background; a crash does not affect OpenCode; next container restart triggers restore-on-start from the last successful snapshot |
+| `AKM_DB_PATH` not set or wrong | Both functions are no-ops when `AKM_DB_PATH` is empty; backup loop also skips if `sqlite3` is not in PATH |
+| Restore copies a corrupt snapshot | Add `sqlite3 "${db_path}" "PRAGMA integrity_check"` after the `cp` and abort startup if it fails, to avoid starting with a known-bad db |
+| emptyDir cleared on revision update | Expected; entrypoint restore runs automatically on every cold start |
+| Single replica constraint | Documented explicitly; `maxReplicas: 1` enforced in YAML |

--- a/deploy/azure/PLAN.md
+++ b/deploy/azure/PLAN.md
@@ -1,0 +1,328 @@
+# Simplified Azure Container Apps Deployment Plan
+
+## Goals
+
+- Remove memory and scheduler containers from the Azure deployment.
+- Keep only assistant and guardian.
+- Expose the assistant's OpenCode webserver as the default ACA ingress, restricted to an explicit IP allowlist.
+- Eliminate the VM entirely — deploy purely on Azure Container Apps.
+- Add an hourly AKM database backup job that syncs `/home/opencode/.akm` to an Azure File Share and retains 7 days of rolling copies.
+
+## Architecture
+
+```
+Internet
+    │
+    ▼ (HTTPS, IP-allowlisted)
+ACA Ingress — openpalm-assistant
+    OpenCode web UI  :4096
+    │
+    │ internal ACA DNS (assistant_net equivalent)
+    ▼
+openpalm-guardian  :8080  (internal-only ingress)
+    HMAC validation, audit logging
+    ↔ routes to openpalm-assistant:4096
+
+openpalm-akm-backup  (ACA Scheduled Job)
+    cron: 0 * * * *  (every hour)
+    mounts: openpalm-stash (ro) → openpalm-akm-backups (rw)
+    retains: 7 days of timestamped snapshots
+```
+
+Guardian has no external ingress in this deployment. It remains internal for any channel integrations added later. The OpenCode web server on the assistant is the only publicly reachable endpoint and is guarded by an ACA IP security restriction allowlist.
+
+## Azure Resources
+
+| Resource | Type | Notes |
+|---|---|---|
+| `rg-openpalm` | Resource Group | All resources in one group for easy teardown |
+| `openpalm-env` | ACA Environment | Shared environment; enables internal DNS between apps |
+| `openpalm-assistant` | Container App | External ingress, IP-restricted, single replica |
+| `openpalm-guardian` | Container App | Internal ingress only |
+| `openpalm-akm-backup` | ACA Scheduled Job | Hourly cron, alpine/busybox image |
+| `openpalmstore<suffix>` | Storage Account | Azure Files backend for all shares |
+| `kv-openpalm-<suffix>` | Key Vault | All runtime secrets; no inline secrets in YAML |
+| `id-openpalm` | User-assigned Managed Identity | Grants apps Key Vault Secrets User role |
+
+### Azure Files Shares
+
+| Share name | Mounted in | Container path | Access |
+|---|---|---|---|
+| `openpalm-assistant-home` | assistant | `/home/opencode` | rw |
+| `openpalm-config` | assistant | `/etc/openpalm` | ro |
+| `openpalm-work` | assistant | `/work` | rw |
+| `openpalm-logs` | assistant | `/home/opencode/.local/state/opencode` | rw |
+| `openpalm-stash` | assistant, akm-backup | `/home/opencode/.akm` (assistant, rw), `/source` (job, ro) | rw / ro |
+| `openpalm-guardian-data` | guardian | `/app/data` | rw |
+| `openpalm-guardian-logs` | guardian | `/app/audit` | rw |
+| `openpalm-akm-backups` | akm-backup | `/backup` | rw |
+
+The `openpalm-stash` share is the live AKM database directory. The backup job mounts it read-only so it never interferes with the assistant's writes.
+
+## Key Vault Secrets
+
+All secrets are written to Key Vault during `setup` before any apps are deployed. The managed identity is attached to every app and job; no inline secret values appear in any YAML or script log.
+
+| Secret name | Consumer | Description |
+|---|---|---|
+| `opencode-password` | assistant | `OPENCODE_PASSWORD` — required when `OPENCODE_AUTH=true` |
+| `assistant-token` | assistant, guardian | `OP_ASSISTANT_TOKEN` / guardian's outbound auth |
+| `guardian-channel-secrets` | guardian | `guardian.env` content or per-channel secrets |
+| `openai-api-key` | assistant | Primary LLM provider key |
+| `anthropic-api-key` | assistant | Alternate provider key |
+| `<additional provider keys>` | assistant | Any other active provider keys |
+
+Token scoping rule: guardian receives only the secrets it needs to validate and forward requests. Assistant receives only the LLM provider key for the configured `SYSTEM_LLM_PROVIDER`; unused provider keys are unset at startup by the existing `maybe_unset_unused_provider_keys` logic in `entrypoint.sh`.
+
+## Container App: assistant
+
+### Ingress
+
+```yaml
+ingress:
+  external: true
+  targetPort: 4096
+  transport: auto
+  ipSecurityRestrictions:
+    - name: allow-<label>
+      ipAddressRange: "<CIDR>"
+      action: Allow
+    # repeat for each allowed CIDR
+```
+
+ACA's allowlist behaviour: when any `Allow` rules are present, all traffic not matching a listed CIDR is automatically denied. No explicit `Deny 0.0.0.0/0` rule is needed.
+
+The allowed IP list is supplied to the deploy script as `OP_ALLOWED_IPS`, a comma-separated list of CIDRs (e.g. `1.2.3.4/32,5.6.7.8/32`). The script emits one `ipSecurityRestrictions` entry per CIDR.
+
+### Environment Changes vs. core.compose.yml
+
+- `OPENCODE_AUTH=true` — **required**; the server is externally reachable, authentication must be on.
+- `OPENCODE_PASSWORD` — sourced from Key Vault secret `opencode-password`.
+- Remove `MEMORY_API_URL` and `MEMORY_AUTH_TOKEN` — memory container is not deployed.
+- Remove `MEMORY_USER_ID` — unused without memory.
+- Remove `depends_on: memory` — no longer applicable.
+- `OP_ADMIN_API_URL` — leave empty; assistant admin tools already fail gracefully when Admin is absent.
+
+All other env vars (LLM provider keys, AKM paths, Google/Microsoft credential paths) are unchanged. Provider credential files that live in `vault/user/` in self-hosted deployments are handled in ACA via Key Vault secrets or operator-seeded files on the `openpalm-config` share.
+
+### Sizing
+
+```yaml
+resources:
+  cpu: 2.0
+  memory: 4Gi
+scale:
+  minReplicas: 1
+  maxReplicas: 1
+```
+
+Single replica enforced: OpenCode maintains per-session state in the mounted home volume. Multi-replica would require session affinity and is out of scope.
+
+### Health probe
+
+Existing healthcheck maps directly to an ACA HTTP probe:
+
+```yaml
+probes:
+  - type: liveness
+    httpGet:
+      path: /health
+      port: 4096
+    initialDelaySeconds: 30
+    periodSeconds: 30
+    failureThreshold: 5
+  - type: readiness
+    httpGet:
+      path: /health
+      port: 4096
+    initialDelaySeconds: 30
+    periodSeconds: 30
+    failureThreshold: 5
+```
+
+## Container App: guardian
+
+### Ingress
+
+Internal only — no `external: true`. Guardian is reachable within the ACA environment at `https://openpalm-guardian.internal.<env-domain>:443`.
+
+```yaml
+ingress:
+  external: false
+  targetPort: 8080
+  transport: http
+```
+
+### Environment
+
+`OP_ASSISTANT_URL` is set to the internal FQDN of the assistant app, resolved at deploy time from `az containerapp show`:
+
+```
+OP_ASSISTANT_URL=https://openpalm-assistant.internal.<env-domain>
+```
+
+All channel HMAC secrets come from Key Vault via managed identity references.
+
+### Sizing
+
+```yaml
+resources:
+  cpu: 0.25
+  memory: 0.5Gi
+scale:
+  minReplicas: 1
+  maxReplicas: 1
+```
+
+## ACA Scheduled Job: akm-backup
+
+### Purpose
+
+Every hour, copy the contents of the live AKM stash directory to a timestamped snapshot on the backup share, then prune snapshots older than 7 days.
+
+### Schedule
+
+```
+0 * * * *
+```
+
+### Image
+
+`busybox:latest` or `alpine:3` (no custom build needed).
+
+### Volume mounts
+
+| Share | Mount path | Mode |
+|---|---|---|
+| `openpalm-stash` | `/source` | ro |
+| `openpalm-akm-backups` | `/backup` | rw |
+
+### Job script
+
+```sh
+#!/bin/sh
+set -eu
+
+SNAPSHOT="snapshot-$(date -u +%Y%m%dT%H%M%SZ)"
+DEST="/backup/${SNAPSHOT}"
+STAGING="${DEST}.tmp"
+
+# Copy to a staging directory first, then rename to make the
+# snapshot appear atomically. SQLite WAL files are copied together
+# with the main db file to keep the snapshot consistent.
+cp -a /source/. "${STAGING}/"
+mv "${STAGING}" "${DEST}"
+
+# Prune snapshots older than 7 days. find with -mtime +7 matches
+# directories whose modification time is more than 7*24h ago.
+find /backup -maxdepth 1 -name 'snapshot-*' -type d -mtime +7 \
+  -exec rm -rf {} +
+
+echo "Backup complete: ${SNAPSHOT}"
+find /backup -maxdepth 1 -name 'snapshot-*' -type d | sort
+```
+
+The staging-then-rename pattern avoids leaving a partial snapshot visible to any monitoring that reads the backup share. Note that because Azure Files does not support atomic rename across directories in all SMB configurations, the script uses a `.tmp` suffix convention; operators should treat any `*.tmp` directories as incomplete and safe to delete.
+
+### SQLite safety note
+
+If the AKM database uses WAL mode, the `.db`, `.db-wal`, and `.db-shm` files must all be present in the snapshot together. The `cp -a /source/.` command copies the entire directory, so all three files are captured in the same pass. A brief window of inconsistency is possible (e.g. a write commits between copying the main db and the WAL file). For the assistant-only deployment, this is acceptable: the backup is a recovery aid, not a transactional replica. Operators needing stronger consistency can use the `VACUUM INTO` SQLite command via the assistant before triggering a backup.
+
+### Retry policy
+
+```yaml
+retryPolicy:
+  maxRetries: 3
+  retryDelay: 30s
+```
+
+### Sizing
+
+```yaml
+resources:
+  cpu: 0.25
+  memory: 0.5Gi
+```
+
+## Deployment Script: deploy/azure/deploy-aca.sh
+
+### Subcommands
+
+| Subcommand | Action |
+|---|---|
+| `setup` | Provision resource group, storage account, file shares, Key Vault, managed identity; write all secrets to Key Vault; seed directory structure on shares |
+| `deploy` | Generate and apply ACA app YAML for assistant and guardian; create akm-backup scheduled job |
+| `all` | `setup` then `deploy` |
+| `update-ips` | Update the IP allowlist on the assistant ingress without redeploying the full app |
+| `status` | Print running state of both apps and last backup job execution |
+| `teardown` | Delete the resource group and all contained resources |
+
+### Required inputs (environment variables or flags)
+
+| Variable | Description |
+|---|---|
+| `AZURE_RESOURCE_GROUP` | Resource group name (default: `rg-openpalm`) |
+| `AZURE_LOCATION` | Region (e.g. `eastus`) |
+| `AZURE_SUBSCRIPTION` | Subscription ID |
+| `OP_IMAGE_TAG` | Image tag to deploy (default: `latest`) |
+| `OP_IMAGE_NAMESPACE` | Registry namespace/prefix (default: `openpalm`) |
+| `OP_ALLOWED_IPS` | Comma-separated list of allowed CIDRs for assistant ingress |
+| `OP_OPENCODE_PASSWORD` | Password for OpenCode web UI (will be stored in Key Vault) |
+| `OP_ASSISTANT_TOKEN` | Assistant token for guardian→assistant auth |
+| `SYSTEM_LLM_PROVIDER` | Active LLM provider name |
+| `<PROVIDER>_API_KEY` | API key for the active provider |
+
+### Script conventions
+
+- Use `az` CLI argument arrays, not inline interpolation, for any value that could contain special characters or secrets.
+- Generate per-app YAML to `deploy/azure/apps/` (gitignored rendered output; checked-in templates only).
+- Validate with `shellcheck` before committing.
+- Print all provisioned resource names and the assistant ingress URL on successful `deploy`; never print secret values.
+
+## Deliverables
+
+```
+deploy/azure/
+├── PLAN.md                        (this file)
+├── README.md                      (operator guide)
+├── deploy-aca.sh                  (main deployment script)
+├── apps/
+│   ├── assistant.yaml             (ACA app template)
+│   └── guardian.yaml              (ACA app template)
+└── jobs/
+    └── akm-backup.yaml            (ACA scheduled job template)
+```
+
+## What This Removes vs. Issue #315
+
+| #315 scope | This plan |
+|---|---|
+| `memory` container | Removed |
+| `scheduler` container | Removed |
+| `channel-chat` container and add-channel flow | Removed (no channels in simplified deployment) |
+| Guardian as the only external ingress | Changed — assistant is the external ingress |
+| Admin-less runtime with memory persistence | Memory dropped; AKM stash on Azure Files is the primary persistence |
+
+Guardian is retained as an internal service available for future channel additions. The `add-channel` workflow is deferred until channel support is re-introduced.
+
+## Deviations from Self-Hosted Model
+
+| Self-hosted | ACA |
+|---|---|
+| `~/.openpalm/vault/stack/stack.env` | Key Vault secrets via managed identity |
+| `~/.openpalm/data/stash` | `openpalm-stash` Azure Files share |
+| Init service creates data dirs | `setup` subcommand seeds shares before first deploy |
+| Guardian is LAN-only by network topology | Guardian has internal ACA ingress; no external route |
+| No inbound authentication on assistant (127.0.0.1 only) | `OPENCODE_AUTH=true` mandatory; IP allowlist on ACA ingress |
+| Memory service provides vector persistence | No memory service; AKM SQLite on Azure Files is sole persistence |
+
+## Risks and Mitigations
+
+| Risk | Mitigation |
+|---|---|
+| OpenCode auth disabled by default | Plan mandates `OPENCODE_AUTH=true`; deploy script validates this and refuses to proceed without a password |
+| IP allowlist misconfiguration locks out operator | `update-ips` subcommand for safe updates; `setup` documents how to add the operator's current IP |
+| AKM snapshot inconsistency during write | Staging-then-rename pattern; operator guidance on `VACUUM INTO` for hard consistency |
+| Stale `.tmp` backup directories | Job README notes they are safe to delete; backup prune step only targets `snapshot-*` pattern |
+| Azure Files SMB lock contention | Assistant mounts stash rw; backup job mounts stash ro; reads on SMB don't block writes |
+| Single replica constraint | Documented explicitly; `maxReplicas: 1` enforced in YAML; scale-out requires session affinity work outside this plan's scope |

--- a/deploy/azure/PLAN.md
+++ b/deploy/azure/PLAN.md
@@ -6,7 +6,7 @@
 - Keep only assistant and guardian.
 - Expose the assistant's OpenCode webserver as the default ACA ingress, restricted to an explicit IP allowlist.
 - Eliminate the VM entirely — deploy purely on Azure Container Apps.
-- Add an hourly AKM database backup job that syncs `/home/opencode/.akm` to an Azure File Share and retains 7 days of rolling copies.
+- Add an hourly AKM database backup that safely snapshots the SQLite database in `$HOME/.local/state` to an Azure File Share and retains 7 days of rolling copies. The backup runs as a sidecar container inside the assistant app so it has direct filesystem access and can use SQLite's online backup API without raw file copying.
 
 ## Architecture
 
@@ -23,10 +23,11 @@ openpalm-guardian  :8080  (internal-only ingress)
     HMAC validation, audit logging
     ↔ routes to openpalm-assistant:4096
 
-openpalm-akm-backup  (ACA Scheduled Job)
-    cron: 0 * * * *  (every hour)
-    mounts: openpalm-stash (ro) → openpalm-akm-backups (rw)
-    retains: 7 days of timestamped snapshots
+akm-backup  (sidecar in openpalm-assistant)
+    runs every hour inside the assistant app
+    reads $HOME/.local/state/*.db via shared home volume
+    writes to openpalm-akm-backups share
+    retains 7 days of timestamped snapshots
 ```
 
 Guardian has no external ingress in this deployment. It remains internal for any channel integrations added later. The OpenCode web server on the assistant is the only publicly reachable endpoint and is guarded by an ACA IP security restriction allowlist.
@@ -37,9 +38,8 @@ Guardian has no external ingress in this deployment. It remains internal for any
 |---|---|---|
 | `rg-openpalm` | Resource Group | All resources in one group for easy teardown |
 | `openpalm-env` | ACA Environment | Shared environment; enables internal DNS between apps |
-| `openpalm-assistant` | Container App | External ingress, IP-restricted, single replica |
+| `openpalm-assistant` | Container App | External ingress, IP-restricted, single replica; includes `akm-backup` sidecar |
 | `openpalm-guardian` | Container App | Internal ingress only |
-| `openpalm-akm-backup` | ACA Scheduled Job | Hourly cron, alpine/busybox image |
 | `openpalmstore<suffix>` | Storage Account | Azure Files backend for all shares |
 | `kv-openpalm-<suffix>` | Key Vault | All runtime secrets; no inline secrets in YAML |
 | `id-openpalm` | User-assigned Managed Identity | Grants apps Key Vault Secrets User role |
@@ -48,16 +48,18 @@ Guardian has no external ingress in this deployment. It remains internal for any
 
 | Share name | Mounted in | Container path | Access |
 |---|---|---|---|
-| `openpalm-assistant-home` | assistant | `/home/opencode` | rw |
-| `openpalm-config` | assistant | `/etc/openpalm` | ro |
-| `openpalm-work` | assistant | `/work` | rw |
-| `openpalm-logs` | assistant | `/home/opencode/.local/state/opencode` | rw |
-| `openpalm-stash` | assistant, akm-backup | `/home/opencode/.akm` (assistant, rw), `/source` (job, ro) | rw / ro |
+| `openpalm-assistant-home` | opencode (main), akm-backup (sidecar) | `/home/opencode` | rw (main), ro (sidecar) |
+| `openpalm-config` | opencode (main) | `/etc/openpalm` | ro |
+| `openpalm-work` | opencode (main) | `/work` | rw |
+| `openpalm-logs` | opencode (main) | `/home/opencode/.local/state/opencode` | rw |
+| `openpalm-stash` | opencode (main) | `/home/opencode/.akm` | rw |
 | `openpalm-guardian-data` | guardian | `/app/data` | rw |
 | `openpalm-guardian-logs` | guardian | `/app/audit` | rw |
-| `openpalm-akm-backups` | akm-backup | `/backup` | rw |
+| `openpalm-akm-backups` | akm-backup (sidecar) | `/backup` | rw |
 
-The `openpalm-stash` share is the live AKM database directory. The backup job mounts it read-only so it never interferes with the assistant's writes.
+The AKM SQLite database lives under `$HOME/.local/state/` inside the main opencode container, which is part of the `openpalm-assistant-home` share. The sidecar mounts that same share read-only so it can never write to or corrupt the live database. Backups are written to the separate `openpalm-akm-backups` share.
+
+The `openpalm-logs` share overlays a subdirectory of the home share (`/home/opencode/.local/state/opencode`). The AKM database is NOT inside that subdirectory; it sits directly under `.local/state/` and is therefore visible to the sidecar through the home share mount.
 
 ## Key Vault Secrets
 
@@ -174,75 +176,104 @@ scale:
   maxReplicas: 1
 ```
 
-## ACA Scheduled Job: akm-backup
+## Sidecar Container: akm-backup
 
-### Purpose
+### Why a sidecar, not a separate ACA job
 
-Every hour, copy the contents of the live AKM stash directory to a timestamped snapshot on the backup share, then prune snapshots older than 7 days.
+The AKM database is a live SQLite file inside the assistant container's filesystem. A separate ACA job can only see it via an Azure Files share mount, which means the job would be doing a raw file copy of a potentially open database — guaranteed to produce a corrupt snapshot if a write is in flight.
 
-### Schedule
+Running the backup as a sidecar container inside the same ACA app gives it two things a separate job cannot have:
 
-```
-0 * * * *
-```
+1. **SQLite's online backup API** — `sqlite3 source.db ".backup 'dest.db'"` uses the SQLite Online Backup API, which creates a consistent snapshot even under concurrent write activity, respects WAL mode checkpointing, and never requires an exclusive lock.
+2. **Shared volume mount** — the sidecar mounts `openpalm-assistant-home` read-only, giving it direct access to the live database path without any intermediate copy step.
 
 ### Image
 
-`busybox:latest` or `alpine:3` (no custom build needed).
+`alpine:3` with `apk add sqlite` added at build time, or any image that provides the `sqlite3` CLI. No custom image is required; a Dockerfile for the sidecar lives at `deploy/azure/sidecar/Dockerfile`.
 
-### Volume mounts
+### Volume mounts (sidecar only)
 
 | Share | Mount path | Mode |
 |---|---|---|
-| `openpalm-stash` | `/source` | ro |
+| `openpalm-assistant-home` | `/home/opencode` | ro |
 | `openpalm-akm-backups` | `/backup` | rw |
 
-### Job script
+### Backup script
 
 ```sh
 #!/bin/sh
 set -eu
 
-SNAPSHOT="snapshot-$(date -u +%Y%m%dT%H%M%SZ)"
-DEST="/backup/${SNAPSHOT}"
-STAGING="${DEST}.tmp"
+# Operator sets AKM_DB_PATH to the exact SQLite file path.
+# Default assumes a single db directly under .local/state/.
+AKM_DB_PATH="${AKM_DB_PATH:-/home/opencode/.local/state/akm.db}"
+BACKUP_ROOT="/backup"
+INTERVAL="${BACKUP_INTERVAL_SECONDS:-3600}"
 
-# Copy to a staging directory first, then rename to make the
-# snapshot appear atomically. SQLite WAL files are copied together
-# with the main db file to keep the snapshot consistent.
-cp -a /source/. "${STAGING}/"
-mv "${STAGING}" "${DEST}"
+run_backup() {
+  if [ ! -f "${AKM_DB_PATH}" ]; then
+    echo "AKM db not found at ${AKM_DB_PATH}, skipping"
+    return 0
+  fi
 
-# Prune snapshots older than 7 days. find with -mtime +7 matches
-# directories whose modification time is more than 7*24h ago.
-find /backup -maxdepth 1 -name 'snapshot-*' -type d -mtime +7 \
-  -exec rm -rf {} +
+  SNAPSHOT="${BACKUP_ROOT}/snapshot-$(date -u +%Y%m%dT%H%M%SZ)"
+  mkdir -p "${SNAPSHOT}"
 
-echo "Backup complete: ${SNAPSHOT}"
-find /backup -maxdepth 1 -name 'snapshot-*' -type d | sort
+  # SQLite online backup API. Creates a consistent snapshot of a live,
+  # potentially write-active database without requiring an exclusive lock.
+  # Works correctly with WAL mode — the WAL is checkpointed into the copy.
+  sqlite3 "${AKM_DB_PATH}" ".backup '${SNAPSHOT}/akm.db'"
+
+  # Prune snapshots older than 7 days.
+  find "${BACKUP_ROOT}" -maxdepth 1 -name 'snapshot-*' -type d -mtime +7 \
+    -exec rm -rf {} +
+
+  echo "Backup complete: ${SNAPSHOT}"
+}
+
+# Run once immediately on startup, then every INTERVAL seconds.
+run_backup
+while true; do
+  sleep "${INTERVAL}"
+  run_backup
+done
 ```
 
-The staging-then-rename pattern avoids leaving a partial snapshot visible to any monitoring that reads the backup share. Note that because Azure Files does not support atomic rename across directories in all SMB configurations, the script uses a `.tmp` suffix convention; operators should treat any `*.tmp` directories as incomplete and safe to delete.
+`AKM_DB_PATH` is passed as an environment variable on the sidecar container so the path can be overridden without rebuilding the image. The operator should confirm the exact filename; if AKM creates multiple database files under `.local/state/`, extend the script to iterate over `*.db` files in that directory.
 
-### SQLite safety note
-
-If the AKM database uses WAL mode, the `.db`, `.db-wal`, and `.db-shm` files must all be present in the snapshot together. The `cp -a /source/.` command copies the entire directory, so all three files are captured in the same pass. A brief window of inconsistency is possible (e.g. a write commits between copying the main db and the WAL file). For the assistant-only deployment, this is acceptable: the backup is a recovery aid, not a transactional replica. Operators needing stronger consistency can use the `VACUUM INTO` SQLite command via the assistant before triggering a backup.
-
-### Retry policy
+### Sidecar container definition (within assistant.yaml)
 
 ```yaml
-retryPolicy:
-  maxRetries: 3
-  retryDelay: 30s
+containers:
+  - name: opencode
+    image: <registry>/assistant:<tag>
+    # ... main container config ...
+    volumeMounts:
+      - volumeName: assistant-home
+        mountPath: /home/opencode
+      # ... other mounts ...
+
+  - name: akm-backup
+    image: <registry>/akm-backup-sidecar:<tag>
+    env:
+      - name: AKM_DB_PATH
+        value: /home/opencode/.local/state/akm.db
+    volumeMounts:
+      - volumeName: assistant-home
+        mountPath: /home/opencode
+        readOnly: true
+      - volumeName: akm-backups
+        mountPath: /backup
+    resources:
+      cpu: 0.25
+      memory: 0.5Gi
 ```
 
-### Sizing
+Volumes are defined at the app level and shared across both containers; only the mount mode (readOnly) differs.
 
-```yaml
-resources:
-  cpu: 0.25
-  memory: 0.5Gi
-```
+### Sidecar lifecycle
+
+The sidecar starts and stops with the assistant app revision. If the sidecar crashes, ACA restarts only the sidecar container, not the main opencode process — this is the standard ACA multi-container behaviour. The sidecar has no liveness probe; a failed backup logs an error and retries on the next hourly cycle rather than killing the container.
 
 ## Deployment Script: deploy/azure/deploy-aca.sh
 
@@ -251,10 +282,10 @@ resources:
 | Subcommand | Action |
 |---|---|
 | `setup` | Provision resource group, storage account, file shares, Key Vault, managed identity; write all secrets to Key Vault; seed directory structure on shares |
-| `deploy` | Generate and apply ACA app YAML for assistant and guardian; create akm-backup scheduled job |
+| `deploy` | Generate and apply ACA app YAML for assistant (including akm-backup sidecar) and guardian |
 | `all` | `setup` then `deploy` |
 | `update-ips` | Update the IP allowlist on the assistant ingress without redeploying the full app |
-| `status` | Print running state of both apps and last backup job execution |
+| `status` | Print running state of both apps and last backup log from the akm-backup sidecar |
 | `teardown` | Delete the resource group and all contained resources |
 
 ### Required inputs (environment variables or flags)
@@ -287,10 +318,11 @@ deploy/azure/
 ├── README.md                      (operator guide)
 ├── deploy-aca.sh                  (main deployment script)
 ├── apps/
-│   ├── assistant.yaml             (ACA app template)
+│   ├── assistant.yaml             (ACA app template — includes akm-backup sidecar)
 │   └── guardian.yaml              (ACA app template)
-└── jobs/
-    └── akm-backup.yaml            (ACA scheduled job template)
+└── sidecar/
+    ├── Dockerfile                 (alpine + sqlite3 for akm-backup sidecar)
+    └── backup.sh                  (backup script baked into sidecar image)
 ```
 
 ## What This Removes vs. Issue #315
@@ -310,11 +342,11 @@ Guardian is retained as an internal service available for future channel additio
 | Self-hosted | ACA |
 |---|---|
 | `~/.openpalm/vault/stack/stack.env` | Key Vault secrets via managed identity |
-| `~/.openpalm/data/stash` | `openpalm-stash` Azure Files share |
+| `~/.openpalm/data/stash` | `openpalm-stash` Azure Files share (AKM stash artifacts, not the db) |
 | Init service creates data dirs | `setup` subcommand seeds shares before first deploy |
 | Guardian is LAN-only by network topology | Guardian has internal ACA ingress; no external route |
 | No inbound authentication on assistant (127.0.0.1 only) | `OPENCODE_AUTH=true` mandatory; IP allowlist on ACA ingress |
-| Memory service provides vector persistence | No memory service; AKM SQLite on Azure Files is sole persistence |
+| Memory service provides vector persistence | No memory service; AKM SQLite in `$HOME/.local/state` (on home share) is sole persistence |
 
 ## Risks and Mitigations
 
@@ -322,7 +354,8 @@ Guardian is retained as an internal service available for future channel additio
 |---|---|
 | OpenCode auth disabled by default | Plan mandates `OPENCODE_AUTH=true`; deploy script validates this and refuses to proceed without a password |
 | IP allowlist misconfiguration locks out operator | `update-ips` subcommand for safe updates; `setup` documents how to add the operator's current IP |
-| AKM snapshot inconsistency during write | Staging-then-rename pattern; operator guidance on `VACUUM INTO` for hard consistency |
-| Stale `.tmp` backup directories | Job README notes they are safe to delete; backup prune step only targets `snapshot-*` pattern |
-| Azure Files SMB lock contention | Assistant mounts stash rw; backup job mounts stash ro; reads on SMB don't block writes |
+| AKM db corruption during backup | SQLite `.backup` command uses the online backup API — no raw file copy, no exclusive lock required, WAL-safe |
+| Sidecar crashes and disrupts assistant | ACA restarts only the crashed sidecar container; the main opencode process is unaffected |
+| AKM_DB_PATH wrong at first deploy | Sidecar logs "db not found" and skips gracefully; operator corrects the env var and restarts the revision |
+| Azure Files SMB lock contention | Home share: main container rw, sidecar ro — SMB read-only mounts never block concurrent writes |
 | Single replica constraint | Documented explicitly; `maxReplicas: 1` enforced in YAML; scale-out requires session affinity work outside this plan's scope |

--- a/deploy/azure/PLAN.md
+++ b/deploy/azure/PLAN.md
@@ -33,22 +33,67 @@ Azure Files uses SMB. SMB does not correctly implement POSIX advisory file locks
 
 **Solution:** use an ACA `emptyDir` volume for `/home/opencode/.local/state/`. An emptyDir is provisioned from the ACA host's local disk with full POSIX lock semantics. The emptyDir is cleared on container restart; durability comes from the backup/restore cycle baked into `entrypoint.sh`.
 
-## Why no sidecar
+## Why cron instead of a custom loop
 
-The backup can run as a background subshell started in `entrypoint.sh` before the `exec gosu opencode...` call. When `exec` replaces the shell process, the background subshell is orphaned to Tini (PID 1, already the container init). Tini adopts and reaps orphans correctly, so the backup loop runs for the full container lifetime with no second container needed.
+The scheduler container is dropped in this deployment, and the assistant will need cron for other scheduled tasks going forward. Installing the system cron daemon is the right primitive: it handles scheduling correctly, integrates cleanly with additional jobs added later, and avoids a hand-rolled sleep loop that can drift and swallow errors silently.
 
-This keeps the ACA app definition to a single container, removes the need to build and maintain a separate sidecar image, and avoids the shared-emptyDir complexity of multi-container apps.
+## Required Image Changes
 
-## Required Image Change
-
-`sqlite3` CLI is not in the assistant image. Add it to the existing `apt-get install` line in `core/assistant/Dockerfile`:
+Add `cron` and `sqlite3` to the existing `apt-get install` line, and copy the backup script and cron job file into the image:
 
 ```diff
 -    && apt-get install -y --no-install-recommends tini curl git ca-certificates bash openssh-server gosu sudo socat unzip \
-+    && apt-get install -y --no-install-recommends tini curl git ca-certificates bash openssh-server gosu sudo socat unzip sqlite3 \
++    && apt-get install -y --no-install-recommends tini curl git ca-certificates bash openssh-server gosu sudo socat unzip cron sqlite3 \
 ```
 
-No other image changes are required.
+```dockerfile
+COPY core/assistant/akm-backup.sh /usr/local/bin/akm-backup.sh
+COPY core/assistant/cron.d/akm-backup /etc/cron.d/akm-backup
+RUN chmod +x /usr/local/bin/akm-backup.sh \
+    && chmod 0644 /etc/cron.d/akm-backup
+```
+
+### core/assistant/akm-backup.sh
+
+```sh
+#!/bin/sh
+set -eu
+
+# Source the env file written by entrypoint.sh; cron does not inherit
+# the container's environment.
+[ -f /etc/cron-env ] && . /etc/cron-env
+
+AKM_DB_PATH="${AKM_DB_PATH:-}"
+BACKUP_ROOT="/mnt/akm-backups"
+
+if [ -z "${AKM_DB_PATH}" ] || [ ! -f "${AKM_DB_PATH}" ]; then
+  echo "akm-backup: db not found at '${AKM_DB_PATH}', skipping"
+  exit 0
+fi
+
+SNAPSHOT="${BACKUP_ROOT}/snapshot-$(date -u +%Y%m%dT%H%M%SZ)"
+mkdir -p "${SNAPSHOT}"
+
+# SQLite Online Backup API: consistent copy under concurrent write activity,
+# WAL-aware, no exclusive lock required.
+sqlite3 "${AKM_DB_PATH}" ".backup '${SNAPSHOT}/akm.db'"
+
+# Prune snapshots older than 7 days.
+find "${BACKUP_ROOT}" -maxdepth 1 -name 'snapshot-*' -type d -mtime +7 \
+  -exec rm -rf {} +
+
+echo "akm-backup: complete — ${SNAPSHOT}"
+```
+
+### core/assistant/cron.d/akm-backup
+
+```cron
+# AKM database backup — runs at the top of every hour.
+# Adjust the schedule here; do not change the script path.
+0 * * * * root /usr/local/bin/akm-backup.sh >> /proc/1/fd/1 2>&1
+```
+
+Logging to `/proc/1/fd/1` redirects cron job output to the container's stdout, where it appears in ACA log streams alongside OpenCode output.
 
 ## Required Entrypoint Changes
 
@@ -85,43 +130,26 @@ maybe_restore_akm_db() {
 }
 ```
 
-### start_backup_loop
+### start_cron
 
-Starts a background subshell before the `exec`. The subshell is orphaned to Tini when `exec` replaces the shell; it then runs for the lifetime of the container.
+Writes the container's environment to `/etc/cron-env` (cron jobs do not inherit the container environment) then starts the system cron daemon. Cron daemonizes immediately; no backgrounding syntax is needed.
 
 ```sh
-start_backup_loop() {
-  local db_path="${AKM_DB_PATH:-}"
-  local backup_root="/mnt/akm-backups"
-  local interval="${BACKUP_INTERVAL_SECONDS:-3600}"
-
-  if [ -z "${db_path}" ] || ! command -v sqlite3 >/dev/null 2>&1; then
+start_cron() {
+  if ! command -v cron >/dev/null 2>&1; then
     return 0
   fi
 
-  (
-    # Wait for AKM to create the db (it may be created lazily after first use).
-    while [ ! -f "${db_path}" ]; do
-      sleep 10
-    done
+  # Write only the vars that scheduled scripts need.
+  # Do not write secrets — cron-env is root-readable only.
+  printf 'AKM_DB_PATH=%s\n' "${AKM_DB_PATH:-}" > /etc/cron-env
+  chmod 600 /etc/cron-env
 
-    while true; do
-      local snapshot="${backup_root}/snapshot-$(date -u +%Y%m%dT%H%M%SZ)"
-      mkdir -p "${snapshot}"
-
-      # SQLite Online Backup API: consistent copy under concurrent write activity,
-      # WAL-aware, no exclusive lock required.
-      sqlite3 "${db_path}" ".backup '${snapshot}/akm.db'"
-
-      # Prune snapshots older than 7 days.
-      find "${backup_root}" -maxdepth 1 -name 'snapshot-*' -type d -mtime +7 \
-        -exec rm -rf {} +
-
-      sleep "${interval}"
-    done
-  ) &
+  cron
 }
 ```
+
+Additional env vars needed by future cron jobs can be appended to the `printf` call here without touching the individual job scripts.
 
 ### Call order in entrypoint.sh
 
@@ -133,8 +161,8 @@ maybe_enable_ssh
 maybe_proxy_lmstudio
 maybe_unset_unused_provider_keys
 maybe_restore_akm_db    # new
-start_backup_loop       # new — must be before start_opencode
-start_opencode          # exec replaces shell; backup loop orphaned to tini
+start_cron              # new — starts cron daemon before exec
+start_opencode          # exec replaces shell
 ```
 
 ## Azure Resources
@@ -337,14 +365,19 @@ Unused provider keys are unset at startup by the existing `maybe_unset_unused_pr
 
 | File | Change |
 |---|---|
-| `core/assistant/Dockerfile` | Add `sqlite3` to the `apt-get install` line |
-| `core/assistant/entrypoint.sh` | Add `maybe_restore_akm_db` and `start_backup_loop` functions; call them before `start_opencode` |
+| `core/assistant/Dockerfile` | Add `cron` and `sqlite3` to `apt-get install`; copy backup script and cron job |
+| `core/assistant/entrypoint.sh` | Add `maybe_restore_akm_db` and `start_cron`; call them before `start_opencode` |
+| `core/assistant/akm-backup.sh` | New file — backup script (baked into image) |
+| `core/assistant/cron.d/akm-backup` | New file — cron job definition (baked into image) |
 
 ## Deliverables
 
 ```
-core/assistant/Dockerfile            (add sqlite3)
-core/assistant/entrypoint.sh        (add restore + backup loop)
+core/assistant/Dockerfile            (add cron + sqlite3; copy new files)
+core/assistant/entrypoint.sh        (add restore + start_cron)
+core/assistant/akm-backup.sh        (new — backup script)
+core/assistant/cron.d/
+└── akm-backup                       (new — cron job definition)
 
 deploy/azure/
 ├── PLAN.md                          (this file)
@@ -384,7 +417,7 @@ deploy/azure/
 | OpenCode auth disabled | Deploy script validates `OP_OPENCODE_PASSWORD` is set and refuses to proceed without it |
 | IP allowlist misconfiguration locks out operator | `update-ips` subcommand; README documents adding operator's current IP during setup |
 | AKM db corruption during backup | `sqlite3 .backup` uses the SQLite Online Backup API — no raw file copy, no exclusive lock, WAL-safe |
-| Backup loop dies silently | Loop runs in background; a crash does not affect OpenCode; next container restart triggers restore-on-start from the last successful snapshot |
+| Cron job fails silently | Output is redirected to `/proc/1/fd/1` so failures appear in ACA log streams; a failed run does not affect OpenCode; next hourly tick retries automatically |
 | `AKM_DB_PATH` not set or wrong | Both functions are no-ops when `AKM_DB_PATH` is empty; backup loop also skips if `sqlite3` is not in PATH |
 | Restore copies a corrupt snapshot | Add `sqlite3 "${db_path}" "PRAGMA integrity_check"` after the `cp` and abort startup if it fails, to avoid starting with a known-bad db |
 | emptyDir cleared on revision update | Expected; entrypoint restore runs automatically on every cold start |


### PR DESCRIPTION
## Summary

This adds a comprehensive deployment plan for running OpenPalm on Azure Container Apps (ACA) with a simplified architecture that removes the memory and scheduler containers and deploys only the assistant and guardian services.

## Key Changes

- **New deployment plan document** (`deploy/azure/PLAN.md`): Detailed specification covering:
  - Simplified two-container architecture (assistant + guardian only)
  - SQLite database durability strategy using hourly backups to Azure Files with 7-day retention
  - Volume layout separating POSIX-safe paths (emptyDir for SQLite) from SMB-safe paths (Azure Files shares)
  - IP-restricted external ingress on the assistant's OpenCode webserver
  - Cron-based backup scheduling instead of a dedicated scheduler container

- **Required image changes**: Documents additions to the Dockerfile:
  - Install `cron` and `sqlite3` packages
  - Copy backup script (`akm-backup.sh`) and cron job definition (`cron.d/akm-backup`)

- **Required entrypoint changes**: Documents two new shell functions:
  - `maybe_restore_akm_db()`: Restores the AKM SQLite database from the latest backup snapshot on cold start
  - `start_cron()`: Starts the system cron daemon and writes environment variables for scheduled jobs

- **Azure resource architecture**: Specifies resource group, ACA environment, container apps, storage account, Key Vault, and managed identity configuration

- **Deployment script specification**: Outlines `deploy-aca.sh` with subcommands for setup, deploy, update-ips, status, and teardown

## Notable Implementation Details

- **SQLite on emptyDir**: The AKM database lives on an ACA emptyDir volume (local POSIX-compliant filesystem) rather than Azure Files, because SMB does not support the advisory file locks that SQLite requires for write serialization and WAL coordination
- **Backup/restore cycle**: Provides durability despite the ephemeral emptyDir; configurable backup interval (default 1 hour) with automatic restore on container startup
- **Cron environment isolation**: Cron jobs do not inherit the container environment, so the script writes required variables to `/etc/cron-env` before starting the cron daemon
- **Single replica enforcement**: The architecture requires exactly one replica due to per-replica emptyDir state; documented in YAML constraints
- **Granular volume mounts**: Replaces a monolithic home directory share with targeted mounts for config, shared data, artifacts, and backups, reducing SMB lock contention

This is a planning document only; actual implementation of the Dockerfile, entrypoint, and deployment script changes will follow in subsequent PRs.

https://claude.ai/code/session_01MvxXjvN39TFkakcVohckTC