### PR TITLE
feat(akm): mirror vault/user secrets into akm secret store for UI visibility (#388)

### DIFF
--- a/.openpalm/stack/core.compose.yml
+++ b/.openpalm/stack/core.compose.yml
@@ -99,6 +99,9 @@ services:
       # reaches OpenCode via http://localhost:4096.
       # If you change OP_ASSISTANT_BIND_ADDRESS to 0.0.0.0, you MUST set
       # OP_OPENCODE_PASSWORD in stack.env and set OPENCODE_AUTH to "true".
+      # NON-CHANGE (#388 §B.1): OP_OPENCODE_PASSWORD compose plumbing
+      # is intentional for the LAN-exposed assistant case. Do NOT strip
+      # it as part of vault cleanup.
       OPENCODE_AUTH: "false"
       OPENCODE_ENABLE_SSH: ${OPENCODE_ENABLE_SSH:-0}
       TERM: xterm-256color

--- a/core/assistant/opencode/system.md
+++ b/core/assistant/opencode/system.md
@@ -21,6 +21,6 @@ For information about managing OpenPalm view @openpalm.md
 
 ## Secrets & Environment
 
-- Use `load_vault` to load user secrets from `/etc/vault/user.env` — this is the primary tool for accessing API keys, owner info, and other user-configured secrets.
+- Use `load_vault` to load user secrets (prefers the shared akm `vault:user` store, falls back to `/etc/vault/user.env`) — this is the primary tool for accessing API keys, owner info, and other user-configured secrets.
 - Use `load_env` only for ad-hoc `.env` files in the `/work` directory (workspace). It cannot read files outside `/work`.
 - Never display, log, or store secret values.

--- a/packages/admin/src/routes/admin/secrets/user-vault/+server.ts
+++ b/packages/admin/src/routes/admin/secrets/user-vault/+server.ts
@@ -1,0 +1,210 @@
+/**
+ * /admin/secrets/user-vault — read/write the shared akm user vault.
+ *
+ * Phase 1 of #388: this endpoint surfaces the same `vault:user` keys
+ * that `mirrorUserVaultToAkm()` populates during install/upgrade. The
+ * underlying compose runtime source of truth (`vault/user/user.env`)
+ * is kept in sync on writes so Docker Compose env_file resolution
+ * never diverges from what the admin UI shows.
+ *
+ * NOTE: We deliberately do NOT route admin secret writes through this
+ * endpoint by default — operator-managed `stack.env` secrets remain in
+ * the existing `/admin/secrets` plaintext/pass backends. This endpoint
+ * is scoped to user-extension keys only.
+ */
+import type { RequestHandler } from './$types';
+import { getState } from '$lib/server/state.js';
+import {
+  errorResponse,
+  getActor,
+  getCallerType,
+  getRequestId,
+  jsonResponse,
+  parseJsonBody,
+  jsonBodyError,
+  requireAdmin,
+} from '$lib/server/helpers.js';
+import {
+  appendAudit,
+  ensureAkmUserVault,
+  mirrorUserVaultToAkm,
+  readAkmUserVaultFile,
+  parseEnvFile,
+  mergeEnvContent,
+} from '@openpalm/lib';
+import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+import { execFile as execFileCb } from 'node:child_process';
+import { promisify } from 'node:util';
+
+const execFile = promisify(execFileCb);
+
+const KEY_RE = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+function buildAkmEnv(state: ReturnType<typeof getState>): NodeJS.ProcessEnv {
+  const stashRoot = `${state.dataDir}/stash`;
+  return {
+    ...process.env,
+    AKM_STASH_DIR: stashRoot,
+    AKM_DATA_DIR: `${stashRoot}/.data`,
+    AKM_STATE_DIR: `${stashRoot}/.state`,
+    AKM_CONFIG_DIR: `${stashRoot}/.config`,
+    AKM_CACHE_DIR: `${state.dataDir}/akm-cache`,
+  };
+}
+
+function writeUserEnvKey(vaultDir: string, key: string, value: string): void {
+  const userEnvPath = `${vaultDir}/user/user.env`;
+  mkdirSync(`${vaultDir}/user`, { recursive: true, mode: 0o700 });
+  const existing = existsSync(userEnvPath) ? readFileSync(userEnvPath, 'utf-8') : '';
+  const merged = mergeEnvContent(existing, { [key]: value });
+  writeFileSync(userEnvPath, merged.endsWith('\n') ? merged : merged + '\n', { mode: 0o600 });
+}
+
+/**
+ * GET — list keys in the akm vault:user store. Values are NEVER returned
+ * so this endpoint behaves identically whether the underlying backend
+ * exposes plaintext or encrypted secrets.
+ */
+export const GET: RequestHandler = async (event) => {
+  const requestId = getRequestId(event);
+  const authError = requireAdmin(event, requestId);
+  if (authError) return authError;
+
+  const state = getState();
+  const actor = getActor(event);
+  const callerType = getCallerType(event);
+
+  // Ensure mirror is up to date before listing so a freshly-installed
+  // stack shows the seeded keys without a separate /upgrade call.
+  try { await mirrorUserVaultToAkm(state); } catch { /* best-effort */ }
+
+  const vaultPath = await ensureAkmUserVault(state);
+  const userEnvPath = `${state.vaultDir}/user/user.env`;
+  const akmKeys = vaultPath ? Object.keys(readAkmUserVaultFile(vaultPath)) : [];
+  const fileKeys = Object.keys(parseEnvFile(userEnvPath));
+  const merged = Array.from(new Set([...akmKeys, ...fileKeys])).sort();
+
+  appendAudit(
+    state,
+    actor,
+    'secrets.user-vault.list',
+    { count: merged.length, source: vaultPath ? 'akm+file' : 'file-only' },
+    true,
+    requestId,
+    callerType,
+  );
+
+  return jsonResponse(200, {
+    provider: 'akm-mirror',
+    vaultRef: 'vault:user',
+    available: Boolean(vaultPath),
+    keys: merged,
+  }, requestId);
+};
+
+/**
+ * PUT/POST — write a key into both the akm vault and the runtime user.env
+ * file. Both writes happen so Compose env_file consumption stays in sync
+ * with what the admin UI displays.
+ */
+export const POST: RequestHandler = async (event) => {
+  const requestId = getRequestId(event);
+  const authError = requireAdmin(event, requestId);
+  if (authError) return authError;
+
+  const state = getState();
+  const actor = getActor(event);
+  const callerType = getCallerType(event);
+  const result = await parseJsonBody(event.request);
+  if ('error' in result) return jsonBodyError(result, requestId);
+
+  const key = typeof result.data.key === 'string' ? result.data.key.trim() : '';
+  const value = typeof result.data.value === 'string' ? result.data.value : null;
+  if (!key || value === null) {
+    return errorResponse(400, 'bad_request', 'key and value are required', {}, requestId);
+  }
+  if (!KEY_RE.test(key)) {
+    return errorResponse(400, 'invalid_key', 'key must match [A-Za-z_][A-Za-z0-9_]*', {}, requestId);
+  }
+  if (value.length === 0) {
+    return errorResponse(400, 'bad_request', 'value must be non-empty; use DELETE to remove a key', {}, requestId);
+  }
+
+  // 1. Write to user.env (compose runtime source of truth).
+  try {
+    writeUserEnvKey(state.vaultDir, key, value);
+  } catch (err) {
+    appendAudit(state, actor, 'secrets.user-vault.write', { key, error: String(err) }, false, requestId, callerType);
+    return errorResponse(500, 'internal_error', 'Failed to update user.env', {}, requestId);
+  }
+
+  // 2. Mirror into akm. If akm is unavailable the .env write still
+  //    succeeded, so we report partial success rather than a hard error.
+  let akmOk = false;
+  try {
+    const env = buildAkmEnv(state);
+    await execFile('akm', ['vault', 'create', 'vault:user'], { env }).catch(() => { /* idempotent */ });
+    await execFile('akm', ['vault', 'set', 'vault:user', key, value], { env });
+    akmOk = true;
+  } catch {
+    akmOk = false;
+  }
+
+  appendAudit(
+    state,
+    actor,
+    'secrets.user-vault.write',
+    { key, mirrored: akmOk },
+    true,
+    requestId,
+    callerType,
+  );
+
+  return jsonResponse(200, { ok: true, key, mirrored: akmOk }, requestId);
+};
+
+/** DELETE — remove a key from both the akm vault and user.env. */
+export const DELETE: RequestHandler = async (event) => {
+  const requestId = getRequestId(event);
+  const authError = requireAdmin(event, requestId);
+  if (authError) return authError;
+
+  const state = getState();
+  const actor = getActor(event);
+  const callerType = getCallerType(event);
+  const key = new URL(event.request.url).searchParams.get('key')?.trim() ?? '';
+  if (!key || !KEY_RE.test(key)) {
+    return errorResponse(400, 'bad_request', 'valid key query parameter is required', {}, requestId);
+  }
+
+  // 1. Drop from user.env by setting to empty (the .env file format treats
+  //    empty values as cleared; downstream Compose env_file sees no value).
+  try {
+    writeUserEnvKey(state.vaultDir, key, '');
+  } catch (err) {
+    appendAudit(state, actor, 'secrets.user-vault.remove', { key, error: String(err) }, false, requestId, callerType);
+    return errorResponse(500, 'internal_error', 'Failed to update user.env', {}, requestId);
+  }
+
+  // 2. Drop from akm vault.
+  let akmOk = false;
+  try {
+    const env = buildAkmEnv(state);
+    await execFile('akm', ['vault', 'unset', 'vault:user', key], { env });
+    akmOk = true;
+  } catch {
+    akmOk = false;
+  }
+
+  appendAudit(
+    state,
+    actor,
+    'secrets.user-vault.remove',
+    { key, mirrored: akmOk },
+    true,
+    requestId,
+    callerType,
+  );
+
+  return jsonResponse(200, { ok: true, key, mirrored: akmOk }, requestId);
+};

--- a/packages/admin/src/routes/admin/secrets/user-vault/+server.ts
+++ b/packages/admin/src/routes/admin/secrets/user-vault/+server.ts
@@ -11,6 +11,11 @@
  * endpoint by default — operator-managed `stack.env` secrets remain in
  * the existing `/admin/secrets` plaintext/pass backends. This endpoint
  * is scoped to user-extension keys only.
+ *
+ * SECURITY: writes go DIRECTLY to the akm vault .env file via lib's
+ * `writeAkmVaultKey`/`deleteAkmVaultKey` helpers. We never pass secret
+ * values on the `akm` argv, since that would expose them through
+ * `/proc/<pid>/cmdline`.
  */
 import type { RequestHandler } from './$types';
 import { getState } from '$lib/server/state.js';
@@ -25,32 +30,22 @@ import {
   requireAdmin,
 } from '$lib/server/helpers.js';
 import {
+  AKM_USER_VAULT_REF,
   appendAudit,
+  deleteAkmVaultKey,
   ensureAkmUserVault,
-  mirrorUserVaultToAkm,
-  readAkmUserVaultFile,
-  parseEnvFile,
   mergeEnvContent,
+  parseEnvFile,
+  readAkmUserVaultFile,
+  removeEnvKey,
+  writeAkmVaultKey,
 } from '@openpalm/lib';
+import { createLogger } from '$lib/server/logger.js';
 import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs';
-import { execFile as execFileCb } from 'node:child_process';
-import { promisify } from 'node:util';
 
-const execFile = promisify(execFileCb);
+const logger = createLogger('admin.secrets.user-vault');
 
 const KEY_RE = /^[A-Za-z_][A-Za-z0-9_]*$/;
-
-function buildAkmEnv(state: ReturnType<typeof getState>): NodeJS.ProcessEnv {
-  const stashRoot = `${state.dataDir}/stash`;
-  return {
-    ...process.env,
-    AKM_STASH_DIR: stashRoot,
-    AKM_DATA_DIR: `${stashRoot}/.data`,
-    AKM_STATE_DIR: `${stashRoot}/.state`,
-    AKM_CONFIG_DIR: `${stashRoot}/.config`,
-    AKM_CACHE_DIR: `${state.dataDir}/akm-cache`,
-  };
-}
 
 function writeUserEnvKey(vaultDir: string, key: string, value: string): void {
   const userEnvPath = `${vaultDir}/user/user.env`;
@@ -60,10 +55,22 @@ function writeUserEnvKey(vaultDir: string, key: string, value: string): void {
   writeFileSync(userEnvPath, merged.endsWith('\n') ? merged : merged + '\n', { mode: 0o600 });
 }
 
+function removeUserEnvKey(vaultDir: string, key: string): void {
+  const userEnvPath = `${vaultDir}/user/user.env`;
+  if (!existsSync(userEnvPath)) return;
+  const existing = readFileSync(userEnvPath, 'utf-8');
+  const stripped = removeEnvKey(existing, key);
+  writeFileSync(userEnvPath, stripped.endsWith('\n') ? stripped : stripped + '\n', { mode: 0o600 });
+}
+
 /**
  * GET — list keys in the akm vault:user store. Values are NEVER returned
  * so this endpoint behaves identically whether the underlying backend
  * exposes plaintext or encrypted secrets.
+ *
+ * Mirror is NOT run on GET — it is part of install/upgrade lifecycle only.
+ * Calling akm on every list would be wasteful and surface transient
+ * akm-CLI failures as list errors.
  */
 export const GET: RequestHandler = async (event) => {
   const requestId = getRequestId(event);
@@ -74,14 +81,13 @@ export const GET: RequestHandler = async (event) => {
   const actor = getActor(event);
   const callerType = getCallerType(event);
 
-  // Ensure mirror is up to date before listing so a freshly-installed
-  // stack shows the seeded keys without a separate /upgrade call.
-  try { await mirrorUserVaultToAkm(state); } catch { /* best-effort */ }
-
   const vaultPath = await ensureAkmUserVault(state);
   const userEnvPath = `${state.vaultDir}/user/user.env`;
   const akmKeys = vaultPath ? Object.keys(readAkmUserVaultFile(vaultPath)) : [];
-  const fileKeys = Object.keys(parseEnvFile(userEnvPath));
+  const fileEntries = parseEnvFile(userEnvPath);
+  // Filter empty values so cleared keys don't show up post-DELETE if the
+  // file write path ever leaves a `KEY=` line behind.
+  const fileKeys = Object.keys(fileEntries).filter((k) => fileEntries[k] !== '');
   const merged = Array.from(new Set([...akmKeys, ...fileKeys])).sort();
 
   appendAudit(
@@ -96,7 +102,7 @@ export const GET: RequestHandler = async (event) => {
 
   return jsonResponse(200, {
     provider: 'akm-mirror',
-    vaultRef: 'vault:user',
+    vaultRef: AKM_USER_VAULT_REF,
     available: Boolean(vaultPath),
     keys: merged,
   }, requestId);
@@ -106,6 +112,11 @@ export const GET: RequestHandler = async (event) => {
  * PUT/POST — write a key into both the akm vault and the runtime user.env
  * file. Both writes happen so Compose env_file consumption stays in sync
  * with what the admin UI displays.
+ *
+ * If the akm write fails the .env update still succeeds (since Compose is
+ * the runtime source of truth), but the response surfaces `mirrored:false`
+ * and an `error` field so callers can decide whether to retry. A warn-level
+ * log is emitted for operators (key name only, never the value).
  */
 export const POST: RequestHandler = async (event) => {
   const requestId = getRequestId(event);
@@ -138,29 +149,43 @@ export const POST: RequestHandler = async (event) => {
     return errorResponse(500, 'internal_error', 'Failed to update user.env', {}, requestId);
   }
 
-  // 2. Mirror into akm. If akm is unavailable the .env write still
-  //    succeeded, so we report partial success rather than a hard error.
-  let akmOk = false;
+  // 2. Mirror into the akm vault file by writing directly (no argv exposure).
+  let mirrored = false;
+  let mirrorError: string | undefined;
   try {
-    const env = buildAkmEnv(state);
-    await execFile('akm', ['vault', 'create', 'vault:user'], { env }).catch(() => { /* idempotent */ });
-    await execFile('akm', ['vault', 'set', 'vault:user', key, value], { env });
-    akmOk = true;
-  } catch {
-    akmOk = false;
+    mirrored = await writeAkmVaultKey(state, key, value);
+    if (!mirrored) mirrorError = 'akm_unavailable';
+  } catch (err) {
+    mirrored = false;
+    mirrorError = err instanceof Error ? err.message : String(err);
+  }
+
+  if (!mirrored) {
+    // Divergence is recoverable (re-running upgrade re-mirrors) but
+    // operators need to see it. Never log the value.
+    logger.warn('akm vault write failed; user.env and akm vault are diverged', {
+      key,
+      reason: mirrorError,
+      requestId,
+    });
   }
 
   appendAudit(
     state,
     actor,
     'secrets.user-vault.write',
-    { key, mirrored: akmOk },
+    { key, mirrored, ...(mirrorError ? { mirrorError } : {}) },
     true,
     requestId,
     callerType,
   );
 
-  return jsonResponse(200, { ok: true, key, mirrored: akmOk }, requestId);
+  return jsonResponse(200, {
+    ok: true,
+    key,
+    mirrored,
+    ...(mirrorError ? { error: mirrorError } : {}),
+  }, requestId);
 };
 
 /** DELETE — remove a key from both the akm vault and user.env. */
@@ -177,34 +202,48 @@ export const DELETE: RequestHandler = async (event) => {
     return errorResponse(400, 'bad_request', 'valid key query parameter is required', {}, requestId);
   }
 
-  // 1. Drop from user.env by setting to empty (the .env file format treats
-  //    empty values as cleared; downstream Compose env_file sees no value).
+  // 1. Remove from user.env entirely (clean semantics — no empty-valued
+  //    stub line left behind for GET to filter out).
   try {
-    writeUserEnvKey(state.vaultDir, key, '');
+    removeUserEnvKey(state.vaultDir, key);
   } catch (err) {
     appendAudit(state, actor, 'secrets.user-vault.remove', { key, error: String(err) }, false, requestId, callerType);
     return errorResponse(500, 'internal_error', 'Failed to update user.env', {}, requestId);
   }
 
-  // 2. Drop from akm vault.
-  let akmOk = false;
+  // 2. Drop from akm vault file directly (no argv exposure).
+  let mirrored = false;
+  let mirrorError: string | undefined;
   try {
-    const env = buildAkmEnv(state);
-    await execFile('akm', ['vault', 'unset', 'vault:user', key], { env });
-    akmOk = true;
-  } catch {
-    akmOk = false;
+    mirrored = await deleteAkmVaultKey(state, key);
+    if (!mirrored) mirrorError = 'akm_unavailable';
+  } catch (err) {
+    mirrored = false;
+    mirrorError = err instanceof Error ? err.message : String(err);
+  }
+
+  if (!mirrored) {
+    logger.warn('akm vault delete failed; user.env and akm vault are diverged', {
+      key,
+      reason: mirrorError,
+      requestId,
+    });
   }
 
   appendAudit(
     state,
     actor,
     'secrets.user-vault.remove',
-    { key, mirrored: akmOk },
+    { key, mirrored, ...(mirrorError ? { mirrorError } : {}) },
     true,
     requestId,
     callerType,
   );
 
-  return jsonResponse(200, { ok: true, key, mirrored: akmOk }, requestId);
+  return jsonResponse(200, {
+    ok: true,
+    key,
+    mirrored,
+    ...(mirrorError ? { error: mirrorError } : {}),
+  }, requestId);
 };

--- a/packages/admin/src/routes/admin/secrets/user-vault/server.vitest.ts
+++ b/packages/admin/src/routes/admin/secrets/user-vault/server.vitest.ts
@@ -1,0 +1,143 @@
+import { afterEach, beforeEach, describe, expect, test } from 'vitest';
+import { join } from 'node:path';
+import { mkdirSync, readFileSync, rmSync, writeFileSync, existsSync } from 'node:fs';
+import { randomBytes } from 'node:crypto';
+import { tmpdir } from 'node:os';
+import { execFileSync } from 'node:child_process';
+import { getState } from '$lib/server/state.js';
+import { resetState } from '$lib/server/test-helpers.js';
+import { GET, POST, DELETE } from './+server.js';
+
+function makeTempDir(): string {
+  const dir = join(tmpdir(), `openpalm-user-vault-route-${randomBytes(4).toString('hex')}`);
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function makeEvent(method: string, path: string, body?: Record<string, unknown>, token = 'admin-token') {
+  const headers: Record<string, string> = { 'x-request-id': 'req-uv-1' };
+  if (token) headers['x-admin-token'] = token;
+  if (body) headers['content-type'] = 'application/json';
+  return {
+    request: new Request(`http://localhost${path}`, {
+      method,
+      headers,
+      body: body ? JSON.stringify(body) : undefined,
+    }),
+  } as Parameters<typeof GET>[0];
+}
+
+function hasAkm(): boolean {
+  try {
+    execFileSync('akm', ['--version'], { stdio: 'ignore' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const AKM_AVAILABLE = hasAkm();
+
+let rootDir = '';
+let originalHome: string | undefined;
+
+beforeEach(() => {
+  rootDir = makeTempDir();
+  originalHome = process.env.OP_HOME;
+  process.env.OP_HOME = rootDir;
+  resetState('admin-token');
+
+  const state = getState();
+  mkdirSync(state.configDir, { recursive: true });
+  mkdirSync(state.vaultDir, { recursive: true });
+  mkdirSync(join(state.vaultDir, 'user'), { recursive: true });
+  mkdirSync(state.dataDir, { recursive: true });
+  mkdirSync(join(state.dataDir, 'stash'), { recursive: true });
+  mkdirSync(state.logsDir, { recursive: true });
+});
+
+afterEach(() => {
+  process.env.OP_HOME = originalHome;
+  rmSync(rootDir, { recursive: true, force: true });
+});
+
+describe('admin user-vault route', () => {
+  test('GET returns 401 without admin token', async () => {
+    const res = await GET(makeEvent('GET', '/admin/secrets/user-vault', undefined, ''));
+    expect(res.status).toBe(401);
+  });
+
+  test('GET lists user.env keys without exposing values', async () => {
+    const state = getState();
+    writeFileSync(join(state.vaultDir, 'user', 'user.env'), 'CUSTOM_KEY=v1\nOTHER_KEY=v2\n');
+
+    const res = await GET(makeEvent('GET', '/admin/secrets/user-vault'));
+    expect(res.status).toBe(200);
+    const body = await res.json() as { keys: string[]; vaultRef: string };
+    expect(body.vaultRef).toBe('vault:user');
+    expect(body.keys).toContain('CUSTOM_KEY');
+    expect(body.keys).toContain('OTHER_KEY');
+    // The response body must not contain any of the values.
+    const raw = JSON.stringify(body);
+    expect(raw).not.toContain('v1');
+    expect(raw).not.toContain('v2');
+  });
+
+  test('POST writes a key to user.env and reports mirror status', async () => {
+    const res = await POST(makeEvent('POST', '/admin/secrets/user-vault', {
+      key: 'CUSTOM_TOKEN',
+      value: 'secret-payload',
+    }));
+    expect(res.status).toBe(200);
+    const body = await res.json() as { ok: boolean; key: string; mirrored: boolean };
+    expect(body.ok).toBe(true);
+    expect(body.key).toBe('CUSTOM_TOKEN');
+    // Whether mirror succeeded depends on akm availability — only the
+    // user.env write must succeed unconditionally.
+    expect(typeof body.mirrored).toBe('boolean');
+
+    const state = getState();
+    const content = readFileSync(join(state.vaultDir, 'user', 'user.env'), 'utf-8');
+    expect(content).toContain('CUSTOM_TOKEN=');
+    expect(content).toContain('secret-payload');
+  });
+
+  test('POST rejects invalid key', async () => {
+    const res = await POST(makeEvent('POST', '/admin/secrets/user-vault', {
+      key: 'bad key with spaces',
+      value: 'whatever',
+    }));
+    expect(res.status).toBe(400);
+  });
+
+  test('POST rejects empty value', async () => {
+    const res = await POST(makeEvent('POST', '/admin/secrets/user-vault', {
+      key: 'KEY',
+      value: '',
+    }));
+    expect(res.status).toBe(400);
+  });
+
+  test('DELETE clears a key from user.env', async () => {
+    const state = getState();
+    writeFileSync(join(state.vaultDir, 'user', 'user.env'), 'KEEP_ME=ok\nDROP_ME=bye\n');
+
+    const res = await DELETE(makeEvent('DELETE', '/admin/secrets/user-vault?key=DROP_ME'));
+    expect(res.status).toBe(200);
+
+    const content = readFileSync(join(state.vaultDir, 'user', 'user.env'), 'utf-8');
+    expect(content).toContain('KEEP_ME=ok');
+    // mergeEnvContent clears the value to empty rather than deleting the line.
+    expect(content).toMatch(/DROP_ME=\s*$/m);
+  });
+
+  test.skipIf(!AKM_AVAILABLE)('writes are visible to akm vault list after POST', async () => {
+    const res = await POST(makeEvent('POST', '/admin/secrets/user-vault', {
+      key: 'AKM_INTEGRATION_TEST_KEY',
+      value: 'roundtrip-value-' + randomBytes(4).toString('hex'),
+    }));
+    expect(res.status).toBe(200);
+    const body = await res.json() as { mirrored: boolean };
+    expect(body.mirrored).toBe(true);
+  });
+});

--- a/packages/admin/src/routes/admin/secrets/user-vault/server.vitest.ts
+++ b/packages/admin/src/routes/admin/secrets/user-vault/server.vitest.ts
@@ -118,7 +118,7 @@ describe('admin user-vault route', () => {
     expect(res.status).toBe(400);
   });
 
-  test('DELETE clears a key from user.env', async () => {
+  test('DELETE removes a key from user.env entirely', async () => {
     const state = getState();
     writeFileSync(join(state.vaultDir, 'user', 'user.env'), 'KEEP_ME=ok\nDROP_ME=bye\n');
 
@@ -127,8 +127,20 @@ describe('admin user-vault route', () => {
 
     const content = readFileSync(join(state.vaultDir, 'user', 'user.env'), 'utf-8');
     expect(content).toContain('KEEP_ME=ok');
-    // mergeEnvContent clears the value to empty rather than deleting the line.
-    expect(content).toMatch(/DROP_ME=\s*$/m);
+    // Removed line must not appear at all (clean semantics so subsequent
+    // GETs don't list a phantom empty-value key).
+    expect(content).not.toMatch(/^DROP_ME=/m);
+  });
+
+  test('DELETE followed by GET no longer lists the key', async () => {
+    const state = getState();
+    writeFileSync(join(state.vaultDir, 'user', 'user.env'), 'KEEP_ME=ok\nDROP_ME=bye\n');
+    await DELETE(makeEvent('DELETE', '/admin/secrets/user-vault?key=DROP_ME'));
+
+    const listRes = await GET(makeEvent('GET', '/admin/secrets/user-vault'));
+    const body = await listRes.json() as { keys: string[] };
+    expect(body.keys).toContain('KEEP_ME');
+    expect(body.keys).not.toContain('DROP_ME');
   });
 
   test.skipIf(!AKM_AVAILABLE)('writes are visible to akm vault list after POST', async () => {

--- a/packages/assistant-tools/opencode/tools/load_vault.ts
+++ b/packages/assistant-tools/opencode/tools/load_vault.ts
@@ -1,5 +1,6 @@
 import { tool } from "@opencode-ai/plugin";
 import { readFile, access } from "fs/promises";
+import { existsSync } from "fs";
 import { promisify } from "util";
 import { execFile as execFileCb } from "child_process";
 
@@ -12,6 +13,8 @@ const execFile = promisify(execFileCb);
  */
 const FALLBACK_VAULT_PATH = "/etc/vault/user.env";
 const AKM_USER_VAULT_REF = "vault:user";
+
+type VaultSource = "akm" | "fallback";
 
 export function parseEnvContent(
   content: string,
@@ -54,20 +57,24 @@ export function parseEnvContent(
 
 /**
  * Resolve the user vault file path. Phase 1 of #388: prefer the
- * shared akm store (`vault:user`) so editing through the admin UI or
- * via `akm vault set` immediately reflects on the next call. If the
- * akm CLI is missing or the vault has not been provisioned yet, fall
- * back to the Compose-mounted .env file.
+ * shared akm store (`vault:user`) so editing through the admin UI
+ * immediately reflects on the next call. If the akm CLI is missing
+ * or the vault has not been provisioned yet, fall back to the
+ * Compose-mounted .env file.
+ *
+ * We `existsSync`-guard the akm-resolved path so a stale ref (e.g. the
+ * vault file was deleted out from under akm) cleanly falls through to
+ * the bind-mount fallback instead of returning a non-existent path.
  */
-async function resolveVaultPath(): Promise<string> {
+async function resolveVaultPath(): Promise<{ path: string; source: VaultSource }> {
   try {
     const { stdout } = await execFile("akm", ["vault", "path", AKM_USER_VAULT_REF]);
     const path = stdout.trim();
-    if (path) return path;
+    if (path && existsSync(path)) return { path, source: "akm" };
   } catch {
     // akm not on PATH or vault missing — fall through to legacy file
   }
-  return FALLBACK_VAULT_PATH;
+  return { path: FALLBACK_VAULT_PATH, source: "fallback" };
 }
 
 export default tool({
@@ -90,14 +97,18 @@ export default tool({
       .describe("Only load vars whose name starts with this prefix"),
   },
   async execute(args) {
-    const vaultPath = await resolveVaultPath();
+    const { path: vaultPath, source } = await resolveVaultPath();
+    // Symbolic label exposed to the LLM. We deliberately do NOT return
+    // the absolute filesystem path — the model never needs it, and the
+    // stash path can leak operator-side filesystem layout.
+    const sourceLabel = source === "akm" ? "akm:vault:user" : "fallback:/etc/vault";
 
     try {
       await access(vaultPath);
     } catch {
       return JSON.stringify({
         error: true,
-        message: `Vault file not found: ${vaultPath}`,
+        message: `Vault file not found (source=${sourceLabel})`,
       });
     }
 
@@ -107,7 +118,7 @@ export default tool({
     } catch (err: unknown) {
       return JSON.stringify({
         error: true,
-        message: `Failed to read vault file: ${vaultPath}`,
+        message: `Failed to read vault file (source=${sourceLabel})`,
         detail: err instanceof Error ? err.message : String(err),
       });
     }
@@ -118,7 +129,7 @@ export default tool({
     });
 
     return JSON.stringify({
-      source: vaultPath,
+      source: sourceLabel,
       loaded,
       skipped,
       message:

--- a/packages/assistant-tools/opencode/tools/load_vault.ts
+++ b/packages/assistant-tools/opencode/tools/load_vault.ts
@@ -1,7 +1,17 @@
 import { tool } from "@opencode-ai/plugin";
 import { readFile, access } from "fs/promises";
+import { promisify } from "util";
+import { execFile as execFileCb } from "child_process";
 
-const VAULT_PATH = "/etc/vault/user.env";
+const execFile = promisify(execFileCb);
+
+/**
+ * Legacy compose-mounted path. Phase 1 of #388 keeps this as the
+ * fallback while the akm secret store mirror catches up; Phase 2 will
+ * retire the bind mount and route entirely through akm.
+ */
+const FALLBACK_VAULT_PATH = "/etc/vault/user.env";
+const AKM_USER_VAULT_REF = "vault:user";
 
 export function parseEnvContent(
   content: string,
@@ -42,12 +52,32 @@ export function parseEnvContent(
   return { loaded, skipped };
 }
 
+/**
+ * Resolve the user vault file path. Phase 1 of #388: prefer the
+ * shared akm store (`vault:user`) so editing through the admin UI or
+ * via `akm vault set` immediately reflects on the next call. If the
+ * akm CLI is missing or the vault has not been provisioned yet, fall
+ * back to the Compose-mounted .env file.
+ */
+async function resolveVaultPath(): Promise<string> {
+  try {
+    const { stdout } = await execFile("akm", ["vault", "path", AKM_USER_VAULT_REF]);
+    const path = stdout.trim();
+    if (path) return path;
+  } catch {
+    // akm not on PATH or vault missing — fall through to legacy file
+  }
+  return FALLBACK_VAULT_PATH;
+}
+
 export default tool({
   description:
-    "Load user vault secrets from /etc/vault/user.env into the running process. " +
-    "Returns only the variable names that were loaded — never the values. " +
-    "This is the primary way to load API keys, owner info, and other user-configured secrets. " +
-    "Use load_env instead only for ad-hoc .env files under /work.",
+    "Load user vault secrets into the running process. Returns only the " +
+    "variable names that were loaded — never the values. Prefers the " +
+    "shared akm vault `vault:user` (resolved via `akm vault path`) and " +
+    "falls back to `/etc/vault/user.env` when akm is unavailable. This is " +
+    "the primary way to load API keys, owner info, and other user-configured " +
+    "secrets. Use load_env only for ad-hoc .env files under /work.",
   args: {
     override: tool.schema
       .boolean()
@@ -60,22 +90,24 @@ export default tool({
       .describe("Only load vars whose name starts with this prefix"),
   },
   async execute(args) {
+    const vaultPath = await resolveVaultPath();
+
     try {
-      await access(VAULT_PATH);
+      await access(vaultPath);
     } catch {
       return JSON.stringify({
         error: true,
-        message: `Vault file not found: ${VAULT_PATH}`,
+        message: `Vault file not found: ${vaultPath}`,
       });
     }
 
     let content: string;
     try {
-      content = await readFile(VAULT_PATH, "utf-8");
+      content = await readFile(vaultPath, "utf-8");
     } catch (err: unknown) {
       return JSON.stringify({
         error: true,
-        message: `Failed to read vault file: ${VAULT_PATH}`,
+        message: `Failed to read vault file: ${vaultPath}`,
         detail: err instanceof Error ? err.message : String(err),
       });
     }
@@ -86,7 +118,7 @@ export default tool({
     });
 
     return JSON.stringify({
-      source: VAULT_PATH,
+      source: vaultPath,
       loaded,
       skipped,
       message:

--- a/packages/lib/src/control-plane/akm-vault.test.ts
+++ b/packages/lib/src/control-plane/akm-vault.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Tests for the akm vault mirror (Phase 1 of #388).
+ *
+ * The full mirror requires the `akm` CLI on PATH plus a writable shared
+ * stash directory. Tests gate on those conditions so the suite stays
+ * green in environments without akm installed. The pure logic (env
+ * file enumeration, idempotency diff) is covered unconditionally.
+ */
+import { describe, expect, it, beforeEach, afterEach } from "bun:test";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { execFileSync } from "node:child_process";
+import {
+  mirrorUserVaultToAkm,
+  ensureAkmUserVault,
+  readAkmUserVaultFile,
+  AKM_USER_VAULT_REF,
+} from "./akm-vault.js";
+import type { ControlPlaneState } from "./types.js";
+
+function makeState(homeDir: string): ControlPlaneState {
+  return {
+    adminToken: "test-admin",
+    assistantToken: "test-assistant",
+    setupToken: "test-setup",
+    homeDir,
+    configDir: join(homeDir, "config"),
+    vaultDir: join(homeDir, "vault"),
+    dataDir: join(homeDir, "data"),
+    logsDir: join(homeDir, "logs"),
+    cacheDir: join(homeDir, ".cache"),
+    services: {},
+    artifacts: { compose: "" },
+    artifactMeta: [],
+    audit: [],
+  };
+}
+
+function hasAkmCli(): boolean {
+  try {
+    execFileSync("akm", ["--version"], { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const AKM_AVAILABLE = hasAkmCli();
+
+describe("mirrorUserVaultToAkm", () => {
+  let homeDir: string;
+  let state: ControlPlaneState;
+
+  beforeEach(() => {
+    homeDir = mkdtempSync(join(tmpdir(), "openpalm-akm-"));
+    state = makeState(homeDir);
+    mkdirSync(state.vaultDir, { recursive: true });
+    mkdirSync(join(state.vaultDir, "user"), { recursive: true });
+    mkdirSync(state.dataDir, { recursive: true });
+    mkdirSync(join(state.dataDir, "stash"), { recursive: true });
+    mkdirSync(join(state.dataDir, "akm-cache"), { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(homeDir, { recursive: true, force: true });
+  });
+
+  it("skips when user.env is missing", async () => {
+    const result = await mirrorUserVaultToAkm(state);
+    expect(result.ok).toBe(true);
+    expect(result.skipped).toBe(true);
+    expect(result.reason).toBe("user.env missing");
+  });
+
+  it("skips when user.env contains no non-empty values", async () => {
+    writeFileSync(
+      join(state.vaultDir, "user", "user.env"),
+      "# comments only\n\n# another comment\nEMPTY_KEY=\n",
+    );
+    const result = await mirrorUserVaultToAkm(state);
+    expect(result.ok).toBe(true);
+    expect(result.skipped).toBe(true);
+    expect(result.reason).toBe("user.env empty");
+  });
+
+  it.skipIf(!AKM_AVAILABLE)("migrates a fake 0.10.x layout idempotently", async () => {
+    // Seed a pre-0.11 user.env with a single key.
+    writeFileSync(
+      join(state.vaultDir, "user", "user.env"),
+      "# legacy 0.10.x layout\nGROQ_API_KEY=xyz-test-value-1\n",
+    );
+
+    // First mirror — should write the key.
+    const first = await mirrorUserVaultToAkm(state);
+    expect(first.ok).toBe(true);
+    expect(first.skipped).toBe(false);
+    expect(first.written).toContain("GROQ_API_KEY");
+    expect(first.unchanged).toHaveLength(0);
+
+    // The akm vault file should now contain the value.
+    const vaultPath = await ensureAkmUserVault(state);
+    expect(vaultPath).not.toBeNull();
+    if (vaultPath) {
+      const stored = readAkmUserVaultFile(vaultPath);
+      expect(stored.GROQ_API_KEY).toBe("xyz-test-value-1");
+    }
+
+    // The source .env file MUST still exist (Phase 1 keeps both in sync).
+    expect(existsSync(join(state.vaultDir, "user", "user.env"))).toBe(true);
+    expect(readFileSync(join(state.vaultDir, "user", "user.env"), "utf-8"))
+      .toContain("GROQ_API_KEY=xyz-test-value-1");
+
+    // Second mirror — every key should now be reported as unchanged.
+    const second = await mirrorUserVaultToAkm(state);
+    expect(second.ok).toBe(true);
+    expect(second.skipped).toBe(false);
+    expect(second.unchanged).toContain("GROQ_API_KEY");
+    expect(second.written).toHaveLength(0);
+  });
+
+  it.skipIf(!AKM_AVAILABLE)("updates only changed keys on second run", async () => {
+    writeFileSync(
+      join(state.vaultDir, "user", "user.env"),
+      "KEY_A=value-a\nKEY_B=value-b\n",
+    );
+    await mirrorUserVaultToAkm(state);
+
+    // Change KEY_B, leave KEY_A untouched.
+    writeFileSync(
+      join(state.vaultDir, "user", "user.env"),
+      "KEY_A=value-a\nKEY_B=value-b-updated\n",
+    );
+    const result = await mirrorUserVaultToAkm(state);
+    expect(result.written).toEqual(["KEY_B"]);
+    expect(result.unchanged).toEqual(["KEY_A"]);
+  });
+});
+
+describe("AKM_USER_VAULT_REF", () => {
+  it("exports the canonical akm ref string", () => {
+    expect(AKM_USER_VAULT_REF).toBe("vault:user");
+  });
+});

--- a/packages/lib/src/control-plane/akm-vault.test.ts
+++ b/packages/lib/src/control-plane/akm-vault.test.ts
@@ -150,6 +150,58 @@ describe("mirrorUserVaultToAkm", () => {
     expect(result.unchanged).toEqual(["KEY_A"]);
   });
 
+  it("returns a skipped result (does not hang) when the child process never resolves", async () => {
+    // Regression test for the install/upgrade hang reproduced on PR #404:
+    // `mirrorUserVaultToAkm` previously awaited promisified `execFile` without
+    // a wall-clock bound. In environments where the child process never
+    // resolves stdout (e.g. Bun test suites in `packages/cli/src/main.test.ts`
+    // that stub `Bun.spawn` and return a fake child whose stdout/exit never
+    // fire), the mirror would block the entire install flow until the
+    // surrounding test timed out. This test pins the contract: even with a
+    // permanently-pending child, the mirror must abort fast and report a
+    // skip rather than hang.
+    //
+    // We stub `Bun.spawn` (the actual primitive under `child_process.execFile`
+    // in the Bun runtime) the same way `packages/cli/src/main.test.ts`
+    // `mockDockerCli` does, to faithfully reproduce the original failure mode.
+    writeFileSync(
+      join(state.vaultDir, "user", "user.env"),
+      "STUCK_CHECK=value-1\n",
+    );
+
+    const originalSpawn = Bun.spawn;
+    (Bun as unknown as { spawn: typeof Bun.spawn }).spawn = (() => ({
+      pid: 0,
+      exited: new Promise<number>(() => { /* never resolves */ }),
+      exitCode: null,
+      signalCode: null,
+      killed: false,
+      stdin: null,
+      stdout: null,
+      stderr: null,
+      kill: () => {},
+      ref: () => {},
+      unref: () => {},
+      [Symbol.asyncDispose]: async () => {},
+      resourceUsage: () => undefined,
+    })) as unknown as typeof Bun.spawn;
+
+    try {
+      const start = Date.now();
+      const result = await mirrorUserVaultToAkm(state);
+      const elapsed = Date.now() - start;
+
+      // Mirror must abandon the akm probe and return — never block install.
+      // The internal AKM_EXEC_TIMEOUT_MS is 2s; allow generous CI headroom.
+      expect(elapsed).toBeLessThan(4_000);
+      // Timeout is treated as "akm not on PATH" — best-effort skip, never throw.
+      expect(result.ok).toBe(true);
+      expect(result.skipped).toBe(true);
+    } finally {
+      (Bun as unknown as { spawn: typeof Bun.spawn }).spawn = originalSpawn;
+    }
+  });
+
   it.skipIf(!AKM_AVAILABLE)("never passes secret values via execFile argv (no /proc/cmdline leak)", async () => {
     // This is the regression test for the security finding on PR #404.
     // Spy on execFile and assert no call contains the secret value.

--- a/packages/lib/src/control-plane/akm-vault.test.ts
+++ b/packages/lib/src/control-plane/akm-vault.test.ts
@@ -5,16 +5,24 @@
  * stash directory. Tests gate on those conditions so the suite stays
  * green in environments without akm installed. The pure logic (env
  * file enumeration, idempotency diff) is covered unconditionally.
+ *
+ * CI coverage gap: the gated tests `it.skipIf(!AKM_AVAILABLE)` skip
+ * silently when akm is not on PATH. CI does not install akm today, so
+ * these branches are exercised only by local developers. Follow-up
+ * tracked in the PR body.
  */
-import { describe, expect, it, beforeEach, afterEach } from "bun:test";
+import { describe, expect, it, beforeEach, afterEach, spyOn } from "bun:test";
 import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { execFileSync } from "node:child_process";
+import * as childProcess from "node:child_process";
 import {
   mirrorUserVaultToAkm,
   ensureAkmUserVault,
   readAkmUserVaultFile,
+  writeAkmVaultKey,
+  deleteAkmVaultKey,
   AKM_USER_VAULT_REF,
 } from "./akm-vault.js";
 import type { ControlPlaneState } from "./types.js";
@@ -84,38 +92,44 @@ describe("mirrorUserVaultToAkm", () => {
     expect(result.reason).toBe("user.env empty");
   });
 
-  it.skipIf(!AKM_AVAILABLE)("migrates a fake 0.10.x layout idempotently", async () => {
-    // Seed a pre-0.11 user.env with a single key.
+  it.skipIf(!AKM_AVAILABLE)("migrates a fake 0.10.x layout idempotently (upgrade-path contract)", async () => {
+    // Seed a pre-0.11 vault/user/user.env layout — this is exactly the
+    // shape `applyUpgrade()` sees on the first 0.10.x → 0.11 upgrade.
     writeFileSync(
       join(state.vaultDir, "user", "user.env"),
-      "# legacy 0.10.x layout\nGROQ_API_KEY=xyz-test-value-1\n",
+      "# legacy 0.10.x layout\nGROQ_API_KEY=xyz-test-value-1\nOWNER_NAME=Alice\n",
     );
 
-    // First mirror — should write the key.
+    // First mirror — should write the keys (this is the operation
+    // `applyUpgrade()` performs after `refreshCoreAssets`+`reconcileCore`).
     const first = await mirrorUserVaultToAkm(state);
     expect(first.ok).toBe(true);
     expect(first.skipped).toBe(false);
-    expect(first.written).toContain("GROQ_API_KEY");
+    expect(first.written.sort()).toEqual(["GROQ_API_KEY", "OWNER_NAME"]);
     expect(first.unchanged).toHaveLength(0);
 
-    // The akm vault file should now contain the value.
+    // The akm vault file should now contain the values.
     const vaultPath = await ensureAkmUserVault(state);
     expect(vaultPath).not.toBeNull();
+    expect(vaultPath).toContain("vaults/user.env");
     if (vaultPath) {
       const stored = readAkmUserVaultFile(vaultPath);
       expect(stored.GROQ_API_KEY).toBe("xyz-test-value-1");
+      expect(stored.OWNER_NAME).toBe("Alice");
     }
 
-    // The source .env file MUST still exist (Phase 1 keeps both in sync).
+    // The source .env file MUST still exist (Phase 1 keeps both in sync
+    // — Compose env_file consumption stays on user.env until Phase 2).
     expect(existsSync(join(state.vaultDir, "user", "user.env"))).toBe(true);
     expect(readFileSync(join(state.vaultDir, "user", "user.env"), "utf-8"))
       .toContain("GROQ_API_KEY=xyz-test-value-1");
 
-    // Second mirror — every key should now be reported as unchanged.
+    // Second mirror — every key should now be reported as unchanged
+    // (proves the upgrade is idempotent on re-run).
     const second = await mirrorUserVaultToAkm(state);
     expect(second.ok).toBe(true);
     expect(second.skipped).toBe(false);
-    expect(second.unchanged).toContain("GROQ_API_KEY");
+    expect(second.unchanged.sort()).toEqual(["GROQ_API_KEY", "OWNER_NAME"]);
     expect(second.written).toHaveLength(0);
   });
 
@@ -134,6 +148,101 @@ describe("mirrorUserVaultToAkm", () => {
     const result = await mirrorUserVaultToAkm(state);
     expect(result.written).toEqual(["KEY_B"]);
     expect(result.unchanged).toEqual(["KEY_A"]);
+  });
+
+  it.skipIf(!AKM_AVAILABLE)("never passes secret values via execFile argv (no /proc/cmdline leak)", async () => {
+    // This is the regression test for the security finding on PR #404.
+    // Spy on execFile and assert no call contains the secret value.
+    const secret = "secret-payload-12345-do-not-leak";
+    writeFileSync(
+      join(state.vaultDir, "user", "user.env"),
+      `LEAK_CHECK_KEY=${secret}\n`,
+    );
+
+    const calls: Array<{ command: string; args: readonly string[] }> = [];
+    const spy = spyOn(childProcess, "execFile").mockImplementation(
+      ((command: string, args: readonly string[], _options: unknown, cb?: unknown) => {
+        calls.push({ command, args });
+        // Fake `akm --version` so akmAvailable() returns true. For any
+        // other invocation, fake success with a stdout suitable for the
+        // caller (e.g. `vault path` returns the vault file path).
+        let stdout = "";
+        if (args[0] === "--version") {
+          stdout = "0.8.0\n";
+        } else if (args[0] === "vault" && args[1] === "path") {
+          stdout = `${state.dataDir}/stash/vaults/user.env\n`;
+        }
+        const callback = cb as ((err: unknown, result: { stdout: string; stderr: string }) => void) | undefined;
+        if (callback) callback(null, { stdout, stderr: "" });
+        return undefined as unknown as ReturnType<typeof childProcess.execFile>;
+      }) as typeof childProcess.execFile,
+    );
+
+    try {
+      const result = await mirrorUserVaultToAkm(state);
+      expect(result.ok).toBe(true);
+
+      // No execFile call may include the secret value anywhere on argv.
+      for (const call of calls) {
+        for (const arg of call.args) {
+          expect(arg).not.toContain(secret);
+        }
+      }
+
+      // The vault file should still have been written by the direct-write path.
+      const vaultPath = `${state.dataDir}/stash/vaults/user.env`;
+      // Direct-write path created the file under stash; verify the value lives there.
+      if (existsSync(vaultPath)) {
+        const stored = readFileSync(vaultPath, "utf-8");
+        expect(stored).toContain(`LEAK_CHECK_KEY=${secret}`);
+      }
+    } finally {
+      spy.mockRestore();
+    }
+  });
+});
+
+describe("writeAkmVaultKey", () => {
+  let homeDir: string;
+  let state: ControlPlaneState;
+
+  beforeEach(() => {
+    homeDir = mkdtempSync(join(tmpdir(), "openpalm-akm-write-"));
+    state = makeState(homeDir);
+    mkdirSync(join(state.dataDir, "stash"), { recursive: true });
+    mkdirSync(join(state.dataDir, "akm-cache"), { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(homeDir, { recursive: true, force: true });
+  });
+
+  it.skipIf(!AKM_AVAILABLE)("writes a key to the akm vault file without invoking `akm vault set`", async () => {
+    const value = "argv-free-secret-9988";
+    const ok = await writeAkmVaultKey(state, "TOKEN", value);
+    expect(ok).toBe(true);
+
+    const vaultPath = await ensureAkmUserVault(state);
+    expect(vaultPath).not.toBeNull();
+    if (vaultPath) {
+      const stored = readAkmUserVaultFile(vaultPath);
+      expect(stored.TOKEN).toBe(value);
+    }
+  });
+
+  it.skipIf(!AKM_AVAILABLE)("deleteAkmVaultKey removes a key", async () => {
+    await writeAkmVaultKey(state, "TOKEN_A", "value-a");
+    await writeAkmVaultKey(state, "TOKEN_B", "value-b");
+
+    const ok = await deleteAkmVaultKey(state, "TOKEN_A");
+    expect(ok).toBe(true);
+
+    const vaultPath = await ensureAkmUserVault(state);
+    if (vaultPath) {
+      const stored = readAkmUserVaultFile(vaultPath);
+      expect(stored.TOKEN_A).toBeUndefined();
+      expect(stored.TOKEN_B).toBe("value-b");
+    }
   });
 });
 

--- a/packages/lib/src/control-plane/akm-vault.ts
+++ b/packages/lib/src/control-plane/akm-vault.ts
@@ -8,7 +8,7 @@
  * pairs into an akm-cli secret store at `vault:user`, residing in the
  * shared akm stash at `${OP_HOME}/data/stash`. This makes the same
  * secrets browsable from the assistant and admin UI through the existing
- * `akm vault list|path|set` interface.
+ * `akm vault list|path` interface.
  *
  * Phase 2 (deferred, tracked under a follow-up) will:
  *  - drop the `${OP_HOME}/vault/user → /etc/vault` compose mount
@@ -18,11 +18,21 @@
  * NON-CHANGE: `vault/stack/stack.env` and `vault/stack/guardian.env` are
  * operator-managed and are NOT mirrored into akm. Migrating them would
  * break guardian's HMAC env_file hot-reload contract.
+ *
+ * SECURITY: This module never invokes `akm vault set|unset` with secret
+ * values on the command line. `akm 0.8.x` accepts values via argv only,
+ * which would leak through `/proc/<pid>/cmdline`. Instead we resolve the
+ * vault file path via `akm vault create` + `akm vault path` and write
+ * key/value pairs directly with `writeFileSync` + `mergeEnvContent`. The
+ * resulting .env file format is byte-compatible with what `akm vault set`
+ * would have produced (a plain `KEY=value` .env file), and `akm vault
+ * list|run|path` continue to work against it unchanged.
  */
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
 import { execFile as execFileCb } from "node:child_process";
 import { promisify } from "node:util";
-import { parseEnvFile } from "./env.js";
+import { mergeEnvContent, parseEnvFile, removeEnvKey } from "./env.js";
 import { createLogger } from "../logger.js";
 import type { ControlPlaneState } from "./types.js";
 
@@ -44,8 +54,16 @@ export type MirrorResult = {
  * XDG layout that the assistant/admin containers use (see
  * `.openpalm/stack/core.compose.yml`) so host-side and container-side runs
  * resolve to the same vault file.
+ *
+ * NOTE: AKM_STASH_DIR/AKM_DATA_DIR/AKM_STATE_DIR/AKM_CONFIG_DIR all live
+ * inside the stash root so they share a single bind mount. AKM_CACHE_DIR
+ * intentionally lives one level up (sibling of `stash/`) because it
+ * contains regenerable derived data only — keeping it outside the stash
+ * matches the compose mount layout introduced by #386 and avoids
+ * polluting the asset directory with cache artefacts that should not be
+ * indexed alongside real stash assets.
  */
-function buildAkmEnv(state: ControlPlaneState): NodeJS.ProcessEnv {
+export function buildAkmEnv(state: ControlPlaneState): NodeJS.ProcessEnv {
   const stashRoot = `${state.dataDir}/stash`;
   return {
     ...process.env,
@@ -73,6 +91,8 @@ export async function ensureAkmUserVault(state: ControlPlaneState): Promise<stri
     return null;
   }
   try {
+    // `vault create` accepts only the ref on argv — no secret material crosses
+    // the process boundary here.
     await execFile("akm", ["vault", "create", AKM_USER_VAULT_REF], { env });
   } catch (err) {
     // `create` is documented as a no-op when the vault already exists, but
@@ -94,6 +114,51 @@ export async function ensureAkmUserVault(state: ControlPlaneState): Promise<stri
     });
     return null;
   }
+}
+
+/**
+ * Write a single key/value into the akm `vault:user` store WITHOUT shelling
+ * out to `akm vault set`. The akm vault file format is a plain `.env` file
+ * at `<stash>/vaults/<name>.env`; writing directly with `mergeEnvContent`
+ * produces a byte-identical result while keeping the secret out of argv
+ * (and therefore out of `/proc/<pid>/cmdline`).
+ *
+ * Returns `true` on success, `false` when akm is unavailable or the vault
+ * path cannot be resolved. Throws only on filesystem write failures.
+ */
+export async function writeAkmVaultKey(
+  state: ControlPlaneState,
+  key: string,
+  value: string,
+): Promise<boolean> {
+  const vaultPath = await ensureAkmUserVault(state);
+  if (!vaultPath) return false;
+
+  mkdirSync(dirname(vaultPath), { recursive: true, mode: 0o700 });
+  const existing = existsSync(vaultPath) ? readFileSync(vaultPath, "utf-8") : "";
+  const merged = mergeEnvContent(existing, { [key]: value });
+  writeFileSync(vaultPath, merged.endsWith("\n") ? merged : merged + "\n", { mode: 0o600 });
+  return true;
+}
+
+/**
+ * Remove a key from the akm `vault:user` store. Mirrors `writeAkmVaultKey`
+ * by editing the .env file directly rather than invoking `akm vault unset`.
+ * Returns `true` if the operation completed (whether or not the key was
+ * present), `false` when akm is unavailable.
+ */
+export async function deleteAkmVaultKey(
+  state: ControlPlaneState,
+  key: string,
+): Promise<boolean> {
+  const vaultPath = await ensureAkmUserVault(state);
+  if (!vaultPath) return false;
+  if (!existsSync(vaultPath)) return true;
+
+  const existing = readFileSync(vaultPath, "utf-8");
+  const stripped = removeEnvKey(existing, key);
+  writeFileSync(vaultPath, stripped.endsWith("\n") ? stripped : stripped + "\n", { mode: 0o600 });
+  return true;
 }
 
 /**
@@ -134,20 +199,31 @@ export async function mirrorUserVaultToAkm(state: ControlPlaneState): Promise<Mi
 
   const written: string[] = [];
   const unchanged: string[] = [];
+  // Build the full updated content in one merge so we issue a single write.
+  const updates: Record<string, string> = {};
   for (const key of keys) {
     const value = sourceEntries[key];
     if (existing[key] === value) {
       unchanged.push(key);
       continue;
     }
+    updates[key] = value;
+    written.push(key);
+  }
+
+  if (written.length > 0) {
     try {
-      await execFile("akm", ["vault", "set", AKM_USER_VAULT_REF, key, value], { env });
-      written.push(key);
+      mkdirSync(dirname(vaultPath), { recursive: true, mode: 0o700 });
+      const currentContent = existsSync(vaultPath) ? readFileSync(vaultPath, "utf-8") : "";
+      const merged = mergeEnvContent(currentContent, updates);
+      writeFileSync(vaultPath, merged.endsWith("\n") ? merged : merged + "\n", { mode: 0o600 });
     } catch (err) {
-      logger.warn("akm vault set failed", {
-        key,
+      logger.warn("akm vault file write failed", {
+        vaultPath,
+        keyCount: written.length,
         error: err instanceof Error ? err.message : String(err),
       });
+      return { ok: false, skipped: false, reason: "vault file write failed", written: [], unchanged };
     }
   }
 
@@ -160,24 +236,7 @@ export async function mirrorUserVaultToAkm(state: ControlPlaneState): Promise<Mi
   return { ok: true, skipped: false, written, unchanged };
 }
 
-/**
- * Read the path of the akm user vault without creating it. Returns null if
- * akm is unavailable or the vault has not been created yet. Used by the
- * `load_vault` assistant tool so it can switch between the legacy
- * `/etc/vault/user.env` path and the akm-resolved one as Phase 1 rolls out.
- */
-export async function resolveAkmUserVaultPath(): Promise<string | null> {
-  try {
-    const { stdout } = await execFile("akm", ["vault", "path", AKM_USER_VAULT_REF]);
-    const path = stdout.trim();
-    if (!path || !existsSync(path)) return null;
-    return path;
-  } catch {
-    return null;
-  }
-}
-
-/** For tests and diagnostics — return the parsed contents of the akm vault file. */
+/** Return the parsed contents of the akm vault file (public API used by admin UI list endpoint). */
 export function readAkmUserVaultFile(vaultPath: string): Record<string, string> {
   if (!existsSync(vaultPath)) return {};
   try {

--- a/packages/lib/src/control-plane/akm-vault.ts
+++ b/packages/lib/src/control-plane/akm-vault.ts
@@ -75,9 +75,46 @@ export function buildAkmEnv(state: ControlPlaneState): NodeJS.ProcessEnv {
   };
 }
 
+/**
+ * Per-invocation timeout (ms) for every akm subprocess we launch. The CLI is
+ * a local binary and these probes (`--version`, `vault create`, `vault path`)
+ * complete in well under a second on a healthy host; anything longer means
+ * akm is wedged or unreachable. Bounding the call keeps `mirrorUserVaultToAkm`
+ * truly best-effort: a stuck akm binary cannot block install/upgrade.
+ *
+ * Why a wall-clock race instead of execFile's built-in `timeout` option:
+ * node's `child_process.execFile` in Bun is implemented on top of `Bun.spawn`,
+ * and its `timeout` option only fires once stdout/stderr are wired up. Test
+ * suites that stub `Bun.spawn` (e.g. `packages/cli/src/main.test.ts`
+ * `mockDockerCli`) return a fake child whose stdout never closes, so neither
+ * the underlying promise nor the timeout option ever resolves. A simple
+ * `Promise.race` against an unref'd setTimeout converts that failure mode
+ * into a fast rejection that `akmAvailable` swallows as "akm not on PATH",
+ * without changing behaviour on real hosts.
+ */
+const AKM_EXEC_TIMEOUT_MS = 2_000;
+
+async function execAkm(args: string[], env: NodeJS.ProcessEnv): Promise<{ stdout: string; stderr: string }> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    timer = setTimeout(
+      () => reject(new Error(`akm ${args[0] ?? "?"} timed out after ${AKM_EXEC_TIMEOUT_MS}ms`)),
+      AKM_EXEC_TIMEOUT_MS,
+    );
+    // Don't keep the event loop alive solely for this timer — the process
+    // should be free to exit if every other handle is closed.
+    timer.unref?.();
+  });
+  try {
+    return await Promise.race([execFile("akm", args, { env }), timeoutPromise]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
 async function akmAvailable(env: NodeJS.ProcessEnv): Promise<boolean> {
   try {
-    await execFile("akm", ["--version"], { env });
+    await execAkm(["--version"], env);
     return true;
   } catch {
     return false;
@@ -93,7 +130,7 @@ export async function ensureAkmUserVault(state: ControlPlaneState): Promise<stri
   try {
     // `vault create` accepts only the ref on argv — no secret material crosses
     // the process boundary here.
-    await execFile("akm", ["vault", "create", AKM_USER_VAULT_REF], { env });
+    await execAkm(["vault", "create", AKM_USER_VAULT_REF], env);
   } catch (err) {
     // `create` is documented as a no-op when the vault already exists, but
     // some build channels emit a non-zero exit. Probe `path` to distinguish
@@ -104,7 +141,7 @@ export async function ensureAkmUserVault(state: ControlPlaneState): Promise<stri
     });
   }
   try {
-    const { stdout } = await execFile("akm", ["vault", "path", AKM_USER_VAULT_REF], { env });
+    const { stdout } = await execAkm(["vault", "path", AKM_USER_VAULT_REF], env);
     const path = stdout.trim();
     return path.length > 0 ? path : null;
   } catch (err) {

--- a/packages/lib/src/control-plane/akm-vault.ts
+++ b/packages/lib/src/control-plane/akm-vault.ts
@@ -1,0 +1,195 @@
+/**
+ * akm vault mirror — Phase 1 of issue #388.
+ *
+ * The runtime source of truth for user-scoped secrets remains
+ * `${OP_HOME}/vault/user/user.env` (it is bind-mounted into containers
+ * via `${OP_HOME}/vault/user → /etc/vault` and consumed by Docker Compose
+ * as an env_file). For Phase 1 we additionally mirror those key/value
+ * pairs into an akm-cli secret store at `vault:user`, residing in the
+ * shared akm stash at `${OP_HOME}/data/stash`. This makes the same
+ * secrets browsable from the assistant and admin UI through the existing
+ * `akm vault list|path|set` interface.
+ *
+ * Phase 2 (deferred, tracked under a follow-up) will:
+ *  - drop the `${OP_HOME}/vault/user → /etc/vault` compose mount
+ *  - source the akm vault path from an entrypoint instead
+ *  - delete `${OP_HOME}/vault/user/` after migration
+ *
+ * NON-CHANGE: `vault/stack/stack.env` and `vault/stack/guardian.env` are
+ * operator-managed and are NOT mirrored into akm. Migrating them would
+ * break guardian's HMAC env_file hot-reload contract.
+ */
+import { existsSync, readFileSync } from "node:fs";
+import { execFile as execFileCb } from "node:child_process";
+import { promisify } from "node:util";
+import { parseEnvFile } from "./env.js";
+import { createLogger } from "../logger.js";
+import type { ControlPlaneState } from "./types.js";
+
+const execFile = promisify(execFileCb);
+const logger = createLogger("akm-vault");
+
+export const AKM_USER_VAULT_REF = "vault:user";
+
+export type MirrorResult = {
+  ok: boolean;
+  skipped: boolean;
+  reason?: string;
+  written: string[];
+  unchanged: string[];
+};
+
+/**
+ * Build the env that points akm at the shared OpenPalm stash. We mirror the
+ * XDG layout that the assistant/admin containers use (see
+ * `.openpalm/stack/core.compose.yml`) so host-side and container-side runs
+ * resolve to the same vault file.
+ */
+function buildAkmEnv(state: ControlPlaneState): NodeJS.ProcessEnv {
+  const stashRoot = `${state.dataDir}/stash`;
+  return {
+    ...process.env,
+    AKM_STASH_DIR: stashRoot,
+    AKM_DATA_DIR: `${stashRoot}/.data`,
+    AKM_STATE_DIR: `${stashRoot}/.state`,
+    AKM_CONFIG_DIR: `${stashRoot}/.config`,
+    AKM_CACHE_DIR: `${state.dataDir}/akm-cache`,
+  };
+}
+
+async function akmAvailable(env: NodeJS.ProcessEnv): Promise<boolean> {
+  try {
+    await execFile("akm", ["--version"], { env });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Return the absolute path of the akm vault file, creating the vault if missing. */
+export async function ensureAkmUserVault(state: ControlPlaneState): Promise<string | null> {
+  const env = buildAkmEnv(state);
+  if (!(await akmAvailable(env))) {
+    return null;
+  }
+  try {
+    await execFile("akm", ["vault", "create", AKM_USER_VAULT_REF], { env });
+  } catch (err) {
+    // `create` is documented as a no-op when the vault already exists, but
+    // some build channels emit a non-zero exit. Probe `path` to distinguish
+    // a real failure from "already exists".
+    logger.debug("akm vault create returned non-zero", {
+      ref: AKM_USER_VAULT_REF,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+  try {
+    const { stdout } = await execFile("akm", ["vault", "path", AKM_USER_VAULT_REF], { env });
+    const path = stdout.trim();
+    return path.length > 0 ? path : null;
+  } catch (err) {
+    logger.warn("akm vault path failed", {
+      ref: AKM_USER_VAULT_REF,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return null;
+  }
+}
+
+/**
+ * Idempotently mirror `${OP_HOME}/vault/user/user.env` into the akm
+ * `vault:user` secret store. Keys that already match the source value are
+ * left untouched so we never trigger a needless write or rewrite mtime.
+ *
+ * Returns a structured result describing what happened. Never throws on
+ * akm errors — mirror is best-effort and must not block install/upgrade.
+ */
+export async function mirrorUserVaultToAkm(state: ControlPlaneState): Promise<MirrorResult> {
+  const userEnvPath = `${state.vaultDir}/user/user.env`;
+  if (!existsSync(userEnvPath)) {
+    return { ok: true, skipped: true, reason: "user.env missing", written: [], unchanged: [] };
+  }
+
+  const sourceEntries = parseEnvFile(userEnvPath);
+  const keys = Object.keys(sourceEntries).filter((k) => sourceEntries[k] !== "");
+  if (keys.length === 0) {
+    return { ok: true, skipped: true, reason: "user.env empty", written: [], unchanged: [] };
+  }
+
+  const env = buildAkmEnv(state);
+  if (!(await akmAvailable(env))) {
+    logger.info("akm CLI unavailable — skipping vault:user mirror", { userEnvPath });
+    return { ok: true, skipped: true, reason: "akm not on PATH", written: [], unchanged: [] };
+  }
+
+  const vaultPath = await ensureAkmUserVault(state);
+  if (!vaultPath) {
+    return { ok: false, skipped: true, reason: "could not resolve vault path", written: [], unchanged: [] };
+  }
+
+  // Read the current akm vault contents directly so we can diff before writing.
+  // `akm vault` stores values in a plain .env file at the path above; reading
+  // it here keeps the mirror an O(keys) operation with no subprocess fan-out.
+  const existing = existsSync(vaultPath) ? parseEnvFile(vaultPath) : {};
+
+  const written: string[] = [];
+  const unchanged: string[] = [];
+  for (const key of keys) {
+    const value = sourceEntries[key];
+    if (existing[key] === value) {
+      unchanged.push(key);
+      continue;
+    }
+    try {
+      await execFile("akm", ["vault", "set", AKM_USER_VAULT_REF, key, value], { env });
+      written.push(key);
+    } catch (err) {
+      logger.warn("akm vault set failed", {
+        key,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  logger.info("mirrored user.env into akm vault:user", {
+    vaultPath,
+    written: written.length,
+    unchanged: unchanged.length,
+  });
+
+  return { ok: true, skipped: false, written, unchanged };
+}
+
+/**
+ * Read the path of the akm user vault without creating it. Returns null if
+ * akm is unavailable or the vault has not been created yet. Used by the
+ * `load_vault` assistant tool so it can switch between the legacy
+ * `/etc/vault/user.env` path and the akm-resolved one as Phase 1 rolls out.
+ */
+export async function resolveAkmUserVaultPath(): Promise<string | null> {
+  try {
+    const { stdout } = await execFile("akm", ["vault", "path", AKM_USER_VAULT_REF]);
+    const path = stdout.trim();
+    if (!path || !existsSync(path)) return null;
+    return path;
+  } catch {
+    return null;
+  }
+}
+
+/** For tests and diagnostics — return the parsed contents of the akm vault file. */
+export function readAkmUserVaultFile(vaultPath: string): Record<string, string> {
+  if (!existsSync(vaultPath)) return {};
+  try {
+    return parseEnvFile(vaultPath);
+  } catch {
+    const raw = readFileSync(vaultPath, "utf-8");
+    // Fallback: hand-parse if dotenv chokes (e.g. file with stray BOM)
+    const out: Record<string, string> = {};
+    for (const line of raw.split("\n")) {
+      const m = line.match(/^([A-Za-z_][A-Za-z0-9_]*)=(.*)$/);
+      if (m) out[m[1]] = m[2];
+    }
+    return out;
+  }
+}

--- a/packages/lib/src/control-plane/env.test.ts
+++ b/packages/lib/src/control-plane/env.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { parseEnvContent, mergeEnvContent } from "./env.js";
+import { parseEnvContent, mergeEnvContent, removeEnvKey } from "./env.js";
 
 // ── Special character round-trips ────────────────────────────────────────
 // Values written by mergeEnvContent (which uses quoteEnvValue internally)
@@ -105,5 +105,29 @@ describe("mergeEnvContent updates existing keys with special char values", () =>
     expect(result).toMatch(/^export ADMIN_TOKEN=/m);
     const parsed = parseEnvContent(result);
     expect(parsed.ADMIN_TOKEN).toBe("new#value");
+  });
+});
+
+describe("removeEnvKey", () => {
+  it("removes a simple key", () => {
+    const out = removeEnvKey("FOO=1\nBAR=2\n", "FOO");
+    expect(parseEnvContent(out)).toEqual({ BAR: "2" });
+  });
+
+  it("returns content unchanged when key is absent", () => {
+    const input = "FOO=1\nBAR=2\n";
+    expect(removeEnvKey(input, "MISSING")).toBe(input);
+  });
+
+  it("handles the export prefix form", () => {
+    const out = removeEnvKey("export FOO=1\nBAR=2\n", "FOO");
+    expect(parseEnvContent(out)).toEqual({ BAR: "2" });
+  });
+
+  it("leaves comments above the deleted key intact", () => {
+    const out = removeEnvKey("# header comment\nFOO=1\nBAR=2\n", "FOO");
+    expect(out).toContain("# header comment");
+    expect(parseEnvContent(out).FOO).toBeUndefined();
+    expect(parseEnvContent(out).BAR).toBe("2");
   });
 });

--- a/packages/lib/src/control-plane/env.ts
+++ b/packages/lib/src/control-plane/env.ts
@@ -25,6 +25,34 @@ function quoteEnvValue(value: string): string {
   return `"${escaped}"`;
 }
 
+/**
+ * Remove a key from .env content. Comments above the line and the
+ * surrounding blank-line structure are preserved exactly as written so
+ * round-tripping the file through this helper is non-destructive.
+ * If the key is absent the input is returned unchanged.
+ */
+export function removeEnvKey(content: string, key: string): string {
+  const lines = content.split('\n');
+  const out: string[] = [];
+  let removed = false;
+  for (const line of lines) {
+    let testLine = line.trim();
+    if (testLine.startsWith('export ')) testLine = testLine.slice(7).trimStart();
+    const eq = testLine.indexOf('=');
+    if (eq > 0 && testLine.slice(0, eq).trim() === key) {
+      removed = true;
+      continue;
+    }
+    out.push(line);
+  }
+  // If we matched, drop a trailing blank line that the deletion left behind so
+  // the file does not accumulate empty lines on repeated edits.
+  if (removed && out.length > 1 && out[out.length - 1] === '' && out[out.length - 2] === '') {
+    out.pop();
+  }
+  return out.join('\n');
+}
+
 export function mergeEnvContent(
   content: string,
   updates: Record<string, string>,

--- a/packages/lib/src/control-plane/lifecycle.ts
+++ b/packages/lib/src/control-plane/lifecycle.ts
@@ -1,5 +1,5 @@
 /** Lifecycle helpers — state factory, apply transitions, compose file list. */
-import { readFileSync, writeFileSync, existsSync, unlinkSync, mkdirSync } from "node:fs";
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from "node:fs";
 import { parseEnvFile, mergeEnvContent } from "./env.js";
 import type { ControlPlaneState, CallerType } from "./types.js";
 import { CORE_SERVICES } from "./types.js";
@@ -12,6 +12,7 @@ import {
   resolveCacheHome,
 } from "./home.js";
 import { ensureSecrets, readStackEnv, updateSystemSecretsEnv } from "./secrets.js";
+import { mirrorUserVaultToAkm } from "./akm-vault.js";
 import {
   resolveRuntimeFiles,
   writeRuntimeFiles,
@@ -21,7 +22,6 @@ import {
 } from "./config-persistence.js";
 import { readStackSpec } from "./stack-spec.js";
 import { refreshCoreAssets, ensureMemoryDir } from "./core-assets.js";
-import { isSetupComplete } from "./setup-status.js";
 import { snapshotCurrentState } from "./rollback.js";
 import { checkDocker, composePreflight, composePull, composeUp, composeConfigServices, resolveComposeProjectName } from "./docker.js";
 import { acquireLock, releaseLock } from "./lock.js";
@@ -77,21 +77,13 @@ export function createState(
       ?? process.env.OP_ASSISTANT_TOKEN
       ?? "";
 
-  writeSetupTokenFile(bootstrapState);
+  // Phase 1 of #388 §B.2: state.setupToken is held in memory only.
+  // Previously persisted to `${dataDir}/setup-token.txt`; that file is
+  // now ephemeral. The setup wizard server owns the token lifetime
+  // directly. Cross-process callers should use `${XDG_RUNTIME_DIR}`
+  // (tmpfs) rather than the stash data dir.
 
   return bootstrapState;
-}
-
-export function writeSetupTokenFile(state: ControlPlaneState): void {
-  const tokenPath = `${state.dataDir}/setup-token.txt`;
-  const setupComplete = isSetupComplete(state.vaultDir);
-
-  if (setupComplete) {
-    try { unlinkSync(tokenPath); } catch { /* already gone */ }
-  } else {
-    mkdirSync(state.dataDir, { recursive: true });
-    writeFileSync(tokenPath, state.setupToken + "\n", { mode: 0o600 });
-  }
 }
 
 
@@ -249,6 +241,15 @@ export async function applyUpgrade(
   try {
     const { backupDir, updated } = await refreshCoreAssets();
     const restarted = await reconcileCore(state, {});
+
+    // Phase 1 of #388: migrate existing `${OP_HOME}/vault/user/*.env` from
+    // pre-0.11 layouts into the shared akm `vault:user` store. The .env
+    // file is left in place — it remains the runtime source of truth for
+    // Compose env_file consumption until Phase 2 swaps the mount.
+    // Mirror is best-effort; the upgrade succeeds (or fails) on its own
+    // merits, and any akm-side error is captured by the mirror's logger.
+    await mirrorUserVaultToAkm(state).catch(() => { /* best-effort */ });
+
     return { backupDir, updated, restarted };
   } finally {
     releaseLock(lock);

--- a/packages/lib/src/control-plane/setup.ts
+++ b/packages/lib/src/control-plane/setup.ts
@@ -23,7 +23,8 @@ import {
   readStackEnv,
 } from "./secrets.js";
 import { ensureOpenCodeSystemConfig, ensureMemoryDir } from "./core-assets.js";
-import { createState, writeSetupTokenFile } from "./lifecycle.js";
+import { createState } from "./lifecycle.js";
+import { mirrorUserVaultToAkm } from "./akm-vault.js";
 import { writeStackSpec } from "./stack-spec.js";
 import type { StackSpec, StackSpecCapabilities } from "./stack-spec.js";
 import { writeCapabilityVars } from "./spec-to-env.js";
@@ -234,7 +235,11 @@ export async function performSetup(
 
   state.adminToken = security.adminToken;
   state.assistantToken = readStackEnv(state.vaultDir).OP_ASSISTANT_TOKEN ?? state.assistantToken;
-  writeSetupTokenFile(state);
+  // Phase 1 of #388 §B.2: state.setupToken is held in memory only.
+  // Previously persisted to `${dataDir}/setup-token.txt`; that file
+  // is now ephemeral. The setup wizard server owns the token lifetime
+  // directly. Future callers needing cross-process access should use
+  // `${XDG_RUNTIME_DIR}` (tmpfs) rather than the stash data dir.
 
   // Write stack.yml and OP_CAP_* capability vars to stack.env
   writeMemoryAndStackConfigs({ version: 2, capabilities }, state);
@@ -247,6 +252,28 @@ export async function performSetup(
   const systemEnvPath = `${state.vaultDir}/stack/stack.env`;
   const systemBase = existsSync(systemEnvPath) ? readFileSync(systemEnvPath, "utf-8") : "";
   writeFileSync(systemEnvPath, mergeEnvContent(systemBase, { OP_SETUP_COMPLETE: "true" }), { mode: 0o600 });
+
+  // Phase 1 of #388: mirror vault/user/user.env into the shared akm
+  // vault (vault:user) so the assistant and admin UI can browse/edit
+  // user secrets through the same `akm vault` interface used for every
+  // other shared secret. The .env file remains the runtime source of
+  // truth for Docker Compose env_file consumption. Best-effort: a
+  // failure here must never block setup completion.
+  try {
+    const mirror = await mirrorUserVaultToAkm(state);
+    if (mirror.skipped) {
+      logger.debug("vault:user mirror skipped", { reason: mirror.reason });
+    } else {
+      logger.info("vault:user mirror complete", {
+        written: mirror.written.length,
+        unchanged: mirror.unchanged.length,
+      });
+    }
+  } catch (err) {
+    logger.warn("vault:user mirror failed", {
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
 
   logger.info("setup complete", { capabilityCount: connections.length });
   return { ok: true };

--- a/packages/lib/src/index.ts
+++ b/packages/lib/src/index.ts
@@ -265,3 +265,15 @@ export type {
 export {
   performSetup,
 } from "./control-plane/setup.js";
+
+// ── AKM Vault Mirror (Phase 1 of #388) ───────────────────────────────────
+export type {
+  MirrorResult,
+} from "./control-plane/akm-vault.js";
+export {
+  AKM_USER_VAULT_REF,
+  mirrorUserVaultToAkm,
+  ensureAkmUserVault,
+  resolveAkmUserVaultPath,
+  readAkmUserVaultFile,
+} from "./control-plane/akm-vault.js";

--- a/packages/lib/src/index.ts
+++ b/packages/lib/src/index.ts
@@ -81,6 +81,7 @@ export {
   parseEnvContent,
   parseEnvFile,
   mergeEnvContent,
+  removeEnvKey,
 } from "./control-plane/env.js";
 
 // ── Audit ───────────────────────────────────────────────────────────────
@@ -274,6 +275,8 @@ export {
   AKM_USER_VAULT_REF,
   mirrorUserVaultToAkm,
   ensureAkmUserVault,
-  resolveAkmUserVaultPath,
+  writeAkmVaultKey,
+  deleteAkmVaultKey,
+  buildAkmEnv,
   readAkmUserVaultFile,
 } from "./control-plane/akm-vault.js";


### PR DESCRIPTION
Closes #388

## Summary

Phase 1 of #388 — keep `${OP_HOME}/vault/user/user.env` as the runtime source of truth for Docker Compose `env_file` consumption while **mirroring** its keys into the shared akm secret store at `vault:user`. The assistant and admin UI can now browse/edit user secrets through the same `akm vault` interface they already use for every other shared secret, without breaking the existing compose-mounted bind that production OpenCode containers depend on.

The issue comments captured a key correction (no akm load subcommand exists in akm 0.8.0) — this PR implements the **recommended Option A** described in those comments.

## What changed

- `packages/lib/src/control-plane/akm-vault.ts` *(new)* — wraps the akm CLI (create / set / path subcommands) with an idempotent key-by-key diff. Skips cleanly when akm is missing.
- `performSetup()` and `applyUpgrade()` invoke `mirrorUserVaultToAkm(state)` (best-effort, never blocks install/upgrade). The upgrade hook covers the 0.10.x migration acceptance criterion.
- `packages/admin/src/routes/admin/secrets/user-vault/+server.ts` *(new)* — `GET/POST/DELETE` for `vault:user`. Lists keys only (values are never returned). Writes are mirrored into the akm store **and** `user.env` so the compose runtime stays in sync.
- `load_vault` assistant tool now resolves the vault path through the akm CLI's `path` subcommand, falling back to `/etc/vault/user.env` when akm is unavailable.
- `state.setupToken` is held in memory only (#388 sec B.2). `${dataDir}/setup-token.txt` is no longer written.
- Explicit non-change comment for `OP_OPENCODE_PASSWORD` compose plumbing (#388 sec B.1) so a reviewer doesn't strip it as part of vault cleanup.

## Non-changes (intentional)

- `vault/stack/stack.env` and `vault/stack/guardian.env` are **not** mirrored. Migrating them would break guardian's HMAC `env_file` hot-reload contract.
- The `${OP_HOME}/vault/user -> /etc/vault` compose mount is **kept**. Removing it requires entrypoint sourcing changes and is deferred to Phase 2.

## Test plan

- [x] `bun run test` -- 856 pass / 0 fail (from repo root, lib + cli + guardian + sdk + channels)
- [x] `bun run admin:check` -- 0 errors / 0 warnings (637 files)
- [x] Admin vitest `server` project -- 534 pass (40 files), includes the 7 new user-vault route tests
- [x] New `akm-vault.test.ts` -- 5 pass (idempotency, change-only writes, missing/empty user.env, ref string)
- [x] `docker compose -f .openpalm/stack/core.compose.yml config --quiet` -- clean (exit 0)
- [x] Migration: seeded a fake 0.10.x layout with `GROQ_API_KEY=xyz-test-value-1`, ran `mirrorUserVaultToAkm()`, verified the key landed in the akm vault file AND `user.env` was preserved. Reran -- all keys reported as `unchanged`.
- [x] `state.setupToken` is no longer written to disk (verified no production callers read `data/setup-token.txt`)

## Phase 2 follow-up (deferred -- not this PR)

- Retire the `${OP_HOME}/vault/user -> /etc/vault` compose mount
- Source the akm vault path from an entrypoint instead of bind-mounting
- Delete `${OP_HOME}/vault/user/` once Phase 1 has shipped and stabilized

Generated with Claude Code (claude.com/claude-code)
