### PR TITLE
refactor(types): convert single-impl interfaces to type aliases; remove bunShim() (lib uses process.env)

### DIFF
--- a/packages/admin/src/lib/test-utils/console-guard.ts
+++ b/packages/admin/src/lib/test-utils/console-guard.ts
@@ -14,7 +14,7 @@
  */
 import { expect } from 'vitest';
 
-export interface ConsoleGuard {
+export type ConsoleGuard = {
 	/** Assert that no console errors or uncaught exceptions occurred. */
 	expectNoErrors: () => void;
 	/** Assert that no console warnings occurred. */
@@ -25,7 +25,7 @@ export interface ConsoleGuard {
 	getWarnings: () => string[];
 	/** Cleanup — call in afterEach if not using the auto-cleanup pattern. */
 	cleanup: () => void;
-}
+};
 
 /**
  * Install console error/warning monitoring for the current test.

--- a/packages/admin/src/lib/types/providers.ts
+++ b/packages/admin/src/lib/types/providers.ts
@@ -1,35 +1,35 @@
 export type ProviderFilter = 'all' | 'connected' | 'configured' | 'oauth' | 'disabled';
 
-export interface ProviderAuthPrompt {
+export type ProviderAuthPrompt = {
 	key: string;
 	message: string;
 	placeholder?: string;
 	options?: string[];
 	when?: string;
-}
+};
 
-export interface ProviderAuthMethod {
+export type ProviderAuthMethod = {
 	index: number;
 	type: 'oauth' | 'api';
 	label: string;
 	prompts: ProviderAuthPrompt[];
-}
+};
 
-export interface ProviderModelOption {
+export type ProviderModelOption = {
 	id: string;
 	name: string;
-}
+};
 
-export interface ProviderOptionView {
+export type ProviderOptionView = {
 	apiKey?: string;
 	baseURL?: string;
 	headers?: Record<string, string>;
 	timeout?: number;
 	chunkTimeout?: number;
 	setCacheKey?: boolean;
-}
+};
 
-export interface ProviderView {
+export type ProviderView = {
 	id: string;
 	name: string;
 	source: string;
@@ -46,9 +46,9 @@ export interface ProviderView {
 	options: ProviderOptionView;
 	supportsOauth: boolean;
 	supportsApiAuth: boolean;
-}
+};
 
-export interface ProviderPageState {
+export type ProviderPageState = {
 	available: boolean;
 	error?: string;
 	providers: ProviderView[];
@@ -63,9 +63,9 @@ export interface ProviderPageState {
 	defaultModels: Record<string, string>;
 	allowlistActive: boolean;
 	providerCountLabel: string;
-}
+};
 
-export interface ProviderActionResult {
+export type ProviderActionResult = {
 	ok?: boolean;
 	message?: string;
 	selectedProviderId?: string;
@@ -77,4 +77,4 @@ export interface ProviderActionResult {
 		instructions?: string;
 		inputs?: Record<string, string>;
 	};
-}
+};

--- a/packages/channels-sdk/src/assistant-client.ts
+++ b/packages/channels-sdk/src/assistant-client.ts
@@ -5,7 +5,7 @@
  * Uses standard `fetch()` so it works in both Node.js and Bun runtimes.
  */
 
-export interface AssistantClientOptions {
+export type AssistantClientOptions = {
   /** Base URL of the OpenCode server. */
   baseUrl: string;
   /** Optional Basic-auth username (defaults to "opencode"). */
@@ -16,28 +16,28 @@ export interface AssistantClientOptions {
   createTimeoutMs?: number;
   /** Timeout for the message request (ms). Default: 0 (no timeout). Set to a positive value to enable. */
   messageTimeoutMs?: number;
-}
+};
 
-interface SessionCreateResponse {
+type SessionCreateResponse = {
   id: string;
-}
+};
 
-interface SessionListItemResponse {
+type SessionListItemResponse = {
   id?: unknown;
   title?: unknown;
-}
+};
 
-interface MessageResponse {
+type MessageResponse = {
   info?: unknown;
   parts?: Array<{ type: string; text?: string; content?: string }>;
-}
+};
 
 const SESSION_ID_RE = /^[a-zA-Z0-9_-]+$/;
 
-export interface AssistantSessionSummary {
+export type AssistantSessionSummary = {
   id: string;
   title: string;
-}
+};
 
 /**
  * Produce a short human-readable description for an assistant HTTP error.

--- a/packages/lib/src/control-plane/registry.ts
+++ b/packages/lib/src/control-plane/registry.ts
@@ -46,10 +46,10 @@ export function isValidComponentName(name: string): boolean {
 
 const DEFAULT_REPO = 'itlackey/openpalm';
 
-export interface RegistryConfig {
+export type RegistryConfig = {
   repoUrl: string;
   branch: string;
-}
+};
 
 export function getRegistryConfig(): RegistryConfig {
   return {


### PR DESCRIPTION
## Summary

TypeScript hygiene cleanup per CLAUDE.md "no interfaces" rule.

### Single-impl interfaces converted to `type` aliases

**`packages/admin/src/lib/types/providers.ts`** (7 interfaces):
- `ProviderAuthPrompt`
- `ProviderAuthMethod`
- `ProviderModelOption`
- `ProviderOptionView`
- `ProviderView`
- `ProviderPageState`
- `ProviderActionResult`

**`packages/admin/src/lib/test-utils/console-guard.ts`** (1 interface):
- `ConsoleGuard`

**`packages/channels-sdk/src/assistant-client.ts`** (5 interfaces):
- `AssistantClientOptions` (exported)
- `AssistantSessionSummary` (exported)
- `SessionCreateResponse` (internal)
- `SessionListItemResponse` (internal)
- `MessageResponse` (internal)

**`packages/lib/src/control-plane/registry.ts`** (1 interface):
- `RegistryConfig`

All converted shapes are pure DTOs — verified via `grep -rn 'implements …\|extends …'`: no class implements them and no other interface extends them.

### Left intact (intentional)

- **`packages/lib/src/control-plane/secret-backend.ts` `SecretBackend`** — true polymorphism (both `PlaintextBackend` and `PassBackend` `implements` it).
- **`packages/admin/src/lib/voice/speech-recognition.d.ts`** (`SpeechRecognitionEvent`, `SpeechRecognitionErrorEvent`, `SpeechRecognitionInstance`, `SpeechRecognitionConstructor`, `Window`) — declaration merging with ambient DOM types. Must remain `interface`.

### bunShim() removal

The bunShim() Vite plugin and the `Bun.env` usages in `packages/lib/` have **already been removed** on `release/0.11.0` prior to this PR. Verified:

```bash
$ grep -rn 'Bun\.env' packages/lib/src/   # no output
$ grep -n 'bunShim' packages/admin/vite.config.ts   # no output
```

`packages/lib/` uses `process.env` exclusively, so the shim is no longer needed and is not present in `vite.config.ts`. No changes required for this part of the task.

## Test plan

- [x] `bun run admin:check` — 0 errors, 0 warnings (628 files)
- [x] `bun run admin:build` — clean build
- [x] `bun run test` (root, non-admin) — 968 pass, 0 fail (40 files)
- [x] `bun run admin:test:unit` — 513 pass, 0 fail (41 files)
- [x] `grep -rn 'Bun\.env' packages/lib/src/` returns nothing
- [x] `bunShim` not in vite config

🤖 Generated with [Claude Code](https://claude.com/claude-code)