### PR TITLE
feat(ssh): move SSH port binding to addon overlay; relax addon validator for overlay-only addons

### DIFF
--- a/.openpalm/registry/addons/ssh/README.md
+++ b/.openpalm/registry/addons/ssh/README.md
@@ -1,0 +1,46 @@
+# SSH Addon
+
+Overlay-only addon that publishes the assistant container's SSH port on
+the host and enables sshd inside the container.
+
+## What it does
+
+- Patches the existing `assistant` service to publish port `22` from the
+  container as `2222` on the host (`127.0.0.1` by default).
+- Sets `OPENCODE_ENABLE_SSH=1` so the assistant entrypoint launches
+  `sshd` at startup.
+
+When this addon is **not** enabled, no SSH port is reserved on the host
+and sshd does not run inside the container.
+
+## Enabling
+
+```bash
+openpalm addon enable ssh
+```
+
+Disable with `openpalm addon disable ssh`.
+
+## Configuration
+
+| Variable                          | Default       | Purpose                                  |
+|-----------------------------------|---------------|------------------------------------------|
+| `OP_ASSISTANT_SSH_BIND_ADDRESS`   | `127.0.0.1`   | Host interface to bind. Use `0.0.0.0` for LAN access. |
+| `OP_ASSISTANT_SSH_PORT`           | `2222`        | Host port to publish.                    |
+
+Set these in `vault/stack/stack.env` if you need to override the
+defaults.
+
+## Security implications
+
+Read these before enabling on a non-loopback interface:
+
+- The `opencode` user inside the container has **passwordless sudo**.
+  Anyone who logs in via SSH can become root in the container.
+- sshd is configured for **public-key authentication only** — password
+  logins are disabled. You must place an authorized key for the
+  `opencode` user inside the container's `~/.ssh/authorized_keys`
+  before connecting.
+- Default bind is loopback (`127.0.0.1`). Exposing on `0.0.0.0` makes
+  the assistant SSH port reachable from the LAN; treat the addon as
+  a privileged ingress when you do.

--- a/.openpalm/registry/addons/ssh/compose.yml
+++ b/.openpalm/registry/addons/ssh/compose.yml
@@ -1,0 +1,16 @@
+# Addon: SSH access to the assistant container.
+#
+# Overlay-only addon — no new service, no env schema. Patches the existing
+# `assistant` service in core.compose.yml to publish the container's sshd
+# port on the host and flips OPENCODE_ENABLE_SSH so the in-container
+# entrypoint actually starts sshd.
+#
+# Defaults: bind to 127.0.0.1 (loopback only) on host port 2222 → :22 in
+# the container. Override OP_ASSISTANT_SSH_BIND_ADDRESS / OP_ASSISTANT_SSH_PORT
+# in stack.env to expose elsewhere.
+services:
+  assistant:
+    ports:
+      - "${OP_ASSISTANT_SSH_BIND_ADDRESS:-127.0.0.1}:${OP_ASSISTANT_SSH_PORT:-2222}:22"
+    environment:
+      OPENCODE_ENABLE_SSH: "1"

--- a/.openpalm/stack/core.compose.yml
+++ b/.openpalm/stack/core.compose.yml
@@ -108,14 +108,11 @@ services:
       GOOGLE_WORKSPACE_PROJECT_ID: ${GOOGLE_WORKSPACE_PROJECT_ID:-}
     ports:
       - "${OP_ASSISTANT_BIND_ADDRESS:-127.0.0.1}:${OP_ASSISTANT_PORT:-3800}:4096"
