### PR TITLE
docs: clean up drift after Epic #382 + #391 (#409)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@
 
 OpenPalm is a self-hosted personal AI platform built on Docker Compose and OpenCode. It manages a stack of containers orchestrated by the host CLI or an optional admin web UI.
 
-Four core containers: **guardian** (HMAC ingress), **assistant** (OpenCode runtime), **memory** (vector-backed agentic memory), **scheduler** (cron/automations). Channels (chat, API, Discord, Slack, voice) and services (Ollama, etc.) are added as addon compose overlays.
+Two core containers: **guardian** (HMAC ingress) and **assistant** (OpenCode runtime — also hosts the scheduler co-process and uses the akm CLI for memory/skills/lessons via a shared akm stash). Channels (chat, API, Discord, Slack, voice) and services (Ollama, etc.) are added as addon compose overlays.
 
 Repo layout convention:
 - `packages/*` — app/package source workspaces
@@ -33,13 +33,12 @@ See [`docs/technical/core-principles.md`](docs/technical/core-principles.md) for
 - **CLI** (`packages/cli/`) — Host-side orchestrator. Manages Docker Compose directly. Serves setup wizard during install. Self-sufficient without admin.
 - **Admin** (`packages/admin/`) — SvelteKit app: optional operator web UI + API. Uses Docker socket via docker-socket-proxy. Behind `profiles: ["admin"]` compose profile.
 - **Guardian** (`core/guardian/`) — Bun HTTP server: HMAC verification, replay detection, rate limiting for all channel traffic.
-- **Assistant** (`core/assistant/`) — OpenCode runtime with tools/skills. No Docker socket. When admin is present, calls Admin API for stack operations.
-- **Memory** (`packages/memory/`, `core/memory/`) — Bun-based memory service with sqlite-vec. Provides vector-backed agentic memory.
-- **Scheduler** (`packages/scheduler/`) — Lightweight Bun sidecar: sole automation engine. Runs cron jobs (http, shell, assistant, api actions). Reads enabled automation files from `config/automations/`.
+- **Assistant** (`core/assistant/`) — OpenCode runtime with tools/skills. No Docker socket. When admin is present, calls Admin API for stack operations. Memory/skills/lessons are served by the akm CLI (akm-opencode plugin) via a shared akm stash bind-mounted from `~/.openpalm/data/stash/`.
+- **Scheduler** (`packages/scheduler/`) — Lightweight Bun co-process started inside the assistant container by `core/assistant/entrypoint.sh`. No network port. Runs cron jobs (http, shell, assistant, api actions) from `config/automations/`.
 - **Channel runtime** (`core/channel/`) — Unified `channel` image build and startup entrypoint.
-- **Channel adapters** (`packages/channel-chat/`, `packages/channel-api/`, `packages/channel-discord/`, `packages/channel-slack/`, `packages/channel-voice/`) — Translate external protocols into signed guardian messages.
+- **Channel adapters** (`packages/channel-api/`, `packages/channel-discord/`, `packages/channel-slack/`, `packages/channel-voice/`) — Translate external protocols into signed guardian messages.
 - **Channels SDK** (`packages/channels-sdk/`) — Shared SDK for channel adapters: signing, assistant client, base classes.
-- **Assistant-tools** (`packages/assistant-tools/`) — Memory tools and session hooks for the assistant. No admin dependency.
+- **Assistant-tools** (`packages/assistant-tools/`) — `load_vault` and `health-check` tools for the assistant. No admin dependency. Memory/knowledge access comes from the `akm-opencode` plugin.
 - **Admin-tools** (`packages/admin-tools/`) — Admin API tools for the assistant. Only loaded when admin is present.
 - **Stack** (`.openpalm/stack/`) — Repo-shipped Docker Compose foundation. Contains the core compose file only. Runtime enabled addons live under `~/.openpalm/stack/addons/`.
 
@@ -58,17 +57,15 @@ npm run check                                       # svelte-check + TypeScript
 # Guardian (Bun)
 cd core/guardian && bun install && bun run src/server.ts
 
-# Channel Chat (Bun)
-cd packages/channel-chat && bun install && bun run src/index.ts
-
 # Root shortcuts
 bun run admin:dev        # Runs admin dev from root
 bun run admin:build      # Builds admin from root
 bun run admin:check      # svelte-check + TypeScript for admin
 bun run guardian:dev     # Runs guardian server
-bun run channel:chat:dev    # Runs chat channel dev server
 bun run channel:api:dev     # Runs api channel dev server
 bun run channel:discord:dev # Runs discord channel dev server
+bun run channel:slack:dev   # Runs slack channel dev server
+bun run channel:voice:dev   # Runs voice channel dev server
 
 # Dev environment setup
 ./scripts/dev-setup.sh --seed-env       # Creates .dev/ dirs, seeds configs
@@ -164,7 +161,7 @@ Read these before making significant changes. They are the authoritative sources
 ### Language & Runtime
 
 - **TypeScript** everywhere (`"strict": true`, no `any` for untrusted data)
