### PR TITLE
refactor(containers): cleanup hygiene + scheduler rename + sync OpenCode versions (#409)

### DIFF
--- a/.openpalm/stack/README.md
+++ b/.openpalm/stack/README.md
@@ -64,6 +64,5 @@ Repo addon sources live under `.openpalm/registry/addons/`. At runtime,
 | Network | Purpose |
 |---------|---------|
 | `channel_lan` | Internal/LAN-facing channel traffic |
-| `channel_public` | Public channel traffic when an addon opts in |
 | `assistant_net` | Internal core-service communication |
 | `admin_docker_net` | Isolated network for admin and docker-socket-proxy |

--- a/.openpalm/stack/core.compose.yml
+++ b/.openpalm/stack/core.compose.yml
@@ -108,6 +108,13 @@ services:
       GOOGLE_WORKSPACE_PROJECT_ID: ${GOOGLE_WORKSPACE_PROJECT_ID:-}
     ports:
       - "${OP_ASSISTANT_BIND_ADDRESS:-127.0.0.1}:${OP_ASSISTANT_PORT:-3800}:4096"
+      # KNOWN ISSUE (#409 follow-up): the SSH port is always published even
+      # when OPENCODE_ENABLE_SSH=0, so a port is held on the host with no
+      # listener inside the container. Defaults to 127.0.0.1:2222 → :22 so
+      # nothing is exposed beyond loopback. Compose has no per-port profile
+      # gate; the proper fix is a separate compose overlay (currently blocked
+      # by the registry-component validator that demands env.schema +
+      # healthcheck for everything under registry/addons/).
       - "${OP_ASSISTANT_SSH_BIND_ADDRESS:-127.0.0.1}:${OP_ASSISTANT_SSH_PORT:-2222}:22"
     volumes:
       - ${OP_HOME}/config:/etc/openpalm
@@ -175,20 +182,19 @@ services:
       # Operator-only akm cache (isolated from the shared admin/assistant cache).
       - ${OP_HOME}/data/guardian-cache:/akm-cache
     user: "${OP_UID:-1000}:${OP_GID:-1000}"
-    networks: [ channel_lan, channel_public, assistant_net ]
+    networks: [ channel_lan, assistant_net ]
     depends_on:
       assistant:
         condition: service_healthy
     healthcheck:
-      test: [ "CMD-SHELL", "bun -e \"const r=await fetch('http://localhost:8080/health');if(!r.ok)process.exit(1)\" || exit 1" ]
+      test: [ "CMD-SHELL", "curl -sf http://localhost:8080/health || exit 1" ]
       interval: 30s
       timeout: 5s
       retries: 3
       start_period: 10s
 
-# Channel networks: services join channel_lan (LAN-restricted) or
-# channel_public (publicly accessible) to control access.
+# Channel networks: services join channel_lan (LAN-restricted) to reach
+# the guardian. Public exposure is opt-in per-service via host port bindings.
 networks:
   channel_lan:
-  channel_public:
   assistant_net:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -301,7 +301,7 @@ Before submitting any change:
 | `packages/admin/src/lib/api.ts` | API call functions |
 | `packages/cli/src/lib/cli-state.ts` | CLI state helpers (ensureValidState) |
 | `packages/cli/src/commands/install.ts` | CLI install (setup wizard + compose up) |
-| `packages/scheduler/src/server.ts` | Scheduler sidecar entry point |
+| `packages/scheduler/src/main.ts` | Scheduler co-process entry point |
 | `core/guardian/src/server.ts` | HMAC-signed message guardian |
 | `packages/channels-sdk/src/logger.ts` | Shared logger (createLogger factory) |
 | `.openpalm/stack/core.compose.yml` | Core service definitions (4 services) |

--- a/core/admin/Dockerfile
+++ b/core/admin/Dockerfile
@@ -36,7 +36,11 @@ RUN npm run build
 FROM node:22-trixie-slim
 
 # ── Pinned installer versions ────────────────────────────────────────────────
-ARG OPENCODE_VERSION=1.2.24
+# Keep OPENCODE_VERSION in sync with core/assistant/Dockerfile — admin and
+# assistant must run the same OpenCode build so plugin/config behaviour is
+# identical across both AI surfaces. TODO: extract Bun + akm-cli + OpenCode
+# into a shared core/base image so this version cannot drift again.
+ARG OPENCODE_VERSION=1.3.3
 ARG BUN_VERSION=bun-v1.3.10
 # akm-cli — Agent Kit Manager, installed globally via bun add -g.
 ARG AKM_CLI_VERSION=^0.8.0-rc2

--- a/core/admin/entrypoint.sh
+++ b/core/admin/entrypoint.sh
@@ -1,9 +1,11 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Admin entrypoint — starts SvelteKit (port 8100) and OpenCode.
-# SvelteKit is the main process; OpenCode runs in the background.
-# If either process exits unexpectedly, the container exits.
+# Admin entrypoint — supervises SvelteKit (port 8100) and OpenCode (port 3881).
+# Both run as background children of this bash supervisor so we can:
+#   1. Forward SIGTERM/SIGINT to both children for clean shutdown.
+#   2. Exit (and let Compose restart) when EITHER child dies, so a crashed
+#      OpenCode does not leave the container "healthy" from SvelteKit alone.
 
 SVELTEKIT_PORT="${PORT:-8100}"
 OPENCODE_PORT="${OPENCODE_PORT:-3881}"
@@ -20,6 +22,9 @@ fi
 # Note: varlock-based runtime redaction was retired in #391. Log redaction
 # is enforced in-process by @openpalm/lib's logger, which masks values for
 # keys matching `_TOKEN | _SECRET | _KEY | _PASSWORD`.
+
+OPENCODE_PID=""
+SVELTEKIT_PID=""
 
 # ── Start OpenCode in background ──────────────────────────────────────
 start_opencode() {
@@ -48,20 +53,38 @@ start_opencode() {
 	echo "Admin OpenCode started (PID ${OPENCODE_PID})"
 }
 
-# ── Start SvelteKit (foreground) ──────────────────────────────────────
+# ── Start SvelteKit in background ─────────────────────────────────────
 start_sveltekit() {
 	echo "Starting admin SvelteKit on port ${SVELTEKIT_PORT}..."
-	exec node build/index.js
+	node build/index.js &
+	SVELTEKIT_PID=$!
+	echo "Admin SvelteKit started (PID ${SVELTEKIT_PID})"
 }
 
 # ── Cleanup on exit ───────────────────────────────────────────────────
 cleanup() {
-	if [ -n "${OPENCODE_PID:-}" ]; then
-		kill "$OPENCODE_PID" 2>/dev/null || true
-		wait "$OPENCODE_PID" 2>/dev/null || true
+	if [ -n "${OPENCODE_PID:-}" ] && kill -0 "$OPENCODE_PID" 2>/dev/null; then
+		kill -TERM "$OPENCODE_PID" 2>/dev/null || true
 	fi
+	if [ -n "${SVELTEKIT_PID:-}" ] && kill -0 "$SVELTEKIT_PID" 2>/dev/null; then
+		kill -TERM "$SVELTEKIT_PID" 2>/dev/null || true
+	fi
+	wait 2>/dev/null || true
 }
-trap cleanup EXIT
+trap cleanup TERM INT EXIT
 
 start_opencode
 start_sveltekit
+
+# ── Supervisor: exit when either child dies ──────────────────────────
+# `wait -n` returns when ANY child exits, with that child's status. The
+# container then exits and Compose's `restart: unless-stopped` recreates
+# it, instead of pretending healthy with one crashed component.
+if [ -n "${OPENCODE_PID:-}" ]; then
+	wait -n "$OPENCODE_PID" "$SVELTEKIT_PID"
+else
+	wait -n "$SVELTEKIT_PID"
+fi
+exit_status=$?
+echo "Admin supervisor: a child process exited (status ${exit_status}); shutting down container." >&2
+exit "$exit_status"

--- a/core/assistant/Dockerfile
+++ b/core/assistant/Dockerfile
@@ -1,12 +1,17 @@
 # ── Assistant Service ──────────────────────────────────────────────────────────
-# OpenCode AI runtime with OpenPalm extensions for memory, policy, and tools.
-# Config, plugins, and persona are mounted at runtime — not baked into the image.
+# OpenCode AI runtime with OpenPalm extensions for the akm stash, policy,
+# and tools. Config, plugins, and persona are mounted at runtime — not baked
+# into the image.
 # ──────────────────────────────────────────────────────────────────────────────
 
 FROM node:22-trixie-slim
 
 # ── Pinned installer versions ────────────────────────────────────────────────
 # Bump these ARGs when upgrading; keeps curl|bash installs reproducible.
+# Keep OPENCODE_VERSION in sync with core/admin/Dockerfile — admin and
+# assistant must run the same OpenCode build so plugin/config behaviour is
+# identical across both AI surfaces. TODO: extract Bun + akm-cli + OpenCode
+# into a shared core/base image so this version cannot drift again.
 ARG OPENCODE_VERSION=1.3.3
 ARG BUN_VERSION=bun-v1.3.10
 # akm-cli — Agent Kit Manager, installed globally via bun add -g.

--- a/core/assistant/entrypoint.sh
+++ b/core/assistant/entrypoint.sh
@@ -87,11 +87,15 @@ maybe_enable_ssh() {
 }
 
 maybe_proxy_lmstudio() {
-  # OpenCode v1.2.24's lmstudio provider has hardcoded base URL 127.0.0.1:1234.
-  # The "providers" config key is not supported (causes ConfigInvalidError).
+  # OpenCode's lmstudio provider still ships a hardcoded base URL of
+  # http://127.0.0.1:1234/v1 (verified through OpenCode 1.3.3, the version
+  # pinned in this image). The "providers" config key remains unsupported
+  # there — setting it triggers ConfigInvalidError at startup.
   # Workaround: if LMSTUDIO_BASE_URL points to a remote host, start a TCP
   # proxy from 127.0.0.1:1234 to that host so lmstudio requests reach Ollama
   # or other local LLM providers running outside the container.
+  # TODO: drop this proxy (and `socat` from the apt-get install list in the
+  # Dockerfile) once OpenCode allows runtime baseURL overrides for lmstudio.
   local base_url="${LMSTUDIO_BASE_URL:-}"
   if [ -z "$base_url" ]; then
     return 0
@@ -141,7 +145,7 @@ start_scheduler_coprocess() {
   local triggers_dir="${op_home}/data/scheduler/triggers"
   local scheduler_log="${log_dir}/scheduler.log"
 
-  if [ ! -f "${scheduler_dir}/src/server.ts" ]; then
+  if [ ! -f "${scheduler_dir}/src/main.ts" ]; then
     echo "Scheduler co-process source not found at ${scheduler_dir}; skipping." >&2
     return 0
   fi
@@ -168,10 +172,10 @@ start_scheduler_coprocess() {
     gosu opencode env \
       HOME=/home/opencode \
       OP_HOME="${op_home}" \
-      bun run "${scheduler_dir}/src/server.ts" >>"${scheduler_log}" 2>&1 &
+      bun run "${scheduler_dir}/src/main.ts" >>"${scheduler_log}" 2>&1 &
   else
     env OP_HOME="${op_home}" \
-      bun run "${scheduler_dir}/src/server.ts" >>"${scheduler_log}" 2>&1 &
+      bun run "${scheduler_dir}/src/main.ts" >>"${scheduler_log}" 2>&1 &
   fi
   SCHED_PID=$!
 }

--- a/core/channel/start.sh
+++ b/core/channel/start.sh
@@ -1,10 +1,21 @@
 #!/usr/bin/env bash
 set -e
 
-# Install the channel npm package if specified
+# Install the channel npm package if specified.
+#
+# CHANNEL_PACKAGE should pin the version to keep restarts reproducible
+# (e.g. `@openpalm/channel-api@1.4.2`, not `@openpalm/channel-api@latest`).
+# `--exact` forces bun to record that exact version in the per-container
+# package.json so subsequent installs in this same container resolve to the
+# same artifact even if the registry advances.
+#
+# TODO (follow-up): bake one image per channel at build time so we stop
+# making a network round-trip on every container start. The per-channel
+# image keeps the unified runtime entrypoint and just pre-installs
+# CHANNEL_PACKAGE so this curl-then-run pattern goes away.
 if [ -n "$CHANNEL_PACKAGE" ]; then
 	echo "Installing channel package: $CHANNEL_PACKAGE"
-	bun add "$CHANNEL_PACKAGE"
+	bun add --exact "$CHANNEL_PACKAGE"
 fi
 
 # Run the channel entrypoint. varlock-based runtime redaction was retired

--- a/packages/scheduler/package.json
+++ b/packages/scheduler/package.json
@@ -6,7 +6,7 @@
   "license": "MPL-2.0",
   "type": "module",
   "scripts": {
-    "start": "bun run src/server.ts",
+    "start": "bun run src/main.ts",
     "test": "bun test"
   },
   "dependencies": {

--- a/packages/scheduler/src/main.test.ts
+++ b/packages/scheduler/src/main.test.ts
@@ -57,7 +57,7 @@ beforeAll(async () => {
   mkdirSync(TRIGGERS_DIR, { recursive: true });
   writeFileSync(join(AUTOMATIONS_DIR, "server-test.yml"), SHELL_AUTOMATION);
 
-  serverProc = Bun.spawn(["bun", "run", join(__dirname, "server.ts")], {
+  serverProc = Bun.spawn(["bun", "run", join(__dirname, "main.ts")], {
     env: {
       ...process.env,
       OP_HOME: TEST_DIR,
@@ -183,7 +183,7 @@ on_failure: log
     // Spawn a fresh subprocess so the afterAll teardown still has the
     // primary subprocess available (and so this test is independent of
     // any prior state).
-    const proc = Bun.spawn(["bun", "run", join(__dirname, "server.ts")], {
+    const proc = Bun.spawn(["bun", "run", join(__dirname, "main.ts")], {
       env: {
         ...process.env,
         OP_HOME: TEST_DIR,

--- a/packages/scheduler/src/main.ts
+++ b/packages/scheduler/src/main.ts
@@ -1,11 +1,6 @@
 /**
  * OpenPalm Scheduler — automation co-process.
  *
- * TODO: rename this file to `main.ts` (or `index.ts`) in a follow-up. The
- * `server.ts` name is misleading now that there is no HTTP server. Deferred
- * because the rename touches the assistant entrypoint and the build/test
- * scripts and is out of scope for this PR.
- *
  * Runs alongside the assistant (OpenCode) inside the assistant container.
  * Does NOT expose any network port. The control plane is purely filesystem-
  * driven:


### PR DESCRIPTION
## Summary

Container hygiene pass for #409. Targets `release/0.11.0`.

### Findings addressed

- **C1 — OpenCode version skew.** Bumped admin's `OPENCODE_VERSION` from `1.2.24` to `1.3.3` to match assistant. Added cross-reference comments in both Dockerfiles and a TODO for extracting a shared `core/base` image.
- **C2 — Dead `channel_public` network.** Removed from guardian and from the network definitions. Verified no addon overlay references it. Updated `.openpalm/stack/README.md` accordingly.
- **C3 — `maybe_proxy_lmstudio` socat workaround.** Verified against the OpenCode binary that `lmstudio` still hardcodes `http://127.0.0.1:1234/v1` (true through 1.14.x, including the 1.3.3 we now pin). Updated the comment to reflect that the proxy and the `socat` apt-get entry are still needed; added a TODO referencing the upstream limitation.
- **C4 — Scheduler `server.ts` → `main.ts` rename.** Renamed both the source and test file via `git mv`. Updated:
  - `packages/scheduler/package.json` `start` script
  - `core/assistant/entrypoint.sh` (both the existence check and the launcher)
  - `AGENTS.md` key-files index
  - The file's own docstring (removed the now-obsolete TODO)
  - No external imports referenced `./server` so nothing else needed adjustment.
- **C5 — Admin entrypoint watchdog.** Both OpenCode and SvelteKit are now backgrounded; a `wait -n` supervisor exits the container if EITHER child dies so Compose's `restart: unless-stopped` recreates it instead of leaving the container "healthy" with a crashed OpenCode. SIGTERM/SIGINT propagate to both children.
- **C6 — Channel `bun add` at runtime.** Added `--exact` so the recorded version is pinned per container. Documented the bigger fix (per-channel images with `CHANNEL_PACKAGE` baked at build time) as a follow-up TODO.
- **C7 — SSH port always published.** Documented as a known issue in core.compose.yml. The naive addon-overlay fix is blocked by the registry-component validator (which requires `.env.schema` + healthcheck for everything under `registry/addons/`), so the proper fix needs broader scope. Defaults remain `127.0.0.1` so nothing leaks beyond loopback today.
- **C8 — Guardian healthcheck.** Replaced the `bun -e "..fetch.."` one-liner with `curl -sf http://localhost:8080/health || exit 1` to match the rest of the stack and the Dockerfile's own `HEALTHCHECK` directive.

### Other hygiene

- Stripped the `memory` mention from the assistant Dockerfile header comment so `find core -name Dockerfile -exec grep -l memory {} \;` is empty (acceptance criterion 5).
- Verified all `ARG` declarations in the four Dockerfiles are still actively used; no orphaned varlock/memory/scheduler-image leftovers remain in core/*/Dockerfile or core/*/entrypoint.sh.
- Verified no `depends_on:` entries point at removed services and no compose env passthroughs reference removed services.

### Deferred work

- Shared `core/base` image (bun + akm-cli + opencode) to prevent OpenCode version skew from recurring.
- Per-channel images with `CHANNEL_PACKAGE` baked in (eliminates runtime `bun add`).
- SSH port addon overlay once the registry-component validator can accept overlays that only modify existing services.
- Lifting socat/lmstudio proxy when OpenCode allows runtime baseURL overrides for the `lmstudio` provider.

## Test plan

- [x] `OP_HOME=/tmp/op-fake docker compose -f .openpalm/stack/core.compose.yml config --quiet` — clean
- [x] `OP_HOME=/tmp/op-fake docker compose -f .openpalm/stack/core.compose.yml -f .openpalm/registry/addons/admin/compose.yml config --quiet` — clean
- [x] `bun run test` — 872 pass / 0 fail (was 880p/6f before — the registry-component test made the regression visible when I tried the addon-overlay fix; now resolved).
- [x] `bun run admin:check` — 0 errors / 0 warnings
- [x] `find core -name 'Dockerfile' -exec grep -l 'memory\|MEMORY_\|varlock\|VARLOCK' {} \;` — empty
- [x] `cd packages/scheduler && bun test` — 21 pass / 0 fail (rename verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)