-      # KNOWN ISSUE (#409 follow-up): the SSH port is always published even
-      # when OPENCODE_ENABLE_SSH=0, so a port is held on the host with no
-      # listener inside the container. Defaults to 127.0.0.1:2222 → :22 so
-      # nothing is exposed beyond loopback. Compose has no per-port profile
-      # gate; the proper fix is a separate compose overlay (currently blocked
-      # by the registry-component validator that demands env.schema +
-      # healthcheck for everything under registry/addons/).
-      - "${OP_ASSISTANT_SSH_BIND_ADDRESS:-127.0.0.1}:${OP_ASSISTANT_SSH_PORT:-2222}:22"
+      # SSH port (2222 → :22) is published only when the `ssh` addon is
+      # enabled. The overlay at registry/addons/ssh/compose.yml adds the
+      # port binding and flips OPENCODE_ENABLE_SSH=1 so sshd starts
+      # inside the container. See registry/addons/ssh/README.md for the
+      # security implications (passwordless sudo, key-only auth).
     volumes:
       - ${OP_HOME}/config:/etc/openpalm
       - ${OP_HOME}/config/assistant:/home/opencode/.config/opencode

--- a/packages/lib/src/control-plane/registry-components.test.ts
+++ b/packages/lib/src/control-plane/registry-components.test.ts
@@ -5,6 +5,19 @@
  * component conventions: compose.yml with required labels, .env.schema
  * with documented variables, proper service naming, and no security
  * violations.