-- **Bun** for guardian, channels, memory, and scheduler; **Node/Vite** for admin (SvelteKit + `adapter-node`)
+- **Bun** for guardian, channels, and the scheduler co-process; **Node/Vite** for admin (SvelteKit + `adapter-node`)
 - All packages use `"type": "module"` (ES modules only)
 
 ### Imports
@@ -239,7 +236,7 @@ Full detail in [`docs/technical/core-principles.md`](docs/technical/core-princip
 - **Host CLI or admin is the orchestrator.** CLI manages Docker Compose directly on the host. Admin (optional) provides a web UI via docker-socket-proxy.
 - **Shared control-plane library (`@openpalm/lib`) is the single source of truth.** All portable control-plane logic lives in `packages/lib/`. CLI, admin, and scheduler all import from this package. Never duplicate control-plane logic in a consumer.
 - **Guardian-only ingress.** All channel traffic must enter through the guardian (HMAC, replay protection, rate limiting).
-- **Assistant isolation.** Assistant has no Docker socket. When admin is present, it calls the admin API. When admin is absent, only memory tools are available.
+- **Assistant isolation.** Assistant has no Docker socket. When admin is present, it calls the admin API. When admin is absent, only the akm-backed memory/knowledge tools are available.
 - **LAN-first by default.** Nothing is publicly exposed without explicit user opt-in.
 - **Add a channel** by installing from the registry or dropping an addon compose file into `stack/addons/<name>/` — no code changes.
 - **No shell interpolation.** Docker commands use `execFile` with argument arrays, never shell strings.
@@ -257,7 +254,7 @@ All state lives under `~/.openpalm/` (configurable via `OP_HOME`):
 | `vault/user/` | User | User-managed secrets: `user.env` (LLM keys, owner info) |
 | `vault/stack/` | Admin | System-managed secrets: `stack.env` (admin token, HMAC, paths) |
 | `stack/` | System | Live Docker Compose assembly: `core.compose.yml` + addon overlays |
-| `data/` | Services | Persistent data: assistant, admin, memory, guardian |
+| `data/` | Services | Persistent data: assistant, admin, guardian, shared akm `stash/` |
 | `logs/` | Services | Audit and debug logs |
 | `backups/` | System | Durable upgrade backup snapshots |
 | `~/.cache/openpalm/` | System | Ephemeral: rollback snapshots |
@@ -304,9 +301,9 @@ Before submitting any change:
 | `packages/scheduler/src/server.ts` | Scheduler sidecar entry point |
 | `core/guardian/src/server.ts` | HMAC-signed message guardian |
 | `packages/channels-sdk/src/logger.ts` | Shared logger (createLogger factory) |
-| `.openpalm/stack/core.compose.yml` | Core service definitions (4 services) |
+| `.openpalm/stack/core.compose.yml` | Core service definitions (assistant + guardian) |
 | `.openpalm/registry/` | Repo catalog for available addons and automations |
-| `packages/assistant-tools/AGENTS.md` | Assistant persona and operational guidelines |
-| `packages/assistant-tools/src/index.ts` | Memory tools plugin |
+| `packages/assistant-tools/AGENTS.md` | Contributor pointer for the assistant-tools package |
+| `packages/assistant-tools/src/index.ts` | Assistant tools plugin (`load_vault`, `health-check`) |
 | `packages/admin-tools/src/index.ts` | Admin tools plugin |
 | `.opencode/opencode.json` | OpenCode project configuration |

--- a/core/assistant/opencode/openpalm.md
+++ b/core/assistant/opencode/openpalm.md
@@ -1,21 +1,19 @@
 # Managing the OpenPalm Stack
 
-## Behavior Guidelines
+Stack management instructions for the assistant. See @system.md for the
+canonical memory, tool, and secret guidance.
+
+## Behavior
 
 - Always check current status before making changes.
-- Explain what you intend to do and why before performing destructive or impactful operations (stopping services, changing access scope, uninstalling).
-- If something fails, check the audit log and container status to diagnose.
-- Do not restart yourself (`assistant`) unless the user explicitly asks.
-- When the user asks about the system state, use your tools to get real-time data rather than guessing.
+- Explain destructive or impactful operations (stop, uninstall, access-scope change) before performing them.
+- On failure, check the audit log and container status before guessing.
+- Do not restart yourself (`assistant`) unless explicitly asked.
+- Use your tools for real-time state — do not guess.
 
-## Security Boundaries
+## Stack Boundaries
 
-- You cannot access the Docker socket directly. All Docker operations go through the admin API.
-- Your admin token is provided via environment variable. Do not expose it.
+- No direct Docker socket access — all Docker operations go through the admin API.
+- Your admin token comes from the environment; never expose it.
 - Permission escalation (setting permissions to "allow") is blocked by policy.
-- All your actions are audit-logged with your identity (`assistant`).
-- Never store secrets, tokens, or credentials in memory.
-
-## Additional Information
-
-- OpenPalm system details can be found in @system.md
+- All actions are audit-logged under the `assistant` identity.

--- a/docs/technical/core-principles.md
+++ b/docs/technical/core-principles.md
@@ -4,7 +4,7 @@
 
 The foundation of the OpenPalm stack is simply a set of conventions used to manage Docker compose overlay files, .env files, and configuration files related to specific services in the stack. That is it. That is what the entire stack is built upon.
 
-There are three core containers, the guardian, the assistant, and the memory. These containers vary in complexity but are designed to do one thing each. The guardian and the assistant are OpenCode servers, and the memory is the shared agentic memory server. Automation scheduling runs as a Bun co-process inside the assistant container (no separate service, no network port).
+There are two core containers, the guardian and the assistant. These containers are designed to do one thing each. Both are OpenCode-based services. The assistant uses the akm CLI (with a stash bind-mounted from the host) for persistent memory, skills, lessons, and knowledge — there is no separate memory service. Automation scheduling runs as a Bun co-process inside the assistant container (no separate service, no network port).
 
 The stack allows for three primary extension points.
 
@@ -42,13 +42,12 @@ For (9), OpenCode supports a custom config directory via `OPENCODE_CONFIG_DIR`; 
 - Admin provides:
   - Way to manage addons by copying the compose file to the stack if needed and providing an easy way to provide values or assign secrets to the addons required environment variables.
   - Editor for automation configuration files, simple yaml editor/form and copy from registry function.
-  - Editor the memory configuration file.
   - Editor to manage global capabilities
   - Editor to manage account/assistant details
     - Assistant name, email, persona
     - Admin and assistant tokens
-  - Editor for addon on configurations/environments
-    - This is for the standard .env.schema and any specific configuration files needed by the addon. ie. memory configuration json, etc.
+  - Editor for addon configurations/environments
+    - This is for the standard .env.schema and any specific configuration files needed by the addon.
 
 All of this functionality exists to simplify managing files under the OP_HOME directory. The base line is managing the compose and schema files under OP_HOME/stack, the .env files under OP_HOME/vault, configuration/automation files under OP_HOME/config, possibly service specific files under OP_HOME/data. These tasks should be achievable by a technical user without the tooling by manually editing files and placing them in the proper locations.
 
@@ -58,7 +57,7 @@ These are hard constraints that must never be violated during development. See a
 
 1. **Host CLI or admin is the orchestrator.** The host CLI manages Docker Compose directly on the host. The admin container, when present, provides a web UI and API for remote/assistant-driven stack operations via docker-socket-proxy. Only one orchestrator should manage compose operations at a time. The Docker socket is never exposed to any other container. The admin mounts all of `$OP_HOME` because it manages config, vault, stack assembly, data, and logs — mounting individual subdirectories would be fragile and break when new paths are added. Its blast radius is already constrained by docker-socket-proxy (filtered API), token-authenticated API endpoints, and localhost-only binding.
 2. **Guardian-only ingress.** All channel traffic enters through the guardian, which enforces HMAC verification, timestamp skew rejection, replay detection, and rate limiting. No channel may communicate directly with the assistant. Channel secrets are distributed during addon install (see § Addon secret lifecycle below).
-3. **Assistant isolation.** The assistant has no Docker socket and no broad host filesystem access beyond its designated mounts: `config/ -> /etc/openpalm`, `config/assistant/ -> /home/opencode/.config/opencode`, `vault/stack/auth.json`, `vault/user/ -> /etc/vault/` (directory, rw), `data/assistant/`, `data/stash/`, `data/workspace/`, and `logs/opencode/`. When the admin service is present, the assistant interacts with the stack through the admin API. When admin is absent, assistant stack-management tools are unavailable — the assistant operates with memory tools only.
+3. **Assistant isolation.** The assistant has no Docker socket and no broad host filesystem access beyond its designated mounts: `config/ -> /etc/openpalm`, `config/assistant/ -> /home/opencode/.config/opencode`, `vault/stack/auth.json`, `vault/user/ -> /etc/vault/` (directory, rw), `data/assistant/`, `data/stash/ -> /akm` (shared akm stash), `data/akm-cache/ -> /akm-cache`, `data/workspace/`, and `logs/opencode/`. When the admin service is present, the assistant interacts with the stack through the admin API. When admin is absent, assistant stack-management tools are unavailable — the assistant operates with akm-only access to memory and knowledge.
 4. **Host only by default.** Admin interfaces, dashboards, and channels are host-restricted by default. Nothing is exposed to the network or internet without explicit user opt-in. The admin UI stores the admin token in localStorage; this is acceptable because the admin is LAN-first and never publicly exposed. The threat model for XSS-based token theft requires the attacker to already have network access to the host or LAN, at which point they likely have broader access. Session expiry and httpOnly cookies would add implementation complexity without meaningful security improvement under this threat model. **OpenCode auth (`OPENCODE_AUTH`) is disabled by default** because all host port bindings default to `127.0.0.1` (loopback-only) and the guardian communicates with the assistant over Docker's `assistant_net` network without credentials. If a user changes `OP_ASSISTANT_BIND_ADDRESS` to `0.0.0.0`, they must also set `OP_OPENCODE_PASSWORD` in `stack.env` and enable `OPENCODE_AUTH` — the compose comments document this requirement.
 5. **Scheduler access is scoped to automation needs.** The scheduler co-process inherits the assistant container's environment (including `OP_ASSISTANT_TOKEN`) and mounts `config/` (read-only) and `data/scheduler/` (read-write, for trigger sentinels) plus the shared `logs/` volume. It calls the admin API with the assistant token for `api` actions and `http://localhost:4096` for `assistant` actions. There is no dedicated scheduler↔admin token anymore.
 
@@ -117,7 +116,7 @@ Subtrees:
 
 Env schemas and example files live in the repo at `vault/` (committed, no secret values).
 
-**Rule:** no container except admin may mount `vault/` as a directory. The assistant receives only a bind mount of `vault/user/` (the directory, rw). Guardian and memory receive secrets exclusively through `${VAR}` substitution at container creation time and optional service-specific managed env files located under `vault/stack/services/<service-name>/`. The scheduler co-process inherits the assistant container's environment (and therefore the same vault posture). Note: the `vault/stack/services/` directory is not shipped in the `.openpalm/` bundle -- it is created at runtime by `dev-setup.sh` (dev) or the CLI installer (production) when service-specific managed env files are needed.
+**Rule:** no container except admin may mount `vault/` as a directory. The assistant receives only a bind mount of `vault/user/` (the directory, rw). Guardian and channels receive secrets exclusively through `${VAR}` substitution at container creation time and optional service-specific managed env files located under `vault/stack/services/<service-name>/`. The scheduler co-process inherits the assistant container's environment (and therefore the same vault posture). Note: the `vault/stack/services/` directory is not shipped in the `.openpalm/` bundle -- it is created at runtime by `dev-setup.sh` (dev) or the CLI installer (production) when service-specific managed env files are needed.
 
 ### 3) Data (service-managed, durable)
 
@@ -126,9 +125,9 @@ Env schemas and example files live in the repo at `vault/` (committed, no secret
 
 **Rule:** every persistence-requiring container path is a bind mount into this tree.
 
-Subtrees: `assistant/`, `admin/`, `memory/`, `guardian/`, `stash/` (AKM assets), `workspace/` (shared working directory).
+Subtrees: `assistant/`, `admin/`, `guardian/`, `stash/` (shared akm stash for assistant + admin), `akm-cache/` (regenerable akm registry artifacts), `workspace/` (shared working directory), `scheduler/` (trigger sentinels).
 
-**Write policy:** Each container may write only to its own designated `data/` subdirectories via its mounts. The assistant writes to `data/assistant/`, `data/stash/`, and `data/workspace/`; the memory service writes to `data/memory/`; and so on. No container may access another service's data directories. Stack-wide data operations (creating new data subtrees, managing other services' data) require the admin API.
+**Write policy:** Each container may write only to its own designated `data/` subdirectories via its mounts. The assistant writes to `data/assistant/`, `data/stash/`, `data/akm-cache/`, `data/workspace/`, and `data/scheduler/`; the admin shares `data/stash/` and `data/akm-cache/` with the assistant; the guardian writes to `data/guardian/` (and its private stash); and so on. No container may access another service's data directories. Stack-wide data operations (creating new data subtrees, managing other services' data) require the admin API.
 
 ### 4) Logs (audit and debug)
 
@@ -212,7 +211,6 @@ Host-exposed OpenPalm services default to a small localhost-friendly port set. C
 | **Admin** | 8100 | `127.0.0.1:3880` | Admin UI + API |
 | **Admin OpenCode** | 3881 | `127.0.0.1:3881` | Admin-side OpenCode runtime |
 | **Guardian** | 8080 | (internal only) | HMAC verification + rate limiting |
-| **Memory** | 8765 | `127.0.0.1:3898` | Memory service API |
 | **Chat addon** | 8181 | `127.0.0.1:3820` | OpenAI-compatible chat edge |
 | **API addon** | 8182 | `127.0.0.1:3821` | OpenAI/Anthropic-compatible API edge |
 
@@ -268,7 +266,7 @@ Both sides must have the same secret value. Rotating a channel secret requires u
 
 Addon overlays may extend core services by injecting environment variables or volumes into core service definitions via Compose multi-file merge. This is standard Docker Compose merge behavior — no custom merging logic is involved. ([Docker Documentation][3])
 
-**Known limitation:** the validate-in-place step checks that the assembled compose config is syntactically valid and that Varlock schemas pass, but it does not detect semantic conflicts between addons — for example, two addons setting different values for the same environment variable on a core service. In such cases, Compose's last-file-wins merge order determines the final value. Users installing multiple addons that target the same core service env vars should review the assembled config.
+**Known limitation:** the validate-in-place step checks that the assembled compose config is syntactically valid, but it does not detect semantic conflicts between addons — for example, two addons setting different values for the same environment variable on a core service. In such cases, Compose's last-file-wins merge order determines the final value. Users installing multiple addons that target the same core service env vars should review the assembled config.
 
 ---
 
@@ -290,7 +288,7 @@ On health check failure after deploy, the snapshot is automatically restored and
 - **Add an addon:** drop `compose.yml` into `stack/addons/<n>/`, then rerun `docker compose up -d` with that addon included. ([Docker Documentation][3])
 - **Add an extension (user):** copy OpenCode assets into `config/assistant/` following OpenCode's directory structure. ([OpenCode][1])
 - **Core precedence:** core extensions live in `/etc/opencode` inside the assistant container and are loaded via `OPENCODE_CONFIG_DIR`. ([OpenCode][1])
-- **Apply changes:** the CLI or admin validates proposed changes (Varlock schema, compose config) before writing anything. If validation passes, a snapshot of current live files is saved to `~/.cache/openpalm/rollback/` (see § Rollback scope), changes are written to live paths, and `docker compose up -d` is run. If services fail health checks, the snapshot is automatically restored. No string interpolation or template expansion — just whole-file writes and Compose native `--env-file` substitution. Compose is normally invoked with `vault/stack/stack.env` (system-managed: all config, secrets, and capabilities), `vault/user/user.env` (optional user extensions), and `vault/stack/guardian.env` (channel HMAC secrets; created by CLI installer, not shipped -- compose marks it `required: false`). Automatic lifecycle apply (startup/install/update/setup reruns/upgrades) is non-destructive for `config/` and `vault/user/user.env`; it may seed missing defaults, do targeted updates, and update system-managed files in `stack/` and `vault/stack/`.
+- **Apply changes:** the CLI or admin validates proposed changes (compose config) before writing anything. If validation passes, a snapshot of current live files is saved to `~/.cache/openpalm/rollback/` (see § Rollback scope), changes are written to live paths, and `docker compose up -d` is run. If services fail health checks, the snapshot is automatically restored. No string interpolation or template expansion — just whole-file writes and Compose native `--env-file` substitution. Compose is normally invoked with `vault/stack/stack.env` (system-managed: all config, secrets, and capabilities), `vault/user/user.env` (optional user extensions), and `vault/stack/guardian.env` (channel HMAC secrets; created by CLI installer, not shipped -- compose marks it `required: false`). Automatic lifecycle apply (startup/install/update/setup reruns/upgrades) is non-destructive for `config/` and `vault/user/user.env`; it may seed missing defaults, do targeted updates, and update system-managed files in `stack/` and `vault/stack/`.
 - **Addon overlays may extend core services.** Addon compose files can inject environment variables or volumes into core service definitions via Compose multi-file merge. For example, an addon can add environment entries to the assistant service by defining an `assistant:` block with additional `environment:` entries in its overlay. This is standard Docker Compose merge behavior — no custom merging logic is involved. See § Addon conflict detection for limitations.
 - **API key changes require restart:** provider API keys now live in `vault/stack/stack.env` and are injected into containers via compose `${VAR}` substitution at startup. Changing keys requires a stack restart (`docker compose up -d`) for the new values to take effect.
 - **Rollback:** `openpalm rollback` restores the most recent snapshot from `~/.cache/openpalm/rollback/` and restarts the stack. Available both as an automated response to failed deploys and as a manual escape hatch. See § Rollback scope for snapshot contents.

--- a/docs/technical/foundations.md
+++ b/docs/technical/foundations.md
@@ -53,7 +53,7 @@ The standard startup path uses:
 
 | Network | Purpose | Core members |
 |---|---|---|
-| `assistant_net` | Core internal mesh | `memory`, `assistant` (which also hosts the scheduler co-process), `guardian`, optional `admin` |
+| `assistant_net` | Core internal mesh | `assistant` (which also hosts the scheduler co-process), `guardian`, optional `admin` |
 | `channel_lan` | Default channel ingress (LAN-restricted) | `guardian` and LAN-facing channel addons |
 | `channel_public` | Reserved for internet-facing channel ingress | `guardian` and public-facing channel addons. Access semantics and membership rules are under design. |
 | `admin_docker_net` | Isolated Docker control plane | `admin`, `docker-socket-proxy`. Only exists when the admin addon is installed. |
@@ -62,44 +62,13 @@ The standard startup path uses:
 
 ## Core Containers
 
-### Memory
-
-Role:
-
-- persistent memory API
-- vector storage and embeddings support
-
-Env sources:
-
-- `stack.env` (via compose ${VAR} substitution)
-- `user.env` (optional user additions via compose ${VAR} substitution)
-
-Key env:
-
-- `MEMORY_DATA_DIR=/data`
-- `HOME=/data`
-- `MEM0_DIR=/data/.mem0`
-- `MEMORY_AUTH_TOKEN` (set from `OP_MEMORY_TOKEN` in stack.env)
-- `OPENAI_API_KEY`
-- `OPENAI_BASE_URL`
-
-Mounts:
-
-- `$OP_HOME/data/memory -> /data`
-
-Ports and network:
-
-- host: `${OP_MEMORY_BIND_ADDRESS:-127.0.0.1}:${OP_MEMORY_PORT:-3898}`
-- container: `8765`
-- network: `assistant_net`
-
 ### Assistant
 
 Role:
 
 - OpenCode runtime
 - user-facing AI interaction
-- memory client
+- memory, skills, and knowledge access via the akm CLI (shared akm stash)
 - admin API client when admin is present
 
 Env sources:
@@ -116,16 +85,15 @@ Key env:
 - `OPENCODE_ENABLE_SSH`
 - `OP_ADMIN_API_URL`
 - `OP_ASSISTANT_TOKEN`
-- `MEMORY_API_URL=http://memory:8765`
-- `MEMORY_AUTH_TOKEN` (set from `OP_MEMORY_TOKEN` in stack.env)
-- `MEMORY_USER_ID`
+- `AKM_STASH_DIR=/akm` (and matching `AKM_DATA_DIR`, `AKM_STATE_DIR`, `AKM_CONFIG_DIR`, `AKM_CACHE_DIR`)
 - `OP_UID`, `OP_GID`
 
 Mounts:
 
 - image-baked `/etc/opencode`
 - `$OP_HOME/data/assistant -> /home/opencode/`
-- `$OP_HOME/data/stash -> /home/opencode/.akm`
+- `$OP_HOME/data/stash -> /akm` (shared akm stash; also bind-mounted into the admin container)
+- `$OP_HOME/data/akm-cache -> /akm-cache` (regenerable registry artifacts)
 - `$OP_HOME/data/workspace -> /work`
 - `$OP_HOME/config -> /etc/openpalm`
 - `$OP_HOME/config/assistant -> /home/opencode/.config/opencode`
@@ -156,7 +124,7 @@ SSH (optional, gated by `OPENCODE_ENABLE_SSH=1`):
 Secret redaction (in-process logger):
 
 - The shared logger in `@openpalm/lib` (`createLogger`) walks every structured `extra` payload and replaces values whose keys match the sensitive-key pattern (`(^|_)(TOKEN|SECRET|KEY|PASSWORD|HMAC)(_|$)`, case-insensitive) with `***REDACTED***` before the line is written to stdout/stderr. This applies to all services that use the shared logger (admin, guardian, channels, scheduler, CLI).
-- Replaces the previous varlock-based process- and shell-level redaction, which was retired in #391 along with the schema files. Operators who want stronger guarantees should keep cloud secrets out of the assistant container by setting only the keys their selected provider needs; the assistant entrypoint already strips unused provider keys based on `SYSTEM_LLM_PROVIDER`.
+- Operators who want stronger guarantees should keep cloud secrets out of the assistant container by setting only the keys their selected provider needs; the assistant entrypoint already strips unused provider keys based on `SYSTEM_LLM_PROVIDER`.
 
 ### Guardian
 
@@ -231,7 +199,7 @@ Role:
 
 - scheduled automation execution
 - admin API caller (via the assistant token)
-- assistant and memory client
+- assistant client (calls the co-resident OpenCode runtime over `localhost`)
 
 The scheduler is a Bun co-process that runs **inside the assistant
 container** (started by `core/assistant/entrypoint.sh`). It has no
