### PR TITLE
refactor: eliminate inline duplication across packages (#409)

### DIFF
--- a/packages/admin-tools/opencode/plugins/system-hooks.ts
+++ b/packages/admin-tools/opencode/plugins/system-hooks.ts
@@ -8,11 +8,9 @@
  * no longer touches a memory service.
  */
 import type { Plugin } from '@opencode-ai/plugin';
-import { buildAdminHeaders } from '../tools/lib.ts';
+import { adminFetch } from '../tools/lib.ts';
 
 type HookIO = Record<string, unknown>;
-
-const ADMIN_URL = process.env.OP_ADMIN_API_URL || 'http://admin:8100';
 
 type AdminSessionState = {
   sessionId: string;
@@ -58,27 +56,28 @@ export const SystemHooksPlugin: Plugin = async () => {
   };
 };
 
-async function adminFetch(path: string): Promise<unknown | null> {
-  const headers = buildAdminHeaders();
-  if (!headers) return null;
-
+async function fetchAdminJson(path: string): Promise<unknown | null> {
+  const body = await adminFetch(path);
   try {
-    const res = await fetch(`${ADMIN_URL}${path}`, { headers, signal: AbortSignal.timeout(5_000) });
-    return res.ok ? await res.json() : null;
-  } catch { return null; }
+    const parsed = JSON.parse(body);
+    if (parsed && typeof parsed === 'object' && (parsed as HookIO).error) return null;
+    return parsed;
+  } catch {
+    return null;
+  }
 }
 
 async function buildSystemContext(): Promise<string | null> {
   const lines: string[] = ['## System Session Context'];
 
-  const automations = await adminFetch('/admin/automations');
+  const automations = await fetchAdminJson('/admin/automations');
   if (automations) {
     lines.push('', '### Active Automations', `Automations data available: ${JSON.stringify(automations).slice(0, 200)}...`);
   } else {
     lines.push('', '### Automations: unavailable (admin API unreachable)');
   }
 
-  const containers = await adminFetch('/admin/containers/list') as unknown[] | null;
+  const containers = await fetchAdminJson('/admin/containers/list') as unknown[] | null;
   if (Array.isArray(containers)) {
     const running = containers.filter((c) => (c as HookIO).state === 'running').length;
     lines.push('', '### Stack Health', `Containers: ${running}/${containers.length} running`);

--- a/packages/admin-tools/opencode/tools/admin-artifacts.ts
+++ b/packages/admin-tools/opencode/tools/admin-artifacts.ts
@@ -1,8 +1,6 @@
 import { tool } from "@opencode-ai/plugin";
 import { adminFetch } from "./lib.ts";
 
-const ALLOWED_ARTIFACTS = new Set(["compose"]);
-
 export const list = tool({
   description: "List all generated artifacts with their metadata (name, sha256 hash, generation time, size)",
   async execute() {
@@ -23,7 +21,7 @@ export const get = tool({
     name: tool.schema.string().describe("The artifact to retrieve: 'compose' for docker-compose.yml"),
   },
   async execute(args) {
-    if (!ALLOWED_ARTIFACTS.has(args.name)) {
+    if (args.name !== "compose") {
       return JSON.stringify({
         error: true,
         message: "Invalid artifact name. Expected: compose",

--- a/packages/admin-tools/opencode/tools/stack-diagnostics.ts
+++ b/packages/admin-tools/opencode/tools/stack-diagnostics.ts
@@ -1,5 +1,5 @@
 import { tool } from "@opencode-ai/plugin";
-import { adminFetch, buildAdminHeaders } from "./lib.ts";
+import { buildAdminHeaders } from "./lib.ts";
 
 const GUARDIAN_URL = (process.env.GUARDIAN_URL || "http://guardian:8080").replace(/\/+$/, '');
 const ADMIN_URL = (process.env.OP_ADMIN_API_URL || "http://admin:8100").replace(/\/+$/, '');
@@ -40,6 +40,13 @@ async function fetchServiceHealth(
   }
 }
 
+/**
+ * Fetch a URL with the assistant's admin token attached and parse the
+ * response as JSON. The URL is taken verbatim, so callers can address
+ * either the admin API or any other in-stack service (e.g. guardian).
+ * Errors are surfaced as `{ error }` so the diagnostic report can
+ * include them without throwing.
+ */
 async function safeJsonFetch(url: string, timeout = 5_000): Promise<unknown> {
   const headers = buildAdminHeaders();
   if (!headers) {
@@ -47,22 +54,10 @@ async function safeJsonFetch(url: string, timeout = 5_000): Promise<unknown> {
   }
 
   try {
-    const res = await fetch(url, {
-      headers,
-      signal: AbortSignal.timeout(timeout),
-    });
-    return res.json();
+    const res = await fetch(url, { headers, signal: AbortSignal.timeout(timeout) });
+    return await res.json();
   } catch (err) {
     return { error: err instanceof Error ? err.message : String(err) };
-  }
-}
-
-async function safeAdminFetch(path: string): Promise<unknown> {
-  try {
-    const raw = await adminFetch(path);
-    return JSON.parse(raw);
-  } catch {
-    return { error: "Failed to parse response" };
   }
 }
 
@@ -163,11 +158,11 @@ export default tool({
     ] = await Promise.all([
       fetchServiceHealth("guardian", `${GUARDIAN_URL}/health`),
       fetchServiceHealth("admin", `${ADMIN_URL}/health`),
-      safeAdminFetch("/admin/containers/list"),
-      safeAdminFetch("/admin/config/validate"),
-      safeAdminFetch("/admin/connections/status"),
-      safeAdminFetch("/admin/audit?source=guardian&limit=20"),
-      safeAdminFetch("/admin/audit?limit=20"),
+      safeJsonFetch(`${ADMIN_URL}/admin/containers/list`),
+      safeJsonFetch(`${ADMIN_URL}/admin/config/validate`),
+      safeJsonFetch(`${ADMIN_URL}/admin/connections/status`),
+      safeJsonFetch(`${ADMIN_URL}/admin/audit?source=guardian&limit=20`),
+      safeJsonFetch(`${ADMIN_URL}/admin/audit?limit=20`),
       safeJsonFetch(`${GUARDIAN_URL}/stats`),
     ]);
 

--- a/packages/admin/src/lib/components/CapabilitiesTab.svelte
+++ b/packages/admin/src/lib/components/CapabilitiesTab.svelte
@@ -7,22 +7,9 @@
 		fetchAssignments,
 		saveAssignments,
 	} from '$lib/api.js';
+	import { lookupEmbeddingDims } from '@openpalm/lib/provider-constants';
 
 	type ProviderEntry = OpenCodeProviderSummary & { authMethods: OpenCodeAuthMethod[] };
-
-	const KNOWN_EMB_DIMS: Record<string, number> = {
-		'text-embedding-3-small': 1536,
-		'text-embedding-3-large': 3072,
-		'text-embedding-ada-002': 1536,
-		'nomic-embed-text': 768,
-		'mxbai-embed-large': 1024,
-		'mxbai-embed-large-v1': 1024,
-		'ai/mxbai-embed-large-v1': 1024,
-		'mistral-embed': 1024,
-		'all-minilm': 384,
-		'snowflake-arctic-embed': 1024,
-		'intfloat/multilingual-e5-large': 1024,
-	};
 
 	interface Props { loading: boolean; onRefresh: () => void; openCodeStatus?: 'checking' | 'ready' | 'unavailable'; }
 	let { loading, onRefresh }: Props = $props();
@@ -135,9 +122,7 @@
 	onMount(() => { void loadAll(); });
 
 	function lookupEmbDims(model: string): number {
-		if (KNOWN_EMB_DIMS[model]) return KNOWN_EMB_DIMS[model];
-		const bare = model.includes(':') ? model.slice(0, model.lastIndexOf(':')) : model;
-		return KNOWN_EMB_DIMS[bare] ?? 0;
+		return lookupEmbeddingDims(caps.embeddings.provider, model);
 	}
 
 	// ── Capability change handlers ──────────────────────────────────

--- a/packages/admin/src/lib/server/coercion.ts
+++ b/packages/admin/src/lib/server/coercion.ts
@@ -1,0 +1,37 @@
+/**
+ * Shared `unknown` -> typed coercion helpers used by API routes and
+ * server-side logic that consumes opaque JSON (e.g. OpenCode config blobs).
+ *
+ * Each helper returns `undefined` when the value does not match the expected
+ * shape. Object helpers shallow-clone so callers can mutate without leaking
+ * back into shared state.
+ */
+
+/** Narrow `unknown` to a plain-object record. Returns a shallow clone. */
+export function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? ({ ...value } as Record<string, unknown>)
+    : undefined;
+}
+
+/** Narrow `unknown` to a string. */
+export function asString(value: unknown): string | undefined {
+  return typeof value === 'string' ? value : undefined;
+}
+
+/** Narrow `unknown` to a number. */
+export function asNumber(value: unknown): number | undefined {
+  return typeof value === 'number' ? value : undefined;
+}
+
+/** Narrow `unknown` to an array of strings. Drops non-string entries. */
+export function asStringArray(value: unknown): string[] | undefined {
+  return Array.isArray(value) ? value.filter((e): e is string => typeof e === 'string') : undefined;
+}
+
+/** Narrow `unknown` to a `Record<string, string>`. Returns `undefined` when empty. */
+export function asStringRecord(value: unknown): Record<string, string> | undefined {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return undefined;
+  const entries = Object.entries(value).filter((e): e is [string, string] => typeof e[1] === 'string');
+  return entries.length > 0 ? Object.fromEntries(entries) : undefined;
+}

--- a/packages/admin/src/lib/server/opencode-providers.ts
+++ b/packages/admin/src/lib/server/opencode-providers.ts
@@ -11,6 +11,9 @@ import type {
 	ProviderPageState,
 	ProviderView,
 } from '$lib/types/providers.js';
+import { readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { asRecord, asString, asStringArray, asStringRecord, asNumber } from './coercion.js';
 
 const OPENCODE_URL = process.env.OP_OPENCODE_URL ?? process.env.OP_ASSISTANT_URL ?? 'http://localhost:4096';
 
@@ -137,8 +140,6 @@ export async function loadProviderPage(): Promise<ProviderPageState> {
 
 export async function getCurrentConfig(): Promise<RawConfig> {
 	// Read from disk — OpenCode's in-memory config may not reflect disk changes
-	const { readFileSync } = await import('node:fs');
-	const { join } = await import('node:path');
 	const opHome = process.env.OP_HOME ?? '';
 	const configPath = join(opHome, 'config', 'assistant', 'opencode.json');
 	try {
@@ -152,8 +153,6 @@ export async function getCurrentConfig(): Promise<RawConfig> {
 export async function patchConfig(config: RawConfig) {
 	// Write directly to the host config file — OpenCode's PATCH /config
 	// doesn't persist in Docker because the container config is read-only.
-	const { readFileSync, writeFileSync } = await import('node:fs');
-	const { join } = await import('node:path');
 	const opHome = process.env.OP_HOME ?? '';
 	const configPath = join(opHome, 'config', 'assistant', 'opencode.json');
 
@@ -352,30 +351,8 @@ function splitModel(model: string | undefined, providerId: string) {
 	return model.slice(providerId.length + 1);
 }
 
-function asRecord(value: unknown) {
-	return value && typeof value === 'object' && !Array.isArray(value) ? ({ ...value } as JsonRecord) : undefined;
-}
-
 function asModelRecord(value: unknown) {
 	return value && typeof value === 'object' && !Array.isArray(value)
 		? (value as Record<string, { name?: string }>)
 		: undefined;
-}
-
-function asString(value: unknown) {
-	return typeof value === 'string' ? value : undefined;
-}
-
-function asStringArray(value: unknown) {
-	return Array.isArray(value) ? value.filter((e): e is string => typeof e === 'string') : undefined;
-}
-
-function asStringRecord(value: unknown) {
-	if (!value || typeof value !== 'object' || Array.isArray(value)) return undefined;
-	const entries = Object.entries(value).filter((e): e is [string, string] => typeof e[1] === 'string');
-	return entries.length > 0 ? Object.fromEntries(entries) : undefined;
-}
-
-function asNumber(value: unknown) {
-	return typeof value === 'number' ? value : undefined;
 }

--- a/packages/admin/src/lib/server/provider-constants.vitest.ts
+++ b/packages/admin/src/lib/server/provider-constants.vitest.ts
@@ -124,7 +124,7 @@ describe("EMBEDDING_DIMS", () => {
 
   test("keys follow provider/model naming convention", () => {
     for (const key of Object.keys(EMBEDDING_DIMS)) {
-      expect(key).toMatch(/^[a-z]+\/.+$/);
+      expect(key).toMatch(/^[a-z][a-z-]*\/.+$/);
     }
   });
 

--- a/packages/channels-sdk/src/crypto.ts
+++ b/packages/channels-sdk/src/crypto.ts
@@ -6,6 +6,19 @@
  */
 
 /**
+ * Constant-time string comparison to prevent timing attacks.
+ * Used for API key, token, and HMAC signature validation.
+ */
+export function constantTimeEqual(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  let diff = 0;
+  for (let i = 0; i < a.length; i++) {
+    diff |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  }
+  return diff === 0;
+}
+
+/**
  * Produces an HMAC-SHA256 hex digest of body using secret as the key.
  */
 export function signPayload(secret: string, body: string): string {
@@ -18,11 +31,5 @@ export function signPayload(secret: string, body: string): string {
  */
 export function verifySignature(secret: string, body: string, sig: string): boolean {
   if (!secret || !sig) return false;
-  const expected = signPayload(secret, body);
-  if (expected.length !== sig.length) return false;
-  let diff = 0;
-  for (let i = 0; i < expected.length; i++) {
-    diff |= expected.charCodeAt(i) ^ sig.charCodeAt(i);
-  }
-  return diff === 0;
+  return constantTimeEqual(signPayload(secret, body), sig);
 }

--- a/packages/channels-sdk/src/utils.ts
+++ b/packages/channels-sdk/src/utils.ts
@@ -2,18 +2,8 @@
  * Shared utility functions for OpenPalm channel packages.
  */
 
-/**
- * Constant-time string comparison to prevent timing attacks.
- * Used for API key and token validation.
- */
-export function constantTimeEqual(a: string, b: string): boolean {
-  if (a.length !== b.length) return false;
-  let diff = 0;
-  for (let i = 0; i < a.length; i++) {
-    diff |= a.charCodeAt(i) ^ b.charCodeAt(i);
-  }
-  return diff === 0;
-}
+// Re-export for backwards compatibility — canonical home is `./crypto.ts`.
+export { constantTimeEqual } from "./crypto.ts";
 
 /**
  * Type guard that narrows an unknown value to a plain object record.

--- a/packages/cli/src/commands/install.ts
+++ b/packages/cli/src/commands/install.ts
@@ -14,6 +14,8 @@ import {
   buildManagedServices,
   createOpenCodeClient,
   createLogger,
+  expandEnvVars,
+  parseEnvFile,
   type SetupSpec,
 } from '@openpalm/lib';
 import { seedEmbeddedAssets } from '../lib/embedded-assets.ts';
@@ -410,17 +412,13 @@ async function ensureVolumeMountTargets(homeDir: string, vaultDir: string): Prom
   }
 
   // Read env vars for variable substitution
-  const envVars: Record<string, string> = { ...process.env };
-  const stackEnv = join(vaultDir, 'stack', 'stack.env');
-  if (existsSync(stackEnv)) {
-    for (const line of readFileSync(stackEnv, 'utf-8').split('\n')) {
-      const m = line.match(/^(?:export\s+)?([A-Z_][A-Z0-9_]*)=(.*)$/);
-      if (m) envVars[m[1]] = m[2];
-    }
-  }
+  const envVars: Record<string, string> = {
+    ...(process.env as Record<string, string>),
+    ...parseEnvFile(join(vaultDir, 'stack', 'stack.env')),
+  };
 
   function resolveEnvVar(str: string): string {
-    return str.replace(/\$\{([^}:]+)(?::-([^}]*))?\}/g, (_, name, def) => envVars[name] ?? def ?? '');
+    return expandEnvVars(str, envVars);
   }
 
   // Extract volume mount sources from all compose files

--- a/packages/cli/src/install-flow.test.ts
+++ b/packages/cli/src/install-flow.test.ts
@@ -20,7 +20,7 @@ import {
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { parse as yamlParse } from 'yaml';
-import { readStackSpec } from '@openpalm/lib';
+import { readStackSpec, parseEnvFile, expandEnvVars } from '@openpalm/lib';
 
 // ── Helpers ───────────────────────────────────────────────────────────────
 
@@ -132,22 +132,6 @@ function makeSetupSpec(): Record<string, unknown> {
   };
 }
 
-/** Parse env vars from stack.env for compose variable substitution. */
-function parseEnvFile(path: string): Record<string, string> {
-  const vars: Record<string, string> = {};
-  if (!existsSync(path)) return vars;
-  for (const line of readFileSync(path, 'utf-8').split('\n')) {
-    const m = line.match(/^(?:export\s+)?([A-Z_][A-Z0-9_]*)=(.*)$/);
-    if (m) vars[m[1]] = m[2];
-  }
-  return vars;
-}
-
-/** Resolve ${VAR:-default} patterns in a string. */
-function resolveVars(str: string, vars: Record<string, string>): string {
-  return str.replace(/\$\{([^}:]+)(?::-([^}]*))?\}/g, (_, name, def) => vars[name] ?? def ?? '');
-}
-
 /** Extract all host-side volume mount paths from compose files. */
 function extractVolumeMountPaths(
   composeFiles: string[],
@@ -164,7 +148,7 @@ function extractVolumeMountPaths(
       for (const vol of svc.volumes) {
         const raw = typeof vol === 'string' ? vol.split(':')[0] : (vol?.source ?? '');
         if (!raw || typeof raw !== 'string') continue;
-        const resolved = resolveVars(raw, vars);
+        const resolved = expandEnvVars(raw, vars);
         if (!resolved.startsWith('/')) continue;
         const basename = resolved.split('/').pop() ?? '';
         const isFile = basename.includes('.') && !basename.startsWith('.');

--- a/packages/cli/src/lib/docker.ts
+++ b/packages/cli/src/lib/docker.ts
@@ -1,4 +1,5 @@
 import { mkdir, rm, writeFile } from 'node:fs/promises';
+import { statSync } from 'node:fs';
 import { join, dirname, relative } from 'node:path';
 import { resolveCacheHome } from '@openpalm/lib';
 
@@ -179,17 +180,17 @@ export async function seedOpenPalmDir(
     await writeFile(join(homeDir, 'stack', 'core.compose.yml'), new Uint8Array(await Bun.file(srcCoreCompose).arrayBuffer()));
 
     const srcRegistry = join(tmpDir, '.openpalm', 'registry');
-    if (await dirExists(srcRegistry)) {
+    if (dirExists(srcRegistry)) {
       await copyTree(srcRegistry, join(homeDir, 'registry'));
     }
 
     const srcVault = join(tmpDir, '.openpalm', 'vault');
-    if (await dirExists(srcVault)) {
+    if (dirExists(srcVault)) {
       await copyTree(srcVault, vaultDir, { onlyPattern: /\.schema$/ });
     }
 
     const srcAssistant = join(tmpDir, 'core', 'assistant', 'opencode');
-    if (await dirExists(srcAssistant)) {
+    if (dirExists(srcAssistant)) {
       await copyTree(srcAssistant, join(dataDir, 'assistant'));
     }
   } finally {
@@ -197,13 +198,12 @@ export async function seedOpenPalmDir(
   }
 }
 
-async function dirExists(path: string): Promise<boolean> {
+function dirExists(path: string): boolean {
   try {
-    const stat = await Bun.file(join(path, '.')).exists();
-    // Bun.file().exists() doesn't work for dirs, use a different check
-    const proc = Bun.spawn(['test', '-d', path], { stdout: 'ignore', stderr: 'ignore' });
-    return (await proc.exited) === 0;
-  } catch { return false; }
+    return statSync(path).isDirectory();
+  } catch {
+    return false;
+  }
 }
 
 async function copyTree(

--- a/packages/cli/src/setup-wizard/server.ts
+++ b/packages/cli/src/setup-wizard/server.ts
@@ -52,33 +52,6 @@ function errorResponse(status: number, code: string, message: string): Response 
   return jsonResponse(status, { ok: false, error: code, message });
 }
 
-// ── Route Matching ───────────────────────────────────────────────────────
-
-/**
- * Match a URL path against a pattern with `:param` segments.
- * Returns the matched params or null if no match.
- */
-function matchRoute(
-  path: string,
-  pattern: string
-): Record<string, string> | null {
-  const pathSegments = path.split("/").filter(Boolean);
-  const patternSegments = pattern.split("/").filter(Boolean);
-
-  if (pathSegments.length !== patternSegments.length) return null;
-
-  const params: Record<string, string> = {};
-  for (let i = 0; i < patternSegments.length; i++) {
-    const patSeg = patternSegments[i];
-    if (patSeg.startsWith(":")) {
-      params[patSeg.slice(1)] = decodeURIComponent(pathSegments[i]);
-    } else if (patSeg !== pathSegments[i]) {
-      return null;
-    }
-  }
-  return params;
-}
-
 // ── Server Factory ───────────────────────────────────────────────────────
 
 export type SetupServer = {
@@ -178,9 +151,9 @@ export function createSetupServer(
     // ── API: Fetch Models for a Provider ─────────────────────────────
     // Uses POST to keep API keys out of URLs/query strings.
 
-    const modelsMatch = matchRoute(path, "/api/setup/models/:provider");
-    if (method === "POST" && modelsMatch) {
-      const provider = modelsMatch.provider;
+    const MODELS_PREFIX = "/api/setup/models/";
+    if (method === "POST" && path.startsWith(MODELS_PREFIX) && path.length > MODELS_PREFIX.length) {
+      const provider = decodeURIComponent(path.slice(MODELS_PREFIX.length));
 
       let reqBody: Record<string, unknown> = {};
       try {

--- a/packages/lib/src/control-plane/env.ts
+++ b/packages/lib/src/control-plane/env.ts
@@ -14,6 +14,15 @@ export function parseEnvFile(filePath: string): Record<string, string> {
   }
 }
 
+/**
+ * Resolve `${VAR}` and `${VAR:-default}` patterns in a string against the
+ * provided variable map. Unknown vars without a default expand to an empty
+ * string — mirrors compose's variable substitution semantics.
+ */
+export function expandEnvVars(input: string, vars: Record<string, string>): string {
+  return input.replace(/\$\{([^}:]+)(?::-([^}]*))?\}/g, (_, name, def) => vars[name] ?? def ?? '');
+}
+
 function quoteEnvValue(value: string): string {
   if (value.length === 0) return '';
   const needsQuoting = /[#"'\\\n\r$]/.test(value) || value !== value.trim();

--- a/packages/lib/src/index.ts
+++ b/packages/lib/src/index.ts
@@ -10,6 +10,7 @@
 export {
   LLM_PROVIDERS,
   EMBEDDING_DIMS,
+  lookupEmbeddingDims,
 } from "./provider-constants.js";
 
 // ── Logger ──────────────────────────────────────────────────────────────
@@ -82,6 +83,7 @@ export {
 export {
   parseEnvContent,
   parseEnvFile,
+  expandEnvVars,
   mergeEnvContent,
   removeEnvKey,
 } from "./control-plane/env.js";

--- a/packages/lib/src/provider-constants.ts
+++ b/packages/lib/src/provider-constants.ts
@@ -40,18 +40,39 @@ export const PROVIDER_KEY_MAP: Record<string, string> = {
   huggingface: "HF_TOKEN",
 };
 
-/** Known embedding model dimensions (cloud providers). */
+/** Known embedding model dimensions. Keyed by `provider/model`. */
 export const EMBEDDING_DIMS: Record<string, number> = {
   "openai/text-embedding-3-small": 1536,
   "openai/text-embedding-3-large": 3072,
   "openai/text-embedding-ada-002": 1536,
   "ollama/nomic-embed-text": 768,
   "ollama/mxbai-embed-large": 1024,
+  "ollama/mxbai-embed-large-v1": 1024,
   "ollama/all-minilm": 384,
   "ollama/snowflake-arctic-embed": 1024,
+  "model-runner/ai/mxbai-embed-large-v1": 1024,
+  "mistral/mistral-embed": 1024,
   "google/text-embedding-004": 768,
   "huggingface/sentence-transformers/all-MiniLM-L6-v2": 384,
+  "huggingface/intfloat/multilingual-e5-large": 1024,
 };
+
+/**
+ * Look up embedding model dimensions. Tries the full key first, then strips
+ * any trailing `:tag` from the model name (Ollama-style versions).
+ * Returns 0 when no match is found.
+ */
+export function lookupEmbeddingDims(provider: string, model: string): number {
+  if (!provider || !model) return 0;
+  const key = `${provider}/${model}`;
+  if (EMBEDDING_DIMS[key]) return EMBEDDING_DIMS[key];
+  const colon = model.lastIndexOf(":");
+  if (colon > 0) {
+    const bare = `${provider}/${model.slice(0, colon)}`;
+    if (EMBEDDING_DIMS[bare]) return EMBEDDING_DIMS[bare];
+  }
+  return 0;
+}
 
 /** Provider display labels for UI. */
 export const PROVIDER_LABELS: Record<string, string> = {


### PR DESCRIPTION
## Summary

Eliminates inline duplication across OpenPalm packages by routing each duplicate to a single source-of-truth implementation (usually in `@openpalm/lib` or a shared admin helper).

## Consolidations

| Duplicate | Source-of-truth | Eliminated copies |
|---|---|---|
| Inline `parseEnvFile` regex (`/^(?:export\s+)?([A-Z_][A-Z0-9_]*)=(.*)$/`) | `parseEnvFile` from `@openpalm/lib` | `packages/cli/src/commands/install.ts`, `packages/cli/src/install-flow.test.ts` |
| Inline `${VAR:-default}` regex | New `expandEnvVars` from `@openpalm/lib` | `packages/cli/src/commands/install.ts`, `packages/cli/src/install-flow.test.ts` |
| Private `adminFetch` (no timeout, swallows errors) | `adminFetch` from `packages/admin-tools/opencode/tools/lib.ts` (30s timeout, structured error envelope) | `packages/admin-tools/opencode/plugins/system-hooks.ts` |
| Inline constant-time XOR loop | `constantTimeEqual` (moved to `crypto.ts`, re-exported from `utils.ts` for back-compat) | `packages/channels-sdk/src/crypto.ts` `verifySignature` |
| Local `KNOWN_EMB_DIMS` table (bare model names) | `EMBEDDING_DIMS` + new `lookupEmbeddingDims(provider, model)` from `@openpalm/lib/provider-constants` | `packages/admin/src/lib/components/CapabilitiesTab.svelte` |
| `asRecord` (and `asString`/`asNumber`/`asStringArray`/`asStringRecord`) duplicated across two admin files | New `packages/admin/src/lib/server/coercion.ts` | `packages/admin/src/lib/server/opencode-providers.ts`, `packages/admin/src/routes/admin/providers/actions/+server.ts` |
| `await import('node:fs'/'node:path')` for core built-ins | Static top-of-file imports | `packages/admin/src/lib/server/opencode-providers.ts` (two pairs) |
| `safeJsonFetch` + `safeAdminFetch` near-duplicates | Single URL-taking `safeJsonFetch` | `packages/admin-tools/opencode/tools/stack-diagnostics.ts` |
| `ALLOWED_ARTIFACTS = new Set(["compose"])` (single-value Set) | Direct `args.name !== "compose"` check | `packages/admin-tools/opencode/tools/admin-artifacts.ts` |
| `matchRoute` mini-router (used for one parameterized route) | `path.startsWith(MODELS_PREFIX)` + slice | `packages/cli/src/setup-wizard/server.ts` |
| `dirExists` via `Bun.spawn(['test', '-d', ...])` plus a dead `Bun.file().exists()` | Synchronous `statSync(path).isDirectory()` | `packages/cli/src/lib/docker.ts` |

Where helper behavior diverged (`adminFetch` 5s vs 30s timeout), kept the more conservative (longer) timeout per the spec.

## Test plan

- [x] `bun run test` (root) — 968 pass / 0 fail
- [x] `bun run admin:test:unit` — 473 pass / 40 fail (baseline was 472 / 41; one fewer failure because the EMBEDDING_DIMS regex test now allows hyphenated provider names like `model-runner`). All 40 remaining failures are pre-existing memory/varlock references unrelated to this PR.
- [x] `bun run admin:check` — 33 errors, identical to baseline; all pre-existing memory module references, none introduced by this work.

Net diff: 141 insertions / 170 deletions (net negative -29 lines) across 16 modified files plus the new 39-line coercion module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)