+ *
+ * Two component shapes are accepted:
+ *
+ *   1. Full addons — compose.yml + .env.schema. They introduce a new
+ *      service, declare env vars, and must satisfy the full structural
+ *      checklist (labels, network, healthcheck, restart policy, sensitive
+ *      fields).
+ *   2. Overlay-only addons — compose.yml only. They patch existing
+ *      services (ports, env, volumes) instead of introducing new ones,
+ *      so they have no env vars to document and no service-shaped
+ *      requirements. They still must satisfy the security invariants:
+ *      no INSTANCE_ID, no container_name, no INSTANCE_DIR, no vault
+ *      directory mounts, no docker socket.
  */
 import { describe, expect, it } from "bun:test";
 import {
@@ -26,6 +39,19 @@ function listComponentDirs(): string[] {
   return readdirSync(REGISTRY_DIR, { withFileTypes: true })
     .filter((d) => d.isDirectory())
     .map((d) => d.name);
+}
+
+/** Overlay-only addons ship compose.yml only — no .env.schema. */
+function isOverlayOnly(componentId: string): boolean {
+  return !existsSync(join(REGISTRY_DIR, componentId, ".env.schema"));
+}
+
+function listFullAddonIds(componentIds: string[]): string[] {
+  return componentIds.filter((id) => !isOverlayOnly(id));
+}
+
+function listOverlayOnlyAddonIds(componentIds: string[]): string[] {
+  return componentIds.filter(isOverlayOnly);
 }
 
 /** Read a file from a component directory */
@@ -118,14 +144,54 @@ describe("registry component discovery", () => {
 
 describe("registry component required files", () => {
   const componentIds = listComponentDirs();
+  const fullAddonIds = listFullAddonIds(componentIds);
 
   for (const id of componentIds) {
     it(`${id}: has compose.yml`, () => {
       expect(existsSync(join(REGISTRY_DIR, id, "compose.yml"))).toBe(true);
     });
+  }
 
-    it(`${id}: has .env.schema`, () => {
+  for (const id of fullAddonIds) {
+    it(`${id}: has .env.schema (full addon)`, () => {
       expect(existsSync(join(REGISTRY_DIR, id, ".env.schema"))).toBe(true);
+    });
+  }
+});
+
+// ── Overlay-only Addon Tests ─────────────────────────────────────────────
+
+describe("registry overlay-only addons", () => {
+  const componentIds = listComponentDirs();
+  const overlayIds = listOverlayOnlyAddonIds(componentIds);
+
+  it("at least one overlay-only addon (ssh) is recognized as valid", () => {
+    expect(overlayIds).toContain("ssh");
+  });
+
+  for (const id of overlayIds) {
+    describe(id, () => {
+      it("ships only compose.yml (no .env.schema, no entrypoint, no Dockerfile)", () => {
+        const dirEntries = readdirSync(join(REGISTRY_DIR, id));
+        // compose.yml is required; an optional README.md is allowed; nothing
+        // else (no .env.schema, no entrypoint*, no Dockerfile, no scripts).
+        const allowed = new Set(["compose.yml", "README.md"]);
+        for (const file of dirEntries) {
+          expect(allowed.has(file)).toBe(true);
+        }
+      });
+
+      it("compose.yml does not introduce a new service (no image: or build:)", () => {
+        // Overlay-only addons may patch existing services with new ports/env,
+        // but they MUST NOT introduce a new service that needs its own
+        // network/healthcheck/restart contract — those would belong in a
+        // full addon. Reject service definition keys that imply a new
+        // service body. A pure overlay only sets `ports:`, `environment:`,
+        // `volumes:`, etc. on already-defined services.
+        const compose = readComponentFile(id, "compose.yml");
+        expect(compose).not.toMatch(/^\s+image:\s/m);
+        expect(compose).not.toMatch(/^\s+build:\s/m);
+      });
     });
   }
 });
@@ -134,8 +200,11 @@ describe("registry component required files", () => {
 
 describe("registry compose.yml validation", () => {
   const componentIds = listComponentDirs();
+  const fullAddonIds = listFullAddonIds(componentIds);
 
-  for (const id of componentIds) {
+  // Full-addon-only assertions: anything that requires a service body
+  // (labels, network, healthcheck, restart policy) is checked here.
+  for (const id of fullAddonIds) {
     describe(id, () => {
       const compose = readComponentFile(id, "compose.yml");
 
@@ -145,18 +214,6 @@ describe("registry compose.yml validation", () => {
 
       it("has openpalm.description label", () => {
         expect(compose).toMatch(/openpalm\.description:/);
-      });
-
-      it("uses static service name (no INSTANCE_ID)", () => {
-        expect(compose).not.toContain("${INSTANCE_ID}");
-      });
-
-      it("does not use container_name", () => {
-        expect(compose).not.toMatch(/container_name:/);
-      });
-
-      it("does not reference INSTANCE_DIR", () => {
-        expect(compose).not.toContain("${INSTANCE_DIR}");
       });
 
       it("joins a valid stack network", () => {
@@ -170,6 +227,25 @@ describe("registry compose.yml validation", () => {
 
       it("has healthcheck", () => {
         expect(compose).toMatch(/healthcheck:/);
+      });
+    });
+  }
+
+  // Security/hygiene assertions apply to ALL addons (full and overlay-only).
+  for (const id of componentIds) {
+    describe(`${id} (security)`, () => {
+      const compose = readComponentFile(id, "compose.yml");
+
+      it("uses static service name (no INSTANCE_ID)", () => {
+        expect(compose).not.toContain("${INSTANCE_ID}");
+      });
+
+      it("does not use container_name", () => {
+        expect(compose).not.toMatch(/container_name:/);
+      });
+
+      it("does not reference INSTANCE_DIR", () => {
+        expect(compose).not.toContain("${INSTANCE_DIR}");
       });
 
       it("does not mount vault directory (single-file mounts allowed)", () => {
@@ -209,8 +285,9 @@ describe("registry compose.yml validation", () => {
 
 describe("registry .env.schema validation", () => {
   const componentIds = listComponentDirs();
+  const fullAddonIds = listFullAddonIds(componentIds);
 
-  for (const id of componentIds) {
+  for (const id of fullAddonIds) {
     describe(id, () => {
       const schema = readComponentFile(id, ".env.schema");
       const entries = parseEnvSchema(schema);
@@ -264,8 +341,9 @@ describe("registry .env.schema validation", () => {
 
 describe("registry component sensitive fields", () => {
   const componentIds = listComponentDirs();
+  const fullAddonIds = listFullAddonIds(componentIds);
 
-  for (const id of componentIds) {
+  for (const id of fullAddonIds) {
     it(`${id}: has at least one @sensitive field (channel secret)`, () => {
       // ollama is a local inference server — no channel secret or API key needed
       if (id === "ollama") return;
@@ -283,10 +361,11 @@ describe("registry component sensitive fields", () => {
 
 describe("cross-component consistency", () => {
   const componentIds = listComponentDirs();
+  const fullAddonIds = listFullAddonIds(componentIds);
 
-  it("no duplicate openpalm.name labels across components", () => {
+  it("no duplicate openpalm.name labels across full addons", () => {
     const names = new Set<string>();
-    for (const id of componentIds) {
+    for (const id of fullAddonIds) {
       const compose = readComponentFile(id, "compose.yml");
       const nameMatch = compose.match(/openpalm\.name:\s*(.+)/);
       expect(nameMatch).not.toBeNull();
@@ -296,8 +375,8 @@ describe("cross-component consistency", () => {
     }
   });
 
-  it("all components join a valid stack network", () => {
-    for (const id of componentIds) {
+  it("all full addons join a valid stack network", () => {
+    for (const id of fullAddonIds) {
       const compose = readComponentFile(id, "compose.yml");
       const hasValidNetwork = compose.includes("channel_lan") || compose.includes("channel_public") || compose.includes("assistant_net");
       expect(hasValidNetwork).toBe(true);

--- a/packages/lib/src/control-plane/registry.ts
+++ b/packages/lib/src/control-plane/registry.ts
@@ -95,7 +95,10 @@ function countValidAddons(rootDir: string): number {
   return readdirSync(addonsDir, { withFileTypes: true }).filter((entry) => {
     if (!entry.isDirectory() || !isValidComponentName(entry.name)) return false;
     const addonDir = join(addonsDir, entry.name);
-    return existsSync(join(addonDir, 'compose.yml')) && existsSync(join(addonDir, '.env.schema'));
+    // An addon is valid if it has a compose.yml. Overlay-only addons that only
+    // patch existing services (ports, env, volumes) do not need an .env.schema;
+    // full addons that introduce services and env vars do.
+    return existsSync(join(addonDir, 'compose.yml'));
   }).length;
 }
 
@@ -184,12 +187,16 @@ export function discoverRegistryComponents(): Record<string, RegistryComponentEn
     if (!entry.isDirectory() || !VALID_NAME_RE.test(entry.name)) continue;
     const addonDir = join(addonsDir, entry.name);
     const composeFile = join(addonDir, 'compose.yml');
+    if (!existsSync(composeFile)) continue;
+
+    // .env.schema is optional: overlay-only addons (e.g. a port toggle) do
+    // not introduce new env vars, so they ship just compose.yml.
     const schemaFile = join(addonDir, '.env.schema');
-    if (!existsSync(composeFile) || !existsSync(schemaFile)) continue;
+    const schema = existsSync(schemaFile) ? readFileSync(schemaFile, 'utf-8') : '';
 
     result[entry.name] = {
       compose: readFileSync(composeFile, 'utf-8'),
-      schema: readFileSync(schemaFile, 'utf-8'),
+      schema,
     };
   }
 
@@ -243,11 +250,14 @@ export function getRegistryAddonConfig(homeDir: string, name: string): RegistryA
     throw new Error(`Invalid addon name: ${name}`);
   }
 
+  // Overlay-only addons (compose.yml only, no .env.schema) have no env vars
+  // to render, so the schema reads as an empty string.
   const schemaPath = `registry/addons/${name}/.env.schema`;
+  const schemaFile = join(homeDir, schemaPath);
   return {
     schemaPath,
     userEnvPath: 'vault/user/user.env',
-    envSchema: readFileSync(join(homeDir, schemaPath), 'utf-8'),
+    envSchema: existsSync(schemaFile) ? readFileSync(schemaFile, 'utf-8') : '',
   };
 }
 
@@ -274,7 +284,9 @@ function copyAddonFromRegistry(homeDir: string, name: string): void {
   if (!VALID_NAME_RE.test(name)) throw new Error(`Invalid addon name: ${name}`);
 
   const sourceDir = join(resolveRegistryAddonsDir(), name);
-  if (!existsSync(join(sourceDir, 'compose.yml')) || !existsSync(join(sourceDir, '.env.schema'))) {
+  // compose.yml is the only required file. Overlay-only addons may omit
+  // .env.schema entirely.
+  if (!existsSync(join(sourceDir, 'compose.yml'))) {
     throw new Error(`Addon "${name}" not found in registry`);
   }
 

--- a/scripts/validate-registry.sh
+++ b/scripts/validate-registry.sh
@@ -43,13 +43,40 @@ for addon_dir in "$ADDONS_DIR"/*/; do
 		continue
 	fi
 
+	# Detect overlay-only addons: compose.yml that doesn't introduce a new
+	# service (no `image:` and no `build:` stanza). Such addons override
+	# settings on existing services and don't need .env.schema, labels,
+	# healthcheck, or network membership.
+	overlay_only=0
+	if ! grep -qE '^[[:space:]]+(image|build):' "$compose_file"; then
+		overlay_only=1
+	fi
+
+	# Vault mount violations apply to every addon (security).
+	if grep -qE '^\s*-\s+.*vault(/?)"\s*:' "$compose_file" || grep -qE '^\s*-\s+.*vault(/?)\s*:/' "$compose_file"; then
+		echo "  FAIL: compose.yml mounts vault directory (security violation)"
+		errors=$((errors + 1))
+	fi
+
+	# Legacy ${INSTANCE_ID} pattern check applies to every addon.
+	if grep -q '\${INSTANCE_ID}' "$compose_file"; then
+		echo "  FAIL: compose.yml still uses \${INSTANCE_ID} — should use static service names"
+		errors=$((errors + 1))
+	fi
+
+	if [ "$overlay_only" -eq 1 ]; then
+		echo "  OK (overlay-only)"
+		continue
+	fi
+
+	# Full addons must also have:
 	if [ ! -f "$schema_file" ]; then
 		echo "  FAIL: Missing .env.schema"
 		errors=$((errors + 1))
 		continue
 	fi
 
-	# 2. Check compose.yml has required labels
+	# Required labels
 	if ! grep -q 'openpalm\.name:' "$compose_file"; then
 		echo "  FAIL: compose.yml missing openpalm.name label"
 		errors=$((errors + 1))
@@ -60,33 +87,18 @@ for addon_dir in "$ADDONS_DIR"/*/; do
 		errors=$((errors + 1))
 	fi
 
-	# 3. Check compose.yml does NOT use legacy ${INSTANCE_ID} pattern
-	if grep -q '\${INSTANCE_ID}' "$compose_file"; then
-		echo "  FAIL: compose.yml still uses \${INSTANCE_ID} — should use static service names"
-		errors=$((errors + 1))
-	fi
-
-	# 4. Check for vault mount violations — look for full vault directory mounts
-	# (mounting a specific file like vault/user/ov.conf:ro is allowed)
-	# Flag any broad vault mount (vault:, vault/:) regardless of other mounts
-	if grep -qE '^\s*-\s+.*vault(/?)"\s*:' "$compose_file" || grep -qE '^\s*-\s+.*vault(/?)\s*:/' "$compose_file"; then
-		echo "  FAIL: compose.yml mounts vault directory (security violation)"
-		errors=$((errors + 1))
-	fi
-
-	# 5. Check .env.schema is non-empty and parseable
+	# .env.schema is non-empty and parseable
 	if [ ! -s "$schema_file" ]; then
 		echo "  FAIL: .env.schema is empty"
 		errors=$((errors + 1))
 	else
-		# Validate basic structure: should have at least one VAR= line
 		if ! grep -qE '^[A-Z_][A-Z0-9_]*=' "$schema_file"; then
 			echo "  FAIL: .env.schema has no variable definitions (expected KEY=value lines)"
 			errors=$((errors + 1))
 		fi
 	fi
 
-	# 6. Check compose.yml joins a valid stack network (channel_lan, channel_public, or assistant_net)
+	# Stack network membership
 	if ! grep -qE 'channel_lan|channel_public|assistant_net|admin_docker_net' "$compose_file"; then
 		echo "  FAIL: compose.yml must join at least one stack network"
 		errors=$((errors + 1))


### PR DESCRIPTION
## Summary

- Stop publishing the assistant SSH port (`2222 → :22`) from `core.compose.yml`. The host port is now reserved only when the new `ssh` addon overlay is enabled, which also flips `OPENCODE_ENABLE_SSH=1` so sshd actually starts inside the container. Closes the known-issue carve-out from #411.
- Recognize a new "overlay-only" addon shape in the registry: a directory containing only `compose.yml` (plus optional `README.md`) that patches existing services without introducing new ones. Full addons keep the existing structural checklist; security/hygiene assertions still apply to all addons.
- Document SSH security implications (passwordless sudo for `opencode`, key-only auth, default loopback bind) in `.openpalm/registry/addons/ssh/README.md`.

## Validator change

`packages/lib/src/control-plane/registry-components.test.ts` and the runtime helpers in `packages/lib/src/control-plane/registry.ts` now treat `.env.schema` as optional:

- `countValidAddons` / `discoverRegistryComponents` / `copyAddonFromRegistry` / `getRegistryAddonConfig` only require `compose.yml`. Missing `.env.schema` resolves to an empty schema string (the admin endpoint already round-trips it as a string).
- New test block `registry overlay-only addons` asserts that overlay-only addons (a) ship only `compose.yml` (and an optional `README.md`) and (b) do not introduce a new service via `image:` / `build:`.
- Full-addon assertions (`openpalm.name` / `openpalm.description` labels, network, `restart`, `healthcheck`, `.env.schema` validation, sensitive fields) only run for full addons.
- Security assertions (no `INSTANCE_ID` / `container_name` / `INSTANCE_DIR`, no vault-dir mount, no docker socket, comment header) still run for **every** addon.

## SSH addon move

- `.openpalm/registry/addons/ssh/compose.yml` — overlay that adds the `127.0.0.1:2222:22` publish on `assistant` and sets `OPENCODE_ENABLE_SSH=1`.
- `.openpalm/registry/addons/ssh/README.md` — what it does, how to enable, security implications.
- `.openpalm/stack/core.compose.yml` — SSH port line removed; comment now points to the addon.
- `core/assistant/entrypoint.sh` — unchanged; the in-container sshd toggle stays gated on `OPENCODE_ENABLE_SSH`.

## Security implications

The SSH addon is opt-in but it is privileged ingress when enabled:

- The `opencode` user inside the assistant container has **passwordless sudo**. SSH access = root-in-container.
- sshd is configured for **public-key auth only**; password logins are disabled. An authorized key must be placed in the container before connecting.
- Default bind is loopback (`127.0.0.1`). Operators who set `OP_ASSISTANT_SSH_BIND_ADDRESS=0.0.0.0` must understand they are exposing a privileged shell on the LAN.

These are documented in the addon's `README.md` so users see them when they enable.

## Test plan

- [x] `bun test packages/lib` — 434 pass, 0 fail (includes new overlay-only validator test).
- [x] `bun run cli:test` — 67 pass.
- [x] `bun run sdk:test` — 38 pass.
- [x] `bun run guardian:test` — 31 pass.
- [x] `bun run admin:test:unit` — 503 pass.
- [x] `bun run admin:check` — 0 errors.
- [x] `docker compose -f .openpalm/stack/core.compose.yml config --quiet` exits 0 and contains no `2222`/`22` publish in rendered output.
- [x] `docker compose -f .openpalm/stack/core.compose.yml -f .openpalm/registry/addons/ssh/compose.yml config --quiet` exits 0; rendered output contains the `2222 → 22` publish and `OPENCODE_ENABLE_SSH=1`.
- [ ] (manual / follow-up) `openpalm addon enable ssh` on a real install round-trips through the addon UI without the schema endpoint erroring.

Pre-existing channel-api test failures on `release/0.11.0` (`forwardToGuardian is not a function`) are unrelated to this change and reproduce on the unmodified branch tip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)