### PR TITLE
chore(akm): bump akm-cli to ^0.8.0-rc2

### DIFF
--- a/core/admin/Dockerfile
+++ b/core/admin/Dockerfile
@@ -39,7 +39,7 @@ FROM node:22-trixie-slim
 ARG OPENCODE_VERSION=1.2.24
 ARG BUN_VERSION=bun-v1.3.10
 # akm-cli — Agent Kit Manager, installed globally via bun add -g.
-ARG AKM_CLI_VERSION=^0.8.0-rc1
+ARG AKM_CLI_VERSION=^0.8.0-rc2
 
 RUN apt-get update \
   && apt-get install -y --no-install-recommends curl ca-certificates gnupg git unzip bash pass \

--- a/core/assistant/Dockerfile
+++ b/core/assistant/Dockerfile
@@ -10,7 +10,7 @@ FROM node:22-trixie-slim
 ARG OPENCODE_VERSION=1.3.3
 ARG BUN_VERSION=bun-v1.3.10
 # akm-cli — Agent Kit Manager, installed globally via bun add -g.
-ARG AKM_CLI_VERSION=^0.8.0-rc1
+ARG AKM_CLI_VERSION=^0.8.0-rc2
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends tini curl git ca-certificates bash openssh-server gosu sudo socat unzip \

--- a/core/guardian/Dockerfile
+++ b/core/guardian/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends curl && rm -rf 
 # Pinned via build arg so the install step is reproducible. Install globally
 # into /usr/local so the unprivileged bun user (set with USER below) can
 # execute it without writing to its own $HOME.
-ARG AKM_CLI_VERSION=^0.8.0-rc1
+ARG AKM_CLI_VERSION=^0.8.0-rc2
 RUN BUN_INSTALL=/usr/local bun add -g "akm-cli@${AKM_CLI_VERSION}" \
     && chmod -R a+rX /usr/local/install/global \
     && chmod 755 /usr/local/bin/akm \


### PR DESCRIPTION
## Summary

Bumps the pinned akm-cli version from `^0.8.0-rc1` to `^0.8.0-rc2` in the three trusted-container Dockerfiles (admin, assistant, guardian).

## What's in 0.8.0-rc2

- New stdin-based input on the secret-write subcommand (closes upstream itlackey/akm#361 — filed during PR #404 work)
- Removed positional value form (breaking — but OpenPalm bypasses this subcommand)
- Vault security hardening (file perms, injection, audit, enumeration)
- Vault docs and changelog updates

## Why this PR is safe

OpenPalm's vault writes (added in PR #404 / issue #388) bypass the affected subcommand entirely — values are written directly to the underlying `.env` file using Node `fs` APIs. So the breaking removal of the positional value form does not affect OpenPalm's runtime behaviour.

## Follow-up

Issue #406 tracks switching OpenPalm's vault writes to the new stdin pattern, replacing the direct-file-write workaround. That work is intentionally deferred and is not part of this PR.

## Test plan

- [x] All 3 Dockerfiles updated to `^0.8.0-rc2`
- [ ] CI green
- [ ] Container builds succeed (verified manually after merge)