@@ -248,8 +216,6 @@ Env sources (inherits the assistant container's environment):
 - `OP_HOME=/openpalm`
 - `OP_ASSISTANT_TOKEN` — used as the admin API token for `api` actions
 - `OP_ADMIN_API_URL`
-- `MEMORY_API_URL=http://memory:8765`
-- `MEMORY_AUTH_TOKEN`
 - `OPENCODE_API_URL=http://localhost:4096` (co-resident OpenCode; auth disabled on this interface)
 
 Mounts (provided by the assistant service):
@@ -312,8 +278,7 @@ Key env:
 - `HOME=/home/node`
 - `OP_HOME=/openpalm`
 - `ADMIN_TOKEN`
-- `MEMORY_API_URL=http://memory:8765`
-- `MEMORY_AUTH_TOKEN`
+- `AKM_STASH_DIR=/akm` (and matching `AKM_DATA_DIR`, `AKM_STATE_DIR`, `AKM_CONFIG_DIR`, `AKM_CACHE_DIR`)
 - `GUARDIAN_URL=http://guardian:8080`
 - `OP_ASSISTANT_URL=http://assistant:4096`
 - `OP_ADMIN_API_URL=http://localhost:8100`

--- a/packages/admin-tools/opencode/skills/openpalm-admin/SKILL.md
+++ b/packages/admin-tools/opencode/skills/openpalm-admin/SKILL.md
@@ -13,14 +13,18 @@ OpenPalm runs as a Docker Compose stack with two core services plus optional add
 
 | Service | Role |
 |---------|------|
-| **assistant** | This OpenCode instance (you). Hosts the scheduler co-process and the shared akm stash. |
-| **guardian** | Message routing with HMAC verification |
+| **assistant** | This OpenCode instance (you). Hosts the scheduler co-process. |
+| **guardian** | Message routing with HMAC verification, replay protection, and rate limiting. |
 
-Persistent memory, skills, commands, lessons, and workflows live in the shared akm stash that is bind-mounted into the assistant and admin containers — there is no longer a dedicated memory service.
+Persistent memory, skills, commands, lessons, and workflows live in the shared akm stash bind-mounted into the assistant and admin containers from `~/.openpalm/data/stash/`. There is no dedicated memory service.
 
 Optional addons (enabled by copying from the registry catalog into `stack/addons/`):
-| **admin** | Control plane API (protects Docker socket) |
-| **chat** | OpenAI-compatible chat channel |
+
+| Addon | Role |
+|-------|------|
+| **admin** | Control plane API (talks to Docker via docker-socket-proxy). |
+| **chat** | OpenAI-compatible chat channel. |
+| **api**, **discord**, **slack**, **voice** | Additional channel adapters. |
 
 ## Available Tool Groups
 

--- a/packages/admin-tools/opencode/skills/stack-troubleshooting/SKILL.md
+++ b/packages/admin-tools/opencode/skills/stack-troubleshooting/SKILL.md
@@ -14,32 +14,17 @@ This skill provides a systematic approach to diagnosing and resolving issues in 
 
 ## Overview
 
-### Stack Services
+For the canonical service inventory, network topology, and tool list,
+see the `openpalm-admin` skill — that is the single source of truth.
+This skill focuses on diagnosis flow.
 
-The OpenPalm stack runs two core services:
+Health endpoints used below:
 
-| Service | Role | Health endpoint |
-|---------|------|-----------------|
-| **assistant** | OpenCode runtime (no Docker socket). Hosts the scheduler co-process and the shared akm stash. | TCP check on port 3800 |
-| **guardian** | HMAC-verified message ingress, rate limiting, replay detection | http://localhost:3899/health |
-
-Optional addons (enabled by copying from the registry catalog into `stack/addons/`):
-| **admin** | Control plane API (Docker socket access via docker-socket-proxy) | http://localhost:3880/ |
-
-Persistent memory, lessons, skills, commands, and workflows live in the shared akm stash that the assistant and admin containers bind-mount from `~/.openpalm/data/stash/`.
-
-### Service Communication
-
-```
-External clients -> Guardian (HMAC/validate) -> Assistant -> akm stash (memories, skills, lessons)
-
-Assistant -> Admin API (stack operations, authenticated)
-Admin -> Docker Socket Proxy -> Docker daemon
-```
-
-Networks:
-- `assistant_net` — admin, assistant, guardian (internal communication)
-- `admin_docker_net` — admin, docker-socket-proxy only (isolated)
+| Service | Health endpoint |
+|---------|-----------------|
+| **assistant** | TCP check on port 3800 |
+| **guardian**  | http://localhost:3899/health |
+| **admin** (optional addon) | http://localhost:3880/ |
 
 ### Diagnostic Tools Available
 
@@ -104,7 +89,7 @@ Networks:
 
 ### "Memory / akm stash not working" (assistant cannot search or add memories)
 
-Memory is now served by the akm stash bind-mounted into the assistant container. There is no longer a separate memory service.
+Memory is served by the akm stash bind-mounted into the assistant container. There is no separate memory service.
 
 1. **Check the stash mount:** `admin-containers-inspect service=assistant` — is `/akm` mounted?
    - Missing -> the install/upgrade did not create the bind mount. Re-run `admin-lifecycle-update`.
@@ -114,7 +99,7 @@ Memory is now served by the akm stash bind-mounted into the assistant container.
    | Symptom | Cause | Fix |
    |---------|-------|-----|
    | `AKM_STASH_DIR not writable` | Bind mount owned by wrong UID | Re-run `admin-lifecycle-update`; verify `OP_UID`/`OP_GID` match the host. |
-   | `index out of date` | Stash files added outside akm | Ask the assistant to run `akm index` to rebuild the local index. |
+   | `index out of date` | Stash files added outside akm | Ask the assistant to run `akm improve` to rebuild the local index. |
    | Embedding errors | Configured embedding provider unavailable | Check `admin-providers-local` and the `OP_CAP_EMBEDDINGS_*` env vars on the assistant. |
 
 3. **Inspect the stash directly:** the shared root is `~/.openpalm/data/stash/` on the host. Use `admin-logs service=assistant` to look for errors emitted by the akm CLI.

--- a/packages/assistant-tools/AGENTS.md
+++ b/packages/assistant-tools/AGENTS.md
@@ -1,47 +1,24 @@
-# OpenPalm Assistant
+# assistant-tools (contributor reference)
 
-You are the OpenPalm assistant — a helpful AI that helps the user with their various tasks. This includes managing and operating the OpenPalm personal AI platform on behalf of the user. You have persistent memory and a large variety of tools and knowledge via the akm CLI tool, which is preinstalled and shares a stash with the admin container.
+This package ships the OpenCode plugin loaded into the OpenPalm assistant
+container. It registers two direct tools:
 
-## Your Role
+- `load_vault` — loads user secrets (prefers the shared akm `vault:user`
+  store, falls back to `/etc/vault/user.env`).
+- `health-check` — reports the health of core platform services.
 
-You help the user with tasks and remember context across sessions via the akm stash. You can:
+Everything else the assistant uses (memory, skills, lessons, agents,
+workflows, vaults) comes from the `akm-opencode` plugin via the `akm_*`
+tools — there is no separate memory service.
 
-- Check the health of core platform services
-- Search, read, and record knowledge (skills, lessons, memories, agents) through the akm CLI
-- Load user secrets from the vault when a task requires them
+The assistant's persona, memory guidelines, secret rules, and built-in
+skill list are defined in:
 
-## How You Work
+- `core/assistant/opencode/system.md` — system prompt (memory, tools,
+  secrets, built-in skills).
+- `core/assistant/opencode/openpalm.md` — instructions for managing the
+  stack via the admin API.
 
-You run inside the OpenPalm stack as a containerized OpenCode instance. The `assistant-tools` plugin gives you two direct tools:
-
-- `load_vault` — loads user secrets from `/etc/vault/user.env` (API keys, owner info, other user-configured secrets)
-- `health-check` — reports the health of core platform services
-
-Everything else — memory, skills, lessons, agents, workflows — comes from the `akm-opencode` plugin via the `akm_*` tools (e.g. `akm_search`, `akm_show`, `akm_remember`, `akm_feedback`, `akm_curate`, `akm_wiki`, `akm_vault`, `akm_workflow`). See `core/assistant/opencode/system.md` for the canonical guidance on those tools.
-
-## Memory Guidelines
-
-Memory is your most powerful capability. It now lives in the akm stash, not in a separate memory service.
-
-- Use `akm_search` with descriptive natural-language queries to find relevant memories, lessons, skills, or agents
-- Use `akm_show` to read the full content of any asset returned by search
-- Record memories with `akm_remember` whenever new information is discovered
-- Record mistakes alongside successful solutions — both are valuable lessons
-- Submit `akm_feedback` on assets you used so the stash learns what helps
-- Use `akm_curate` to surface high-signal context for the current task before you act
-
-### Keep Memory Clean
-
-- Write memories as clear, self-contained statements — they must make sense out of context
-- Never store secrets, API keys, passwords, or tokens in memory
-- Don't store ephemeral state (current git branch, temp files)
-- Don't store things any LLM would already know
-- Don't store raw code — store the decision or pattern instead
-- Prefer quality over quantity — one precise statement over five vague ones
-
-## Security Boundaries
-
-- You cannot access the Docker socket directly. All Docker operations go through the admin API.
-- Your admin token is provided via environment variable. Do not expose it.
-- Permission escalation (setting permissions to "allow") is blocked by policy.
-- Never store secrets, tokens, or credentials in the stash; use `akm_vault` or `load_vault` to access them, and never display, log, or echo vault values.
+When changing assistant behavior or guidance, edit those two files.
+This `AGENTS.md` exists only as a contributor pointer and is not loaded
+by OpenCode at runtime.


### PR DESCRIPTION
## Summary

Doc-only cleanup for issue #409. Removes stale references to services and tooling that have already been removed from `release/0.11.0` (memory service in #387, varlock in #391, scheduler-as-service replaced by a co-process, channel-chat package retired, etc.) and consolidates duplicated assistant guidance.

## Changes

- **`docs/technical/foundations.md`** — Drop the entire Memory container section, remove all `MEMORY_*` / `MEM0_*` env vars, switch the assistant to akm stash mounts (`/akm`, `/akm-cache`), update the scheduler co-process env, and drop the varlock retirement footnote.
- **`docs/technical/core-principles.md`** — Rewrite the opening to "two core containers" (guardian + assistant), remove the memory editor bullet, drop the Memory port row, replace memory-service mount/data text with the shared akm stash, and remove leftover `Varlock` references.
- **`AGENTS.md` (root)** — Drop the four-container claim, remove the Memory package entry, demote scheduler from "sidecar" to "co-process", remove `channel-chat` references (package no longer exists), update the Bun runtime line and Key Files table. (The repo's authoritative agent-instructions file; `CLAUDE.md` is gitignored.)
- **`core/assistant/opencode/openpalm.md`** — Trim duplication with `system.md`. Memory/secret/tool guidance now lives in `system.md` only; this file keeps stack-management behavior and boundaries.
- **`packages/assistant-tools/AGENTS.md`** — Collapse to a thin contributor pointer at the source-of-truth files instead of duplicating persona and memory guidance (this file is not loaded by OpenCode at runtime).
- **`packages/admin-tools/opencode/skills/openpalm-admin/SKILL.md`** — Fix the broken addon table, clarify guardian role, drop redundant "no longer a dedicated memory service" wording.
- **`packages/admin-tools/opencode/skills/stack-troubleshooting/SKILL.md`** — Remove the duplicated architecture description (cross-references `openpalm-admin` instead), and replace the obsolete `akm index` advice with `akm improve` (akm 0.8.0).

Net diff: **+93 / -169** across 7 files.

## Test plan

- [x] `grep -in 'MEMORY_\\|mem0\\|MEM0\\|OP_MEMORY' <scoped files>` returns nothing
- [x] `grep -in 'varlock\\|VARLOCK' <scoped files>` returns nothing
- [x] `grep -n 'channel-chat' AGENTS.md docs/` returns nothing
- [x] No remaining references to scheduler as a separate service or port 8090
- [x] Net-negative line count (~76 lines deleted overall)

Closes part of #409.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>