### PR TITLE
feat(vault): complete Phase 2 of #388 + migrate to akm secret-store stdin pattern (closes #406)

### DIFF
--- a/.openpalm/stack/core.compose.yml
+++ b/.openpalm/stack/core.compose.yml
@@ -3,15 +3,22 @@
 # This file defines the core infrastructure. Addon services are added
 # via compose overlays in stack/addons/.
 #
-# Docker Compose reads variable values via --env-file for three env files:
+# Docker Compose reads variable values via --env-file for two env files:
 #   vault/stack/stack.env    — system config, API keys, OP_CAP_* capabilities
-#   vault/user/user.env      — optional user-managed custom vars
 #   vault/stack/guardian.env  — channel HMAC secrets (loaded by guardian)
 #
-# Directory model (v0.10.0):
+# User-managed env secrets live in the akm `vault:user` store at
+# data/stash/vaults/user.env (akm-cli >= 0.8.0 layout). The assistant
+# entrypoint sources that file at startup via `akm vault path vault:user`
+# — see Phase 2 of #388 / closed by #406. The legacy
+# vault/user/user.env compose env_file was retired; on upgrade it is
+# migrated into akm and deleted.
+#
+# Directory model (v0.11.0):
 #   ~/.openpalm/config/       — user-editable, non-secret configuration
-#   ~/.openpalm/vault/stack/   — system-managed secrets (stack.env)
-#   ~/.openpalm/vault/user/    — user-managed runtime files (user.env)
+#   ~/.openpalm/vault/stack/   — system-managed secrets (stack.env, guardian.env)
+#   ~/.openpalm/vault/user/    — operational files only (apprise.yml, gws/gcloud/mgc auth dirs)
+#   ~/.openpalm/data/stash/   — akm-cli stash (skills, vaults, etc.) — vault:user lives here
 #   ~/.openpalm/data/          — service-managed persistent data
 #   ~/.openpalm/logs/          — consolidated audit/debug output
 
@@ -95,7 +102,10 @@ services:
       EMBEDDING_API_KEY: ${EMBEDDING_API_KEY:-}
       # Capability resolution (used by entrypoint.sh to drop unused provider keys).
       OP_CAP_LLM_PROVIDER: ${OP_CAP_LLM_PROVIDER:-}
-      # Google Cloud credentials (file lives in vault/user, mounted at /etc/vault)
+      # Google Cloud credentials (file lives in vault/user, mounted at /etc/vault).
+      # NOTE: the /etc/vault mount no longer carries `user.env` (Phase 2 of #388
+      # routed that through akm `vault:user`). The mount remains because gws,
+      # gcloud, and mgc rely on it for their auth directories below.
       GOOGLE_APPLICATION_CREDENTIALS: /etc/vault/gcloud-credentials.json
       CLOUDSDK_CONFIG: /etc/vault/.gcloud
       # Microsoft Graph CLI credential config

--- a/bun.lock
+++ b/bun.lock
@@ -134,6 +134,9 @@
         "dotenv": "^16.4.7",
         "yaml": "^2.8.0",
       },
+      "devDependencies": {
+        "@types/bun": "^1.0.0",
+      },
     },
     "packages/scheduler": {
       "name": "@openpalm/scheduler",
@@ -382,6 +385,8 @@
 
     "@types/body-parser": ["@types/body-parser@1.19.6", "", { "dependencies": { "@types/connect": "*", "@types/node": "*" } }, "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g=="],
 
+    "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
+
     "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
 
     "@types/connect": ["@types/connect@3.4.38", "", { "dependencies": { "@types/node": "*" } }, "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug=="],
@@ -495,6 +500,8 @@
     "brace-expansion": ["brace-expansion@1.1.12", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg=="],
 
     "buffer-equal-constant-time": ["buffer-equal-constant-time@1.0.1", "", {}, "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="],
+
+    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
     "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
 

--- a/core/assistant/entrypoint.sh
+++ b/core/assistant/entrypoint.sh
@@ -190,6 +190,35 @@ forward_term_to_scheduler() {
   fi
 }
 
+maybe_source_akm_user_vault() {
+  # Phase 2 of #388 (closes #406): user-managed env secrets now live in
+  # the akm `vault:user` store at <stash>/vaults/user.env (akm-cli >= 0.8.0
+  # layout). The legacy `${OP_HOME}/vault/user/user.env` compose env_file
+  # has been retired — instead we ask akm for the resolved vault path and
+  # source it inline so OpenCode and the scheduler co-process inherit
+  # every key. Sourcing happens AFTER the gosu drop in start_opencode, so
+  # the values land in the same process tree as opencode itself.
+  #
+  # We deliberately do NOT shell out to `akm vault run` — that would put
+  # akm in the supervisor path. A static one-shot source keeps the
+  # entrypoint dependency-free post-startup.
+  if ! command -v akm >/dev/null 2>&1; then
+    return 0
+  fi
+  local vault_path
+  vault_path="$(akm vault path vault:user 2>/dev/null || true)"
+  if [ -z "$vault_path" ] || [ ! -f "$vault_path" ]; then
+    return 0
+  fi
+  # `set -a` exports every variable assigned by the sourced file. The .env
+  # format produced by akm is plain `KEY=value` (no `export ` prefix), so
+  # this is the standard way to load it without parsing line-by-line.
+  set -a
+  # shellcheck disable=SC1090
+  . "$vault_path"
+  set +a
+}
+
 maybe_unset_unused_provider_keys() {
   # Unset LLM provider keys that are not needed for the configured provider.
   # This limits the blast radius if the assistant process is compromised —
@@ -274,6 +303,12 @@ maybe_adjust_uid_gid
 ensure_home_layout
 maybe_enable_ssh
 maybe_proxy_lmstudio
+# Source the akm `vault:user` env file BEFORE the scheduler co-process
+# starts so both OpenCode and the scheduler inherit user-managed secrets.
+# This replaces the retired `${OP_HOME}/vault/user → /etc/vault` compose
+# env_file (#388 / #406). Runs as root because gosu has not been invoked
+# yet — root can read the 0600 vault file and re-export to children.
+maybe_source_akm_user_vault
 maybe_unset_unused_provider_keys
 start_scheduler_coprocess
 start_opencode

--- a/packages/admin/src/lib/server/config-persistence.vitest.ts
+++ b/packages/admin/src/lib/server/config-persistence.vitest.ts
@@ -152,36 +152,43 @@ describe("buildEnvFiles", () => {
     expect(buildEnvFiles(state)).toEqual([]);
   });
 
-  test("returns all three files in correct order when they exist", () => {
+  test("returns stack.env and guardian.env in correct order when they exist", () => {
+    // Phase 2 of #388 (closes #406): user.env is no longer a compose
+    // env_file. User-managed env secrets live in the akm `vault:user` store
+    // and are sourced by the assistant entrypoint at container startup.
     const state = makeTestState();
     trackDir(state.homeDir);
 
     mkdirSync(join(state.vaultDir, "stack"), { recursive: true });
     mkdirSync(join(state.vaultDir, "user"), { recursive: true });
     writeFileSync(join(state.vaultDir, "stack", "stack.env"), "KEY=val");
+    // user.env may still exist on disk during migration but must NOT be
+    // surfaced as a compose env_file (compose would shadow akm-sourced values).
     writeFileSync(join(state.vaultDir, "user", "user.env"), "SECRET=val");
     writeFileSync(join(state.vaultDir, "stack", "guardian.env"), "CHANNEL_CHAT_SECRET=abc");
 
     const files = buildEnvFiles(state);
-    expect(files).toHaveLength(3);
+    expect(files).toHaveLength(2);
     expect(files[0]).toContain("stack.env");
-    expect(files[1]).toContain("user.env");
-    expect(files[2]).toContain("guardian.env");
+    expect(files[1]).toContain("guardian.env");
+    // user.env must never appear in the env file list.
+    expect(files.some((f) => f.includes("user.env"))).toBe(false);
   });
 
-  test("returns stack.env and user.env when guardian.env is missing", () => {
+  test("returns only stack.env when guardian.env is missing", () => {
     const state = makeTestState();
     trackDir(state.homeDir);
 
     mkdirSync(join(state.vaultDir, "stack"), { recursive: true });
     mkdirSync(join(state.vaultDir, "user"), { recursive: true });
     writeFileSync(join(state.vaultDir, "stack", "stack.env"), "KEY=val");
+    // Even with a legacy user.env on disk, only stack.env should be returned.
     writeFileSync(join(state.vaultDir, "user", "user.env"), "SECRET=val");
 
     const files = buildEnvFiles(state);
-    expect(files).toHaveLength(2);
+    expect(files).toHaveLength(1);
     expect(files[0]).toContain("stack.env");
-    expect(files[1]).toContain("user.env");
+    expect(files.some((f) => f.includes("user.env"))).toBe(false);
   });
 
   test("returns only stack.env when user.env and guardian.env are missing", () => {
@@ -196,7 +203,10 @@ describe("buildEnvFiles", () => {
     expect(files[0]).toContain("stack.env");
   });
 
-  test("returns only user.env when stack.env and guardian.env are missing", () => {
+  test("returns empty list when stack.env and guardian.env are missing (user.env is ignored post-Phase 2)", () => {
+    // Phase 2 of #388: a lingering legacy user.env is intentionally NOT
+    // promoted to a compose env_file — its contents have already been
+    // migrated into the akm vault:user store.
     const state = makeTestState();
     trackDir(state.homeDir);
 
@@ -204,8 +214,7 @@ describe("buildEnvFiles", () => {
     writeFileSync(join(state.vaultDir, "user", "user.env"), "SECRET=val");
 
     const files = buildEnvFiles(state);
-    expect(files).toHaveLength(1);
-    expect(files[0]).toContain("user.env");
+    expect(files).toEqual([]);
   });
 
   test("guardian.env is last (takes precedence for channel secrets)", () => {

--- a/packages/admin/src/lib/server/ensure-secrets.vitest.ts
+++ b/packages/admin/src/lib/server/ensure-secrets.vitest.ts
@@ -39,7 +39,12 @@ describe("ensureSecrets", () => {
     expect(stackEnv).toContain("OWNER_NAME=");
     expect(stackEnv).toContain("OP_ADMIN_TOKEN=");
     expect(stackEnv).toContain("OP_ASSISTANT_TOKEN=");
-    expect(existsSync(join(vaultDir, "user", "user.env"))).toBe(true);
+    // Phase 2 of #388 (closes #406): user-managed env secrets live in the
+    // akm `vault:user` store, not in `vault/user/user.env`. The vault/user
+    // directory is still created (it backs apprise.yml, gcloud creds, etc.)
+    // but the .env file is no longer seeded.
+    expect(existsSync(join(vaultDir, "user"))).toBe(true);
+    expect(existsSync(join(vaultDir, "user", "user.env"))).toBe(false);
   });
 
   test("applies strict permissions to vault files", () => {
@@ -53,7 +58,9 @@ describe("ensureSecrets", () => {
     ensureSecrets(state);
 
     expect(statSync(vaultDir).mode & 0o777).toBe(0o700);
-    expect(statSync(join(vaultDir, "user", "user.env")).mode & 0o777).toBe(0o600);
+    // vault/user is still managed (0700) for non-env operational files;
+    // user.env itself is no longer seeded under Phase 2 of #388.
+    expect(statSync(join(vaultDir, "user")).mode & 0o777).toBe(0o700);
     expect(statSync(join(vaultDir, "stack", "stack.env")).mode & 0o777).toBe(0o600);
   });
 });

--- a/packages/admin/src/lib/server/secrets.vitest.ts
+++ b/packages/admin/src/lib/server/secrets.vitest.ts
@@ -72,7 +72,12 @@ describe("ensureSecrets", () => {
     ensureSecrets(state);
 
     expect(existsSync(join(nestedDir, "stack", "stack.env"))).toBe(true);
-    expect(existsSync(join(nestedDir, "user", "user.env"))).toBe(true);
+    // Phase 2 of #388 (closes #406): user.env is no longer seeded; the
+    // user-managed env store lives in akm `vault:user` instead. The
+    // `vault/user/` directory is still created (it backs operational
+    // non-env files mounted into the assistant container).
+    expect(existsSync(join(nestedDir, "user"))).toBe(true);
+    expect(existsSync(join(nestedDir, "user", "user.env"))).toBe(false);
   });
 });
 

--- a/packages/admin/src/routes/admin/secrets/user-vault/+server.ts
+++ b/packages/admin/src/routes/admin/secrets/user-vault/+server.ts
@@ -1,21 +1,16 @@
 /**
  * /admin/secrets/user-vault — read/write the shared akm user vault.
  *
- * Phase 1 of #388: this endpoint surfaces the same `vault:user` keys
- * that `mirrorUserVaultToAkm()` populates during install/upgrade. The
- * underlying compose runtime source of truth (`vault/user/user.env`)
- * is kept in sync on writes so Docker Compose env_file resolution
- * never diverges from what the admin UI shows.
+ * Phase 2 of #388 (closed by #406): the akm `vault:user` store is now the
+ * sole source of truth for user-managed env secrets. The legacy
+ * `vault/user/user.env` mirror is gone — writes go straight to akm via
+ * `akm vault set` with the value delivered on stdin (never on argv), and
+ * deletes call `akm vault unset`.
  *
- * NOTE: We deliberately do NOT route admin secret writes through this
- * endpoint by default — operator-managed `stack.env` secrets remain in
- * the existing `/admin/secrets` plaintext/pass backends. This endpoint
- * is scoped to user-extension keys only.
- *
- * SECURITY: writes go DIRECTLY to the akm vault .env file via lib's
- * `writeAkmVaultKey`/`deleteAkmVaultKey` helpers. We never pass secret
- * values on the `akm` argv, since that would expose them through
- * `/proc/<pid>/cmdline`.
+ * SECURITY: this module never spells a secret value on a process argv.
+ * Both writeAkmVaultKey and deleteAkmVaultKey route through akm-cli's
+ * stdin-mode set / argv-safe unset commands, so no secret can leak
+ * through `/proc/<pid>/cmdline`.
  */
 import type { RequestHandler } from './$types';
 import { getState } from '$lib/server/state.js';
@@ -35,42 +30,18 @@ import {
   createLogger,
   deleteAkmVaultKey,
   ensureAkmUserVault,
-  mergeEnvContent,
-  parseEnvFile,
   readAkmUserVaultFile,
-  removeEnvKey,
   writeAkmVaultKey,
 } from '@openpalm/lib';
-import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs';
 
 const logger = createLogger('admin.secrets.user-vault');
 
 const KEY_RE = /^[A-Za-z_][A-Za-z0-9_]*$/;
 
-function writeUserEnvKey(vaultDir: string, key: string, value: string): void {
-  const userEnvPath = `${vaultDir}/user/user.env`;
-  mkdirSync(`${vaultDir}/user`, { recursive: true, mode: 0o700 });
-  const existing = existsSync(userEnvPath) ? readFileSync(userEnvPath, 'utf-8') : '';
-  const merged = mergeEnvContent(existing, { [key]: value });
-  writeFileSync(userEnvPath, merged.endsWith('\n') ? merged : merged + '\n', { mode: 0o600 });
-}
-
-function removeUserEnvKey(vaultDir: string, key: string): void {
-  const userEnvPath = `${vaultDir}/user/user.env`;
-  if (!existsSync(userEnvPath)) return;
-  const existing = readFileSync(userEnvPath, 'utf-8');
-  const stripped = removeEnvKey(existing, key);
-  writeFileSync(userEnvPath, stripped.endsWith('\n') ? stripped : stripped + '\n', { mode: 0o600 });
-}
-
 /**
  * GET — list keys in the akm vault:user store. Values are NEVER returned
  * so this endpoint behaves identically whether the underlying backend
  * exposes plaintext or encrypted secrets.
- *
- * Mirror is NOT run on GET — it is part of install/upgrade lifecycle only.
- * Calling akm on every list would be wasteful and surface transient
- * akm-CLI failures as list errors.
  */
 export const GET: RequestHandler = async (event) => {
   const requestId = getRequestId(event);
@@ -82,41 +53,33 @@ export const GET: RequestHandler = async (event) => {
   const callerType = getCallerType(event);
 
   const vaultPath = await ensureAkmUserVault(state);
-  const userEnvPath = `${state.vaultDir}/user/user.env`;
-  const akmKeys = vaultPath ? Object.keys(readAkmUserVaultFile(vaultPath)) : [];
-  const fileEntries = parseEnvFile(userEnvPath);
-  // Filter empty values so cleared keys don't show up post-DELETE if the
-  // file write path ever leaves a `KEY=` line behind.
-  const fileKeys = Object.keys(fileEntries).filter((k) => fileEntries[k] !== '');
-  const merged = Array.from(new Set([...akmKeys, ...fileKeys])).sort();
+  const keys = vaultPath ? Object.keys(readAkmUserVaultFile(vaultPath)).sort() : [];
 
   appendAudit(
     state,
     actor,
     'secrets.user-vault.list',
-    { count: merged.length, source: vaultPath ? 'akm+file' : 'file-only' },
+    { count: keys.length, source: vaultPath ? 'akm' : 'unavailable' },
     true,
     requestId,
     callerType,
   );
 
   return jsonResponse(200, {
-    provider: 'akm-mirror',
+    provider: 'akm',
     vaultRef: AKM_USER_VAULT_REF,
     available: Boolean(vaultPath),
-    keys: merged,
+    keys,
   }, requestId);
 };
 
 /**
- * PUT/POST — write a key into both the akm vault and the runtime user.env
- * file. Both writes happen so Compose env_file consumption stays in sync
- * with what the admin UI displays.
- *
- * If the akm write fails the .env update still succeeds (since Compose is
- * the runtime source of truth), but the response surfaces `mirrored:false`
- * and an `error` field so callers can decide whether to retry. A warn-level
- * log is emitted for operators (key name only, never the value).
+ * PUT/POST — write a key into the akm vault. The value is piped to
+ * `akm vault set` via stdin, so it never appears on the akm argv. The
+ * assistant entrypoint sources the akm vault file at container start; a
+ * key written here will be visible to OpenCode after the next assistant
+ * recreate. (Hot-reload of the akm vault is out of scope for Phase 2 —
+ * see follow-up issue.)
  */
 export const POST: RequestHandler = async (event) => {
   const requestId = getRequestId(event);
@@ -141,54 +104,52 @@ export const POST: RequestHandler = async (event) => {
     return errorResponse(400, 'bad_request', 'value must be non-empty; use DELETE to remove a key', {}, requestId);
   }
 
-  // 1. Write to user.env (compose runtime source of truth).
+  let written = false;
+  let writeError: string | undefined;
   try {
-    writeUserEnvKey(state.vaultDir, key, value);
+    written = await writeAkmVaultKey(state, key, value);
+    if (!written) writeError = 'akm_unavailable';
   } catch (err) {
-    appendAudit(state, actor, 'secrets.user-vault.write', { key, error: String(err) }, false, requestId, callerType);
-    return errorResponse(500, 'internal_error', 'Failed to update user.env', {}, requestId);
+    written = false;
+    writeError = err instanceof Error ? err.message : String(err);
+    // Never log the value. The key name is fine — operators need to see
+    // which entry failed when debugging from logs.
+    logger.warn('akm vault set failed', { key, reason: writeError, requestId });
   }
 
-  // 2. Mirror into the akm vault file by writing directly (no argv exposure).
-  let mirrored = false;
-  let mirrorError: string | undefined;
-  try {
-    mirrored = await writeAkmVaultKey(state, key, value);
-    if (!mirrored) mirrorError = 'akm_unavailable';
-  } catch (err) {
-    mirrored = false;
-    mirrorError = err instanceof Error ? err.message : String(err);
-  }
-
-  if (!mirrored) {
-    // Divergence is recoverable (re-running upgrade re-mirrors) but
-    // operators need to see it. Never log the value.
-    logger.warn('akm vault write failed; user.env and akm vault are diverged', {
-      key,
-      reason: mirrorError,
+  if (!written) {
+    appendAudit(
+      state,
+      actor,
+      'secrets.user-vault.write',
+      { key, error: writeError ?? 'unknown' },
+      false,
       requestId,
-    });
+      callerType,
+    );
+    return errorResponse(
+      503,
+      'akm_unavailable',
+      `Failed to write to akm vault: ${writeError ?? 'unknown error'}`,
+      {},
+      requestId,
+    );
   }
 
   appendAudit(
     state,
     actor,
     'secrets.user-vault.write',
-    { key, mirrored, ...(mirrorError ? { mirrorError } : {}) },
+    { key },
     true,
     requestId,
     callerType,
   );
 
-  return jsonResponse(200, {
-    ok: true,
-    key,
-    mirrored,
-    ...(mirrorError ? { error: mirrorError } : {}),
-  }, requestId);
+  return jsonResponse(200, { ok: true, key }, requestId);
 };
 
-/** DELETE — remove a key from both the akm vault and user.env. */
+/** DELETE — remove a key from the akm vault. */
 export const DELETE: RequestHandler = async (event) => {
   const requestId = getRequestId(event);
   const authError = requireAdmin(event, requestId);
@@ -202,48 +163,45 @@ export const DELETE: RequestHandler = async (event) => {
     return errorResponse(400, 'bad_request', 'valid key query parameter is required', {}, requestId);
   }
 
-  // 1. Remove from user.env entirely (clean semantics — no empty-valued
-  //    stub line left behind for GET to filter out).
+  let removed = false;
+  let removeError: string | undefined;
   try {
-    removeUserEnvKey(state.vaultDir, key);
+    removed = await deleteAkmVaultKey(state, key);
+    if (!removed) removeError = 'akm_unavailable';
   } catch (err) {
-    appendAudit(state, actor, 'secrets.user-vault.remove', { key, error: String(err) }, false, requestId, callerType);
-    return errorResponse(500, 'internal_error', 'Failed to update user.env', {}, requestId);
+    removed = false;
+    removeError = err instanceof Error ? err.message : String(err);
+    logger.warn('akm vault unset failed', { key, reason: removeError, requestId });
   }
 
-  // 2. Drop from akm vault file directly (no argv exposure).
-  let mirrored = false;
-  let mirrorError: string | undefined;
-  try {
-    mirrored = await deleteAkmVaultKey(state, key);
-    if (!mirrored) mirrorError = 'akm_unavailable';
-  } catch (err) {
-    mirrored = false;
-    mirrorError = err instanceof Error ? err.message : String(err);
-  }
-
-  if (!mirrored) {
-    logger.warn('akm vault delete failed; user.env and akm vault are diverged', {
-      key,
-      reason: mirrorError,
+  if (!removed) {
+    appendAudit(
+      state,
+      actor,
+      'secrets.user-vault.remove',
+      { key, error: removeError ?? 'unknown' },
+      false,
       requestId,
-    });
+      callerType,
+    );
+    return errorResponse(
+      503,
+      'akm_unavailable',
+      `Failed to remove key from akm vault: ${removeError ?? 'unknown error'}`,
+      {},
+      requestId,
+    );
   }
 
   appendAudit(
     state,
     actor,
     'secrets.user-vault.remove',
-    { key, mirrored, ...(mirrorError ? { mirrorError } : {}) },
+    { key },
     true,
     requestId,
     callerType,
   );
 
-  return jsonResponse(200, {
-    ok: true,
-    key,
-    mirrored,
-    ...(mirrorError ? { error: mirrorError } : {}),
-  }, requestId);
+  return jsonResponse(200, { ok: true, key }, requestId);
 };

--- a/packages/admin/src/routes/admin/secrets/user-vault/server.vitest.ts
+++ b/packages/admin/src/routes/admin/secrets/user-vault/server.vitest.ts
@@ -1,9 +1,51 @@
-import { afterEach, beforeEach, describe, expect, test } from 'vitest';
+/**
+ * Tests for the /admin/secrets/user-vault route.
+ *
+ * Phase 2 of #388 (closes #406): the route operates on the akm `vault:user`
+ * store directly. The legacy `vault/user/user.env` mirror is gone — writes
+ * go straight to akm via `akm vault set` (stdin mode), and deletes call
+ * `akm vault unset`.
+ *
+ * The akm-vault library helpers spawn the real `akm` binary via `Bun.spawn`,
+ * which is unavailable inside vitest's Node worker pool. We therefore mock
+ * the helpers exposed by `@openpalm/lib` and assert behavior against an
+ * in-memory vault. End-to-end coverage that exercises the real akm binary
+ * lives in `packages/lib/src/control-plane/akm-vault.test.ts` (run under
+ * `bun test`).
+ */
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import { join } from 'node:path';
-import { mkdirSync, readFileSync, rmSync, writeFileSync, existsSync } from 'node:fs';
+import { mkdirSync, rmSync } from 'node:fs';
 import { randomBytes } from 'node:crypto';
 import { tmpdir } from 'node:os';
-import { execFileSync } from 'node:child_process';
+
+// In-memory akm vault state shared by the mocked helpers below. Each test
+// resets the map in beforeEach so writes from one test cannot leak into
+// another.
+const mockAkmVault = new Map<string, string>();
+let mockAkmAvailable = true;
+let mockVaultPath: string | null = null;
+
+vi.mock('@openpalm/lib', async () => {
+  const actual = await vi.importActual<typeof import('@openpalm/lib')>('@openpalm/lib');
+  return {
+    ...actual,
+    AKM_USER_VAULT_REF: 'vault:user',
+    ensureAkmUserVault: vi.fn(async () => (mockAkmAvailable ? mockVaultPath : null)),
+    readAkmUserVaultFile: vi.fn(() => Object.fromEntries(mockAkmVault)),
+    writeAkmVaultKey: vi.fn(async (_state: unknown, key: string, value: string) => {
+      if (!mockAkmAvailable) return false;
+      mockAkmVault.set(key, value);
+      return true;
+    }),
+    deleteAkmVaultKey: vi.fn(async (_state: unknown, key: string) => {
+      if (!mockAkmAvailable) return false;
+      mockAkmVault.delete(key);
+      return true;
+    }),
+  };
+});
+
 import { getState } from '$lib/server/state.js';
 import { resetState } from '$lib/server/test-helpers.js';
 import { GET, POST, DELETE } from './+server.js';
@@ -27,17 +69,6 @@ function makeEvent(method: string, path: string, body?: Record<string, unknown>,
   } as Parameters<typeof GET>[0];
 }
 
-function hasAkm(): boolean {
-  try {
-    execFileSync('akm', ['--version'], { stdio: 'ignore' });
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-const AKM_AVAILABLE = hasAkm();
-
 let rootDir = '';
 let originalHome: string | undefined;
 
@@ -54,6 +85,11 @@ beforeEach(() => {
   mkdirSync(state.dataDir, { recursive: true });
   mkdirSync(join(state.dataDir, 'stash'), { recursive: true });
   mkdirSync(state.logsDir, { recursive: true });
+
+  // Reset the mocked akm vault state to a fresh, available, empty store.
+  mockAkmVault.clear();
+  mockAkmAvailable = true;
+  mockVaultPath = join(state.dataDir, 'stash', 'vaults', 'user.env');
 });
 
 afterEach(() => {
@@ -67,14 +103,18 @@ describe('admin user-vault route', () => {
     expect(res.status).toBe(401);
   });
 
-  test('GET lists user.env keys without exposing values', async () => {
-    const state = getState();
-    writeFileSync(join(state.vaultDir, 'user', 'user.env'), 'CUSTOM_KEY=v1\nOTHER_KEY=v2\n');
+  test('GET lists akm vault keys without exposing values', async () => {
+    // Phase 2 of #388: the GET endpoint enumerates keys from the akm
+    // vault:user store, NOT from a legacy `vault/user/user.env` file.
+    mockAkmVault.set('CUSTOM_KEY', 'v1');
+    mockAkmVault.set('OTHER_KEY', 'v2');
 
     const res = await GET(makeEvent('GET', '/admin/secrets/user-vault'));
     expect(res.status).toBe(200);
-    const body = await res.json() as { keys: string[]; vaultRef: string };
+    const body = await res.json() as { keys: string[]; vaultRef: string; provider: string; available: boolean };
+    expect(body.provider).toBe('akm');
     expect(body.vaultRef).toBe('vault:user');
+    expect(body.available).toBe(true);
     expect(body.keys).toContain('CUSTOM_KEY');
     expect(body.keys).toContain('OTHER_KEY');
     // The response body must not contain any of the values.
@@ -83,23 +123,45 @@ describe('admin user-vault route', () => {
     expect(raw).not.toContain('v2');
   });
 
-  test('POST writes a key to user.env and reports mirror status', async () => {
+  test('GET reports vault unavailable when akm is missing', async () => {
+    mockAkmAvailable = false;
+    mockVaultPath = null;
+
+    const res = await GET(makeEvent('GET', '/admin/secrets/user-vault'));
+    expect(res.status).toBe(200);
+    const body = await res.json() as { keys: string[]; available: boolean };
+    expect(body.available).toBe(false);
+    expect(body.keys).toEqual([]);
+  });
+
+  test('POST writes a key to the akm vault', async () => {
+    // Phase 2 of #388: POST routes through `akm vault set` (stdin mode).
+    // The value never appears on argv. Here we assert the value lands in
+    // the in-memory vault store via the mocked helper.
     const res = await POST(makeEvent('POST', '/admin/secrets/user-vault', {
       key: 'CUSTOM_TOKEN',
       value: 'secret-payload',
     }));
     expect(res.status).toBe(200);
-    const body = await res.json() as { ok: boolean; key: string; mirrored: boolean };
+    const body = await res.json() as { ok: boolean; key: string };
     expect(body.ok).toBe(true);
     expect(body.key).toBe('CUSTOM_TOKEN');
-    // Whether mirror succeeded depends on akm availability — only the
-    // user.env write must succeed unconditionally.
-    expect(typeof body.mirrored).toBe('boolean');
 
-    const state = getState();
-    const content = readFileSync(join(state.vaultDir, 'user', 'user.env'), 'utf-8');
-    expect(content).toContain('CUSTOM_TOKEN=');
-    expect(content).toContain('secret-payload');
+    // The key/value MUST have landed in the akm vault.
+    expect(mockAkmVault.get('CUSTOM_TOKEN')).toBe('secret-payload');
+  });
+
+  test('POST returns 503 when akm is unavailable', async () => {
+    mockAkmAvailable = false;
+    mockVaultPath = null;
+
+    const res = await POST(makeEvent('POST', '/admin/secrets/user-vault', {
+      key: 'CUSTOM_TOKEN',
+      value: 'secret-payload',
+    }));
+    expect(res.status).toBe(503);
+    const body = await res.json() as { error: string };
+    expect(body.error).toBe('akm_unavailable');
   });
 
   test('POST rejects invalid key', async () => {
@@ -118,23 +180,23 @@ describe('admin user-vault route', () => {
     expect(res.status).toBe(400);
   });
 
-  test('DELETE removes a key from user.env entirely', async () => {
-    const state = getState();
-    writeFileSync(join(state.vaultDir, 'user', 'user.env'), 'KEEP_ME=ok\nDROP_ME=bye\n');
+  test('DELETE removes a key from the akm vault entirely', async () => {
+    // Phase 2 of #388: DELETE routes through `akm vault unset`. The key is
+    // expected to disappear from subsequent reads, not linger as an
+    // empty-value entry.
+    mockAkmVault.set('KEEP_ME', 'ok');
+    mockAkmVault.set('DROP_ME', 'bye');
 
     const res = await DELETE(makeEvent('DELETE', '/admin/secrets/user-vault?key=DROP_ME'));
     expect(res.status).toBe(200);
 
-    const content = readFileSync(join(state.vaultDir, 'user', 'user.env'), 'utf-8');
-    expect(content).toContain('KEEP_ME=ok');
-    // Removed line must not appear at all (clean semantics so subsequent
-    // GETs don't list a phantom empty-value key).
-    expect(content).not.toMatch(/^DROP_ME=/m);
+    expect(mockAkmVault.has('KEEP_ME')).toBe(true);
+    expect(mockAkmVault.has('DROP_ME')).toBe(false);
   });
 
   test('DELETE followed by GET no longer lists the key', async () => {
-    const state = getState();
-    writeFileSync(join(state.vaultDir, 'user', 'user.env'), 'KEEP_ME=ok\nDROP_ME=bye\n');
+    mockAkmVault.set('KEEP_ME', 'ok');
+    mockAkmVault.set('DROP_ME', 'bye');
     await DELETE(makeEvent('DELETE', '/admin/secrets/user-vault?key=DROP_ME'));
 
     const listRes = await GET(makeEvent('GET', '/admin/secrets/user-vault'));
@@ -143,13 +205,11 @@ describe('admin user-vault route', () => {
     expect(body.keys).not.toContain('DROP_ME');
   });
 
-  test.skipIf(!AKM_AVAILABLE)('writes are visible to akm vault list after POST', async () => {
-    const res = await POST(makeEvent('POST', '/admin/secrets/user-vault', {
-      key: 'AKM_INTEGRATION_TEST_KEY',
-      value: 'roundtrip-value-' + randomBytes(4).toString('hex'),
-    }));
-    expect(res.status).toBe(200);
-    const body = await res.json() as { mirrored: boolean };
-    expect(body.mirrored).toBe(true);
+  test('DELETE returns 503 when akm is unavailable', async () => {
+    mockAkmAvailable = false;
+    mockVaultPath = null;
+
+    const res = await DELETE(makeEvent('DELETE', '/admin/secrets/user-vault?key=DROP_ME'));
+    expect(res.status).toBe(503);
   });
 });

--- a/packages/assistant-tools/opencode/tools/load_vault.ts
+++ b/packages/assistant-tools/opencode/tools/load_vault.ts
@@ -1,17 +1,16 @@
 import { tool } from "@opencode-ai/plugin";
 import { readFile, access } from "fs/promises";
-import { existsSync } from "fs";
 
 /**
- * Legacy compose-mounted path. Phase 1 of #388 keeps this as the
- * fallback while the akm secret store mirror catches up; Phase 2
- * (tracked in #406) will retire the bind mount and route entirely
- * through akm.
+ * `vault:user` is the akm-cli ref for the user-managed env vault. Phase 2
+ * of issue #388 (closed by #406) retired the legacy
+ * `${OP_HOME}/vault/user → /etc/vault` compose mount; the assistant
+ * entrypoint now sources the akm vault file directly at container start,
+ * so most callers never need this tool. It remains useful for re-loading
+ * after the operator updates a key via the admin UI, and for `prefix`-
+ * scoped reads.
  */
-const FALLBACK_VAULT_PATH = "/etc/vault/user.env";
 const AKM_USER_VAULT_REF = "vault:user";
-
-type VaultSource = "akm" | "fallback";
 
 export function parseEnvContent(
   content: string,
@@ -53,44 +52,42 @@ export function parseEnvContent(
 }
 
 /**
- * Resolve the user vault file path. Phase 1 of #388: prefer the
- * shared akm store (`vault:user`) so editing through the admin UI
- * immediately reflects on the next call. If the akm CLI is missing
- * or the vault has not been provisioned yet, fall back to the
- * Compose-mounted .env file.
- *
- * We `existsSync`-guard the akm-resolved path so a stale ref (e.g. the
- * vault file was deleted out from under akm) cleanly falls through to
- * the bind-mount fallback instead of returning a non-existent path.
+ * Resolve the akm `vault:user` file path. The legacy `/etc/vault/user.env`
+ * fallback was retired in Phase 2 of #388 — there is no other location to
+ * try. If akm is missing, the vault is unprovisioned, or the path it
+ * returns no longer exists, this returns `null` and the tool reports an
+ * actionable error to the caller.
  */
-async function resolveVaultPath(): Promise<{ path: string; source: VaultSource }> {
+async function resolveVaultPath(): Promise<string | null> {
   try {
-    // Bun.spawn keeps us off node:child_process + util.promisify here.
-    // We need stdout text, so capture it as a pipe and decode on success.
     const proc = Bun.spawn(["akm", "vault", "path", AKM_USER_VAULT_REF], {
       stdout: "pipe",
       stderr: "ignore",
     });
     const stdout = await new Response(proc.stdout).text();
     const exitCode = await proc.exited;
-    if (exitCode === 0) {
-      const path = stdout.trim();
-      if (path && existsSync(path)) return { path, source: "akm" };
+    if (exitCode !== 0) return null;
+    const path = stdout.trim();
+    if (!path) return null;
+    try {
+      await access(path);
+      return path;
+    } catch {
+      return null;
     }
   } catch {
-    // akm not on PATH or vault missing — fall through to legacy file
+    return null;
   }
-  return { path: FALLBACK_VAULT_PATH, source: "fallback" };
 }
 
 export default tool({
   description:
     "Load user vault secrets into the running process. Returns only the " +
-    "variable names that were loaded — never the values. Prefers the " +
-    "shared akm vault `vault:user` (resolved via `akm vault path`) and " +
-    "falls back to `/etc/vault/user.env` when akm is unavailable. This is " +
-    "the primary way to load API keys, owner info, and other user-configured " +
-    "secrets. Use load_env only for ad-hoc .env files under /work.",
+    "variable names that were loaded — never the values. Reads from the " +
+    "shared akm vault `vault:user` (resolved via `akm vault path`). The " +
+    "assistant entrypoint already sources this vault at container startup, " +
+    "so call this tool only when you need to pick up a key the operator " +
+    "added after the assistant started, or to apply a `prefix` filter.",
   args: {
     override: tool.schema
       .boolean()
@@ -103,18 +100,14 @@ export default tool({
       .describe("Only load vars whose name starts with this prefix"),
   },
   async execute(args) {
-    const { path: vaultPath, source } = await resolveVaultPath();
-    // Symbolic label exposed to the LLM. We deliberately do NOT return
-    // the absolute filesystem path — the model never needs it, and the
-    // stash path can leak operator-side filesystem layout.
-    const sourceLabel = source === "akm" ? "akm:vault:user" : "fallback:/etc/vault";
-
-    try {
-      await access(vaultPath);
-    } catch {
+    const vaultPath = await resolveVaultPath();
+    if (!vaultPath) {
       return JSON.stringify({
         error: true,
-        message: `Vault file not found (source=${sourceLabel})`,
+        message:
+          "akm vault `vault:user` not available — the assistant entrypoint " +
+          "should have sourced it at startup. Check that akm-cli is installed " +
+          "and that the operator has populated the vault via the admin UI.",
       });
     }
 
@@ -124,7 +117,7 @@ export default tool({
     } catch (err: unknown) {
       return JSON.stringify({
         error: true,
-        message: `Failed to read vault file (source=${sourceLabel})`,
+        message: "Failed to read akm vault file (source=akm:vault:user)",
         detail: err instanceof Error ? err.message : String(err),
       });
     }
@@ -135,7 +128,7 @@ export default tool({
     });
 
     return JSON.stringify({
-      source: sourceLabel,
+      source: "akm:vault:user",
       loaded,
       skipped,
       message:

--- a/packages/cli/src/commands/install.ts
+++ b/packages/cli/src/commands/install.ts
@@ -131,7 +131,11 @@ export async function bootstrapInstall(options: InstallOptions): Promise<void> {
   const dataDir = resolveDataDir();
   const workDir = defaultWorkDir();
 
-  const alreadyInstalled = await Bun.file(join(vaultDir, 'user', 'user.env')).exists();
+  // Phase 2 of #388 (closes #406): user.env is no longer the install
+  // marker — fresh installs never create it, and upgrades delete it after
+  // migration into akm. Use vault/stack/stack.env (always present after a
+  // successful install) as the canonical "already installed" indicator.
+  const alreadyInstalled = await Bun.file(join(vaultDir, 'stack', 'stack.env')).exists();
   if (alreadyInstalled && !options.force) {
     throw new Error('OpenPalm appears to already be installed. Re-run install with --force to continue.');
   }

--- a/packages/cli/src/install-flow.test.ts
+++ b/packages/cli/src/install-flow.test.ts
@@ -204,16 +204,22 @@ describe('install flow — tier 1 (file validation)', () => {
     expect(existsSync(join(homeDir, 'registry/automations/cleanup-logs.yml'))).toBe(true);
 
     // ── Validate vault files are regular files (not directories) ─────
+    // Phase 2 of #388 (closes #406): vault/user/user.env is no longer
+    // seeded — user-managed env secrets live in akm vault:user
+    // (data/stash/vaults/user.env) and the assistant entrypoint sources
+    // it directly. The compose env_file mount for vault/user/user.env
+    // has been removed too.
     for (const relPath of [
       'vault/stack/stack.env',
       'vault/stack/guardian.env',
       'vault/stack/auth.json',
-      'vault/user/user.env',
     ]) {
       const fullPath = join(homeDir, relPath);
       expect(existsSync(fullPath)).toBe(true);
       expect(statSync(fullPath).isFile()).toBe(true);
     }
+    // Confirm user.env is NOT present after a fresh setup.
+    expect(existsSync(join(homeDir, 'vault/user/user.env'))).toBe(false);
 
     // ── No legacy .env.schema files (removed in #391) ───────────────
     for (const relPath of [
@@ -335,13 +341,15 @@ describe('install flow — tier 1 (file validation)', () => {
     }
 
     // Run docker compose config --quiet
+    // Phase 2 of #388 (closes #406): vault/user/user.env is no longer a
+    // compose env_file. Only stack.env (and guardian.env, when present)
+    // are passed to compose.
     const proc = Bun.spawnSync([
       'docker', 'compose', '--project-name', 'openpalm-test',
       '-f', composeFiles[0],
       '-f', composeFiles[1],
       '-f', composeFiles[2],
       '--env-file', stackEnv,
-      '--env-file', join(homeDir, 'vault/user/user.env'),
       'config', '--quiet',
     ], { stdout: 'pipe', stderr: 'pipe', env: { ...process.env, OP_HOME: homeDir } });
 
@@ -428,12 +436,13 @@ describe('install flow — tier 1 (file validation)', () => {
     expect(noAddonSpec).not.toBeNull();
 
     // Core compose only, no addon files in the compose list
+    // Phase 2 of #388 (closes #406): vault/user/user.env is no longer a
+    // compose env_file. Only stack.env is needed for `compose config`.
     const stackEnv = join(homeDir, 'vault/stack/stack.env');
     const proc = Bun.spawnSync([
       'docker', 'compose', '--project-name', 'openpalm-test',
       '-f', join(homeDir, 'stack/core.compose.yml'),
       '--env-file', stackEnv,
-      '--env-file', join(homeDir, 'vault/user/user.env'),
       'config', '--services',
     ], { stdout: 'pipe', stderr: 'pipe' });
 

--- a/packages/cli/src/lib/env.ts
+++ b/packages/cli/src/lib/env.ts
@@ -57,30 +57,15 @@ export function reconcileStackEnvImageTag(
 }
 
 /**
- * Seeds vault/user/user.env with initial template.
- * Uses `export` prefix so the file can be sourced in a shell and is still
- * compatible with Docker Compose v2 `env_file`.
- * Contains user-managed custom env vars only (the seeded user.env is empty
- * by default). System secrets (OP_ADMIN_TOKEN, OP_ASSISTANT_TOKEN)
- * live in vault/stack/stack.env and are managed by the control plane.
+ * Ensures vault/user exists. Phase 2 of #388 (closes #406): the
+ * `user.env` file is no longer seeded — user-managed env secrets live in
+ * the akm `vault:user` store and are sourced by the assistant entrypoint
+ * directly. The directory itself is still created because operational
+ * files (apprise.yml, gcloud creds, gws/mgc auth dirs) bind-mount from
+ * here into the assistant container at /etc/vault/.
  */
 export async function ensureSecrets(vaultDir: string): Promise<void> {
-  const secretsPath = join(vaultDir, 'user', 'user.env');
-  if (await Bun.file(secretsPath).exists()) {
-    return;
-  }
-
   mkdirSync(join(vaultDir, 'user'), { recursive: true });
-  // user.env is for user-added custom env vars only.
-  // All standard secrets (API keys, tokens) live in stack.env.
-  // Do NOT put API key placeholders here — user.env is loaded after
-  // stack.env by Docker Compose, so empty values would override real keys.
-  const content = `# OpenPalm — User Extensions
-# Add any custom environment variables here.
-# These are loaded by compose alongside stack.env.
-`;
-
-  await Bun.write(secretsPath, content);
 }
 
 /**

--- a/packages/cli/src/main.test.ts
+++ b/packages/cli/src/main.test.ts
@@ -260,12 +260,20 @@ describe('cli main', () => {
     const base = mkdtempSync(join(tmpdir(), 'openpalm-install-force-'));
     const workDir = join(base, 'work');
     const userEnv = join(base, 'vault', 'user', 'user.env');
+    const stackEnv = join(base, 'vault', 'stack', 'stack.env');
     const stackConfig = join(base, 'config', 'stack.yml');
     const specFile = writeMinimalSetupSpec(base);
 
+    // Phase 2 of #388 (closes #406): the canonical "already installed"
+    // marker is now vault/stack/stack.env (user.env may be absent on a
+    // fresh Phase 2 install). Seed both files so the backup path triggers
+    // AND we can prove the backup carries forward legacy user.env content
+    // from pre-Phase-2 hosts that still have it on disk.
     mkdirSync(join(base, 'vault', 'user'), { recursive: true });
+    mkdirSync(join(base, 'vault', 'stack'), { recursive: true });
     mkdirSync(join(base, 'config'), { recursive: true });
     writeFileSync(userEnv, 'EXISTING=1\n');
+    writeFileSync(stackEnv, 'OP_ADMIN_TOKEN=existing-token\n');
     writeFileSync(stackConfig, 'llm: old\n');
 
     process.env.OP_HOME = base;
@@ -616,7 +624,12 @@ describe('cli entrypoint (subprocess)', () => {
 });
 
 describe('secrets.env generation', () => {
-  it('generates user.env as empty placeholder (no API key placeholders)', async () => {
+  it('does NOT seed vault/user/user.env on fresh install (Phase 2 of #388)', async () => {
+    // Phase 2 of #388 (closes #406): user-managed env secrets now live
+    // in the akm vault:user store at `${dataDir}/stash/vaults/user.env`.
+    // Fresh installs MUST NOT create `vault/user/user.env` — leaving an
+    // empty placeholder would shadow the akm-sourced values via compose
+    // env_file precedence and is the bug Phase 2 was designed to remove.
     const { ensureSecrets } = await import('./lib/env.ts');
     const tempDir = mkdtempSync(join(tmpdir(), 'openpalm-secrets-'));
     const vaultDir = join(tempDir, 'vault');
@@ -624,13 +637,9 @@ describe('secrets.env generation', () => {
 
     try {
       await ensureSecrets(vaultDir);
-      const content = await Bun.file(join(vaultDir, 'user', 'user.env')).text();
-      // user.env is for user-added custom vars only — no API key placeholders
-      // (empty values would override real keys in stack.env via compose env-file precedence)
-      expect(content).not.toContain('OPENAI_API_KEY');
-      expect(content).not.toContain('OP_ADMIN_TOKEN');
-      expect(content).not.toContain('OP_ASSISTANT_TOKEN');
-      expect(content).toContain('User Extensions');
+      // The vault/user directory may exist (other operational files live
+      // here, e.g. apprise.yml) but user.env itself must not be created.
+      expect(await Bun.file(join(vaultDir, 'user', 'user.env')).exists()).toBe(false);
     } finally {
       rmSync(tempDir, { recursive: true, force: true });
     }

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -26,5 +26,8 @@
     "croner": "^9.0.0",
     "dotenv": "^16.4.7",
     "yaml": "^2.8.0"
+  },
+  "devDependencies": {
+    "@types/bun": "^1.0.0"
   }
 }

--- a/packages/lib/src/control-plane/akm-vault.test.ts
+++ b/packages/lib/src/control-plane/akm-vault.test.ts
@@ -1,28 +1,28 @@
 /**
- * Tests for the akm vault mirror (Phase 1 of #388).
+ * Tests for the akm vault mirror — Phase 2 of #388 (closes #406).
  *
- * The full mirror requires the `akm` CLI on PATH plus a writable shared
- * stash directory. Tests gate on those conditions so the suite stays
- * green in environments without akm installed. The pure logic (env
- * file enumeration, idempotency diff) is covered unconditionally.
+ * The mirror now spawns `akm vault set <ref> <key>` and feeds the secret
+ * VALUE on stdin (akm-cli >= 0.8.0). After mirror, the legacy
+ * `vault/user/user.env` is deleted by `migrateAndCleanupLegacyUserEnv`
+ * once every key is verified present in the akm vault.
  *
- * CI coverage gap: the gated tests `it.skipIf(!AKM_AVAILABLE)` skip
- * silently when akm is not on PATH. CI does not install akm today, so
- * these branches are exercised only by local developers. Follow-up
- * tracked in the PR body.
+ * Tests gate on the akm CLI being on PATH so the suite stays green in
+ * environments without akm installed. The pure logic (env file
+ * enumeration, idempotency diff, argv-leak guard, cleanup pre-conditions)
+ * is covered unconditionally via Bun.spawn stubs.
  */
-import { describe, expect, it, beforeEach, afterEach, spyOn } from "bun:test";
-import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync, readFileSync } from "node:fs";
+import { describe, expect, it, beforeEach, afterEach } from "bun:test";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { execFileSync } from "node:child_process";
-import * as childProcess from "node:child_process";
 import {
   mirrorUserVaultToAkm,
   ensureAkmUserVault,
   readAkmUserVaultFile,
   writeAkmVaultKey,
   deleteAkmVaultKey,
+  migrateAndCleanupLegacyUserEnv,
   AKM_USER_VAULT_REF,
 } from "./akm-vault.js";
 import type { ControlPlaneState } from "./types.js";
@@ -93,15 +93,14 @@ describe("mirrorUserVaultToAkm", () => {
   });
 
   it.skipIf(!AKM_AVAILABLE)("migrates a fake 0.10.x layout idempotently (upgrade-path contract)", async () => {
-    // Seed a pre-0.11 vault/user/user.env layout — this is exactly the
-    // shape `applyUpgrade()` sees on the first 0.10.x → 0.11 upgrade.
+    // Seed a pre-0.11 vault/user/user.env layout — exactly the shape
+    // `applyUpgrade()` sees on the first 0.10.x → 0.11 upgrade.
     writeFileSync(
       join(state.vaultDir, "user", "user.env"),
       "# legacy 0.10.x layout\nGROQ_API_KEY=xyz-test-value-1\nOWNER_NAME=Alice\n",
     );
 
-    // First mirror — should write the keys (this is the operation
-    // `applyUpgrade()` performs after `refreshCoreAssets`+`reconcileCore`).
+    // First mirror — should write the keys via `akm vault set` (stdin mode).
     const first = await mirrorUserVaultToAkm(state);
     expect(first.ok).toBe(true);
     expect(first.skipped).toBe(false);
@@ -118,14 +117,11 @@ describe("mirrorUserVaultToAkm", () => {
       expect(stored.OWNER_NAME).toBe("Alice");
     }
 
-    // The source .env file MUST still exist (Phase 1 keeps both in sync
-    // — Compose env_file consumption stays on user.env until Phase 2).
+    // The source .env file is still on disk — `mirrorUserVaultToAkm` is
+    // mirror-only. `migrateAndCleanupLegacyUserEnv` performs the delete.
     expect(existsSync(join(state.vaultDir, "user", "user.env"))).toBe(true);
-    expect(readFileSync(join(state.vaultDir, "user", "user.env"), "utf-8"))
-      .toContain("GROQ_API_KEY=xyz-test-value-1");
 
-    // Second mirror — every key should now be reported as unchanged
-    // (proves the upgrade is idempotent on re-run).
+    // Second mirror — every key reported as unchanged (idempotent).
     const second = await mirrorUserVaultToAkm(state);
     expect(second.ok).toBe(true);
     expect(second.skipped).toBe(false);
@@ -160,10 +156,6 @@ describe("mirrorUserVaultToAkm", () => {
     // surrounding test timed out. This test pins the contract: even with a
     // permanently-pending child, the mirror must abort fast and report a
     // skip rather than hang.
-    //
-    // We stub `Bun.spawn` (the actual primitive under `child_process.execFile`
-    // in the Bun runtime) the same way `packages/cli/src/main.test.ts`
-    // `mockDockerCli` does, to faithfully reproduce the original failure mode.
     writeFileSync(
       join(state.vaultDir, "user", "user.env"),
       "STUCK_CHECK=value-1\n",
@@ -202,54 +194,56 @@ describe("mirrorUserVaultToAkm", () => {
     }
   });
 
-  it.skipIf(!AKM_AVAILABLE)("never passes secret values via execFile argv (no /proc/cmdline leak)", async () => {
-    // This is the regression test for the security finding on PR #404.
-    // Spy on execFile and assert no call contains the secret value.
+  it.skipIf(!AKM_AVAILABLE)("never passes secret values via Bun.spawn argv (no /proc/cmdline leak)", async () => {
+    // Phase 2 regression test for the security finding on PR #404. We now
+    // route every write through `akm vault set <ref> <key>` with the value
+    // delivered on stdin. Wrap Bun.spawn with a spy that records every
+    // argv it sees while delegating to the real akm binary, then assert
+    // no secret appeared on argv and that the value did transit through
+    // the spawn `stdin: "pipe"` channel.
     const secret = "secret-payload-12345-do-not-leak";
     writeFileSync(
       join(state.vaultDir, "user", "user.env"),
       `LEAK_CHECK_KEY=${secret}\n`,
     );
 
-    const calls: Array<{ command: string; args: readonly string[] }> = [];
-    const spy = spyOn(childProcess, "execFile").mockImplementation(
-      ((command: string, args: readonly string[], _options: unknown, cb?: unknown) => {
-        calls.push({ command, args });
-        // Fake `akm --version` so akmAvailable() returns true. For any
-        // other invocation, fake success with a stdout suitable for the
-        // caller (e.g. `vault path` returns the vault file path).
-        let stdout = "";
-        if (args[0] === "--version") {
-          stdout = "0.8.0\n";
-        } else if (args[0] === "vault" && args[1] === "path") {
-          stdout = `${state.dataDir}/stash/vaults/user.env\n`;
-        }
-        const callback = cb as ((err: unknown, result: { stdout: string; stderr: string }) => void) | undefined;
-        if (callback) callback(null, { stdout, stderr: "" });
-        return undefined as unknown as ReturnType<typeof childProcess.execFile>;
-      }) as typeof childProcess.execFile,
-    );
+    const argvCalls: Array<{ cmd: string; args: readonly string[] }> = [];
+    let stdinPiped = false;
+    const originalSpawn = Bun.spawn;
+    (Bun as unknown as { spawn: typeof Bun.spawn }).spawn = ((cmd: unknown, opts?: Record<string, unknown>) => {
+      const argv = Array.isArray(cmd) ? (cmd as string[]) : [String(cmd)];
+      argvCalls.push({ cmd: argv[0] ?? "", args: argv.slice(1) });
+      if (argv[0] === "akm" && argv[1] === "vault" && argv[2] === "set" && opts?.stdin === "pipe") {
+        stdinPiped = true;
+      }
+      return (originalSpawn as (...a: unknown[]) => unknown)(cmd, opts) as ReturnType<typeof Bun.spawn>;
+    }) as typeof Bun.spawn;
 
     try {
       const result = await mirrorUserVaultToAkm(state);
       expect(result.ok).toBe(true);
 
-      // No execFile call may include the secret value anywhere on argv.
-      for (const call of calls) {
+      // SECURITY ASSERTION: the secret value MUST NOT appear on any
+      // observed argv (including argv to akm or any subprocess akm
+      // itself spawned via the wrapped Bun.spawn).
+      for (const call of argvCalls) {
         for (const arg of call.args) {
           expect(arg).not.toContain(secret);
         }
       }
 
-      // The vault file should still have been written by the direct-write path.
+      // POSITIVE: at least one `akm vault set` invocation requested a
+      // stdin pipe — i.e. the value path used stdin, not argv.
+      expect(stdinPiped).toBe(true);
+
+      // The value still landed in the vault file (proves stdin actually
+      // delivered it end-to-end through the real akm binary).
       const vaultPath = `${state.dataDir}/stash/vaults/user.env`;
-      // Direct-write path created the file under stash; verify the value lives there.
-      if (existsSync(vaultPath)) {
-        const stored = readFileSync(vaultPath, "utf-8");
-        expect(stored).toContain(`LEAK_CHECK_KEY=${secret}`);
-      }
+      expect(existsSync(vaultPath)).toBe(true);
+      const stored = readAkmUserVaultFile(vaultPath);
+      expect(stored.LEAK_CHECK_KEY).toBe(secret);
     } finally {
-      spy.mockRestore();
+      (Bun as unknown as { spawn: typeof Bun.spawn }).spawn = originalSpawn;
     }
   });
 });
@@ -269,7 +263,7 @@ describe("writeAkmVaultKey", () => {
     rmSync(homeDir, { recursive: true, force: true });
   });
 
-  it.skipIf(!AKM_AVAILABLE)("writes a key to the akm vault file without invoking `akm vault set`", async () => {
+  it.skipIf(!AKM_AVAILABLE)("writes a key via `akm vault set` (stdin mode, no argv leak)", async () => {
     const value = "argv-free-secret-9988";
     const ok = await writeAkmVaultKey(state, "TOKEN", value);
     expect(ok).toBe(true);
@@ -282,7 +276,7 @@ describe("writeAkmVaultKey", () => {
     }
   });
 
-  it.skipIf(!AKM_AVAILABLE)("deleteAkmVaultKey removes a key", async () => {
+  it.skipIf(!AKM_AVAILABLE)("deleteAkmVaultKey removes a key via `akm vault unset`", async () => {
     await writeAkmVaultKey(state, "TOKEN_A", "value-a");
     await writeAkmVaultKey(state, "TOKEN_B", "value-b");
 
@@ -294,6 +288,103 @@ describe("writeAkmVaultKey", () => {
       const stored = readAkmUserVaultFile(vaultPath);
       expect(stored.TOKEN_A).toBeUndefined();
       expect(stored.TOKEN_B).toBe("value-b");
+    }
+  });
+
+  it.skipIf(!AKM_AVAILABLE)("deleteAkmVaultKey is idempotent on a missing key", async () => {
+    // Deleting a key that was never set should not throw — `akm vault unset`
+    // either exits 0 or emits a "not found" message we tolerate.
+    const ok = await deleteAkmVaultKey(state, "NEVER_SET_KEY");
+    expect(ok).toBe(true);
+  });
+});
+
+describe("migrateAndCleanupLegacyUserEnv", () => {
+  let homeDir: string;
+  let state: ControlPlaneState;
+
+  beforeEach(() => {
+    homeDir = mkdtempSync(join(tmpdir(), "openpalm-akm-cleanup-"));
+    state = makeState(homeDir);
+    mkdirSync(join(state.vaultDir, "user"), { recursive: true });
+    mkdirSync(join(state.dataDir, "stash"), { recursive: true });
+    mkdirSync(join(state.dataDir, "akm-cache"), { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(homeDir, { recursive: true, force: true });
+  });
+
+  it("reports already-absent when no legacy file exists", async () => {
+    const result = await migrateAndCleanupLegacyUserEnv(state);
+    expect(result.deleted).toBe(false);
+    expect(result.reason).toBe("user.env already absent");
+  });
+
+  it("deletes an empty placeholder user.env without invoking akm", async () => {
+    writeFileSync(join(state.vaultDir, "user", "user.env"), "# placeholder only\nEMPTY=\n");
+    const result = await migrateAndCleanupLegacyUserEnv(state);
+    expect(result.deleted).toBe(true);
+    expect(existsSync(join(state.vaultDir, "user", "user.env"))).toBe(false);
+  });
+
+  it.skipIf(!AKM_AVAILABLE)("end-to-end: mirror then cleanup deletes the legacy file", async () => {
+    writeFileSync(
+      join(state.vaultDir, "user", "user.env"),
+      "MIGRATE_KEY=migrated-value\nOWNER_NAME=Alice\n",
+    );
+
+    const mirror = await mirrorUserVaultToAkm(state);
+    expect(mirror.ok).toBe(true);
+    expect(mirror.written.sort()).toEqual(["MIGRATE_KEY", "OWNER_NAME"]);
+
+    const cleanup = await migrateAndCleanupLegacyUserEnv(state);
+    expect(cleanup.deleted).toBe(true);
+    expect(existsSync(join(state.vaultDir, "user", "user.env"))).toBe(false);
+
+    // The akm vault still has the migrated keys after cleanup.
+    const vaultPath = await ensureAkmUserVault(state);
+    expect(vaultPath).not.toBeNull();
+    if (vaultPath) {
+      const stored = readAkmUserVaultFile(vaultPath);
+      expect(stored.MIGRATE_KEY).toBe("migrated-value");
+      expect(stored.OWNER_NAME).toBe("Alice");
+    }
+  });
+
+  it("retains the legacy file when akm is unavailable (operator can re-run)", async () => {
+    writeFileSync(
+      join(state.vaultDir, "user", "user.env"),
+      "REAL_KEY=real-value\n",
+    );
+
+    // Stub Bun.spawn so akm appears unavailable.
+    const originalSpawn = Bun.spawn;
+    (Bun as unknown as { spawn: typeof Bun.spawn }).spawn = (() => ({
+      pid: 0,
+      exited: Promise.resolve(127),
+      exitCode: 127,
+      signalCode: null,
+      killed: false,
+      stdin: null,
+      stdout: new Response("").body,
+      stderr: new Response("akm: command not found").body,
+      kill: () => {},
+      ref: () => {},
+      unref: () => {},
+      [Symbol.asyncDispose]: async () => {},
+      resourceUsage: () => undefined,
+    })) as unknown as typeof Bun.spawn;
+
+    try {
+      const cleanup = await migrateAndCleanupLegacyUserEnv(state);
+      expect(cleanup.deleted).toBe(false);
+      expect(cleanup.reason).toBe("akm not on PATH");
+      // Legacy file MUST still exist so the upgrade is re-runnable once
+      // akm is fixed.
+      expect(existsSync(join(state.vaultDir, "user", "user.env"))).toBe(true);
+    } finally {
+      (Bun as unknown as { spawn: typeof Bun.spawn }).spawn = originalSpawn;
     }
   });
 });

--- a/packages/lib/src/control-plane/akm-vault.ts
+++ b/packages/lib/src/control-plane/akm-vault.ts
@@ -1,38 +1,27 @@
 /**
- * akm vault mirror — Phase 1 of issue #388.
+ * akm vault mirror — completes Phase 2 of issue #388.
  *
- * The runtime source of truth for user-scoped secrets remains
- * `${OP_HOME}/vault/user/user.env` (it is bind-mounted into containers
- * via `${OP_HOME}/vault/user → /etc/vault` and consumed by Docker Compose
- * as an env_file). For Phase 1 we additionally mirror those key/value
- * pairs into an akm-cli secret store at `vault:user`, residing in the
- * shared akm stash at `${OP_HOME}/data/stash`. This makes the same
- * secrets browsable from the assistant and admin UI through the existing
- * `akm vault list|path` interface.
- *
- * Phase 2 (deferred, tracked under a follow-up) will:
- *  - drop the `${OP_HOME}/vault/user → /etc/vault` compose mount
- *  - source the akm vault path from an entrypoint instead
- *  - delete `${OP_HOME}/vault/user/` after migration
+ * The akm-cli `vault:user` secret store at `${OP_HOME}/data/stash/vaults/user.env`
+ * is now the canonical home for user-managed environment secrets. The
+ * `${OP_HOME}/vault/user/user.env` file (the legacy compose env_file) is no
+ * longer mounted into containers — the assistant entrypoint sources the
+ * akm vault file directly. Migration on upgrade copies the legacy file into
+ * akm and then deletes it.
  *
  * NON-CHANGE: `vault/stack/stack.env` and `vault/stack/guardian.env` are
  * operator-managed and are NOT mirrored into akm. Migrating them would
  * break guardian's HMAC env_file hot-reload contract.
  *
- * SECURITY: This module never invokes `akm vault set|unset` with secret
- * values on the command line. `akm 0.8.x` accepts values via argv only,
- * which would leak through `/proc/<pid>/cmdline`. Instead we resolve the
- * vault file path via `akm vault create` + `akm vault path` and write
- * key/value pairs directly with `writeFileSync` + `mergeEnvContent`. The
- * resulting .env file format is byte-compatible with what `akm vault set`
- * would have produced (a plain `KEY=value` .env file), and `akm vault
- * list|run|path` continue to work against it unchanged.
+ * SECURITY: Every write into the akm vault is performed by spawning
+ * `akm vault set <ref> <key>` with the secret VALUE delivered via stdin
+ * (akm-cli >= 0.8.0). Values never appear in argv, so they cannot leak
+ * through `/proc/<pid>/cmdline`. The matching delete path uses
+ * `akm vault unset <ref> <key>` which is naturally argv-safe.
  */
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
-import { dirname } from "node:path";
+import { existsSync, readFileSync, unlinkSync } from "node:fs";
 import { execFile as execFileCb } from "node:child_process";
 import { promisify } from "node:util";
-import { mergeEnvContent, parseEnvFile, removeEnvKey } from "./env.js";
+import { parseEnvFile } from "./env.js";
 import { createLogger } from "../logger.js";
 import type { ControlPlaneState } from "./types.js";
 
@@ -77,10 +66,11 @@ export function buildAkmEnv(state: ControlPlaneState): NodeJS.ProcessEnv {
 
 /**
  * Per-invocation timeout (ms) for every akm subprocess we launch. The CLI is
- * a local binary and these probes (`--version`, `vault create`, `vault path`)
- * complete in well under a second on a healthy host; anything longer means
- * akm is wedged or unreachable. Bounding the call keeps `mirrorUserVaultToAkm`
- * truly best-effort: a stuck akm binary cannot block install/upgrade.
+ * a local binary and these probes (`--version`, `vault create`, `vault path`,
+ * `vault set/unset`) complete in well under a second on a healthy host;
+ * anything longer means akm is wedged or unreachable. Bounding the call
+ * keeps `mirrorUserVaultToAkm` truly best-effort: a stuck akm binary cannot
+ * block install/upgrade.
  *
  * Why a wall-clock race instead of execFile's built-in `timeout` option:
  * node's `child_process.execFile` in Bun is implemented on top of `Bun.spawn`,
@@ -154,54 +144,123 @@ export async function ensureAkmUserVault(state: ControlPlaneState): Promise<stri
 }
 
 /**
- * Write a single key/value into the akm `vault:user` store WITHOUT shelling
- * out to `akm vault set`. The akm vault file format is a plain `.env` file
- * at `<stash>/vaults/<name>.env`; writing directly with `mergeEnvContent`
- * produces a byte-identical result while keeping the secret out of argv
- * (and therefore out of `/proc/<pid>/cmdline`).
+ * Spawn `akm vault set <ref> <key>` and feed the secret VALUE via stdin.
+ * The value never crosses argv, so it cannot leak through
+ * `/proc/<pid>/cmdline`. Bounded by AKM_EXEC_TIMEOUT_MS — a stuck akm
+ * binary cannot block the calling install/upgrade flow.
+ */
+async function akmVaultSetViaStdin(
+  ref: string,
+  key: string,
+  value: string,
+  env: NodeJS.ProcessEnv,
+): Promise<void> {
+  // We use Bun.spawn directly because it supports an in-memory stdin pipe
+  // (a buffer/string stream) without dragging in an extra dependency, and
+  // because akm-cli on >= 0.8.0 reads the value from stdin when no
+  // positional `<value>` is provided. (The CLI silently switched stdin to
+  // the default in commit c50f9f4; explicit `--stdin` is still accepted
+  // for older binaries — but since we pin akm-cli >= 0.8.0-rc2 across all
+  // images via Dockerfile ARGs, the implicit form is enough.)
+  const child = Bun.spawn(["akm", "vault", "set", ref, key], {
+    env,
+    stdin: "pipe",
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  // Wall-clock bound. Mirrors the pattern in execAkm above.
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => {
+      try { child.kill(); } catch { /* best-effort */ }
+      reject(new Error(`akm vault set ${key} timed out after ${AKM_EXEC_TIMEOUT_MS}ms`));
+    }, AKM_EXEC_TIMEOUT_MS);
+    timer.unref?.();
+  });
+
+  try {
+    // Feed the secret. `child.stdin` is a FileSink in Bun — write+end then
+    // wait for exit. We don't use `await child.stdin.end(value)` because
+    // some Bun versions return undefined here; explicit write+end is portable.
+    if (child.stdin) {
+      // child.stdin is typed as FileSink in Bun
+      const sink = child.stdin as { write: (data: string) => unknown; end: () => unknown };
+      sink.write(value);
+      sink.end();
+    }
+    const exitCode = await Promise.race([child.exited, timeoutPromise]);
+    if (exitCode !== 0) {
+      const stderrText = child.stderr ? await new Response(child.stderr).text() : "";
+      throw new Error(`akm vault set ${key} failed (exit ${exitCode}): ${stderrText.trim()}`);
+    }
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+/**
+ * Write a single key/value into the akm `vault:user` store via
+ * `akm vault set <ref> <key>` with the value delivered on stdin.
  *
  * Returns `true` on success, `false` when akm is unavailable or the vault
- * path cannot be resolved. Throws only on filesystem write failures.
+ * could not be ensured. Throws on akm subprocess failures (non-zero exit
+ * with a captured stderr, or wall-clock timeout) so callers can surface
+ * the real error instead of silently dropping the write.
  */
 export async function writeAkmVaultKey(
   state: ControlPlaneState,
   key: string,
   value: string,
 ): Promise<boolean> {
+  const env = buildAkmEnv(state);
+  // ensureAkmUserVault already runs the availability probe. We re-check
+  // here to short-circuit before spawning the set process when akm is
+  // missing on PATH.
   const vaultPath = await ensureAkmUserVault(state);
   if (!vaultPath) return false;
-
-  mkdirSync(dirname(vaultPath), { recursive: true, mode: 0o700 });
-  const existing = existsSync(vaultPath) ? readFileSync(vaultPath, "utf-8") : "";
-  const merged = mergeEnvContent(existing, { [key]: value });
-  writeFileSync(vaultPath, merged.endsWith("\n") ? merged : merged + "\n", { mode: 0o600 });
+  await akmVaultSetViaStdin(AKM_USER_VAULT_REF, key, value, env);
   return true;
 }
 
 /**
- * Remove a key from the akm `vault:user` store. Mirrors `writeAkmVaultKey`
- * by editing the .env file directly rather than invoking `akm vault unset`.
- * Returns `true` if the operation completed (whether or not the key was
- * present), `false` when akm is unavailable.
+ * Remove a key from the akm `vault:user` store via `akm vault unset`.
+ * The key name is a normal identifier and crosses argv only — secret
+ * values are never involved. Returns `true` if the operation completed
+ * (whether or not the key was present), `false` when akm is unavailable.
  */
 export async function deleteAkmVaultKey(
   state: ControlPlaneState,
   key: string,
 ): Promise<boolean> {
+  const env = buildAkmEnv(state);
   const vaultPath = await ensureAkmUserVault(state);
   if (!vaultPath) return false;
-  if (!existsSync(vaultPath)) return true;
-
-  const existing = readFileSync(vaultPath, "utf-8");
-  const stripped = removeEnvKey(existing, key);
-  writeFileSync(vaultPath, stripped.endsWith("\n") ? stripped : stripped + "\n", { mode: 0o600 });
+  try {
+    await execAkm(["vault", "unset", AKM_USER_VAULT_REF, key], env);
+  } catch (err) {
+    // `unset` of a missing key is a benign no-op; many akm versions exit 0
+    // anyway. If akm hard-fails (non-zero, non-empty stderr) we surface it.
+    const message = err instanceof Error ? err.message : String(err);
+    // Heuristic: tolerate "not found" / "no such" messages so re-running
+    // delete on an already-deleted key stays idempotent for callers.
+    if (/not\s*found|no\s+such|does\s+not\s+exist/i.test(message)) {
+      logger.debug("akm vault unset reported missing key", { key, message });
+      return true;
+    }
+    throw err;
+  }
   return true;
 }
 
 /**
  * Idempotently mirror `${OP_HOME}/vault/user/user.env` into the akm
- * `vault:user` secret store. Keys that already match the source value are
- * left untouched so we never trigger a needless write or rewrite mtime.
+ * `vault:user` secret store. Keys whose value already matches the source
+ * are skipped so we never trigger a needless write or rewrite mtime.
+ *
+ * On Phase 2 (this PR), the legacy `user.env` file is the migration source
+ * only — once every key has landed in the akm vault, callers should
+ * delete it (see `migrateAndCleanupLegacyUserEnv` below).
  *
  * Returns a structured result describing what happened. Never throws on
  * akm errors — mirror is best-effort and must not block install/upgrade.
@@ -229,38 +288,28 @@ export async function mirrorUserVaultToAkm(state: ControlPlaneState): Promise<Mi
     return { ok: false, skipped: true, reason: "could not resolve vault path", written: [], unchanged: [] };
   }
 
-  // Read the current akm vault contents directly so we can diff before writing.
-  // `akm vault` stores values in a plain .env file at the path above; reading
-  // it here keeps the mirror an O(keys) operation with no subprocess fan-out.
+  // Diff against the existing vault file so we issue exactly one
+  // `akm vault set` per changed key. The vault file is a plain .env file
+  // produced by akm itself, so parseEnvFile() is the right parser.
   const existing = existsSync(vaultPath) ? parseEnvFile(vaultPath) : {};
 
   const written: string[] = [];
   const unchanged: string[] = [];
-  // Build the full updated content in one merge so we issue a single write.
-  const updates: Record<string, string> = {};
   for (const key of keys) {
     const value = sourceEntries[key];
     if (existing[key] === value) {
       unchanged.push(key);
       continue;
     }
-    updates[key] = value;
-    written.push(key);
-  }
-
-  if (written.length > 0) {
     try {
-      mkdirSync(dirname(vaultPath), { recursive: true, mode: 0o700 });
-      const currentContent = existsSync(vaultPath) ? readFileSync(vaultPath, "utf-8") : "";
-      const merged = mergeEnvContent(currentContent, updates);
-      writeFileSync(vaultPath, merged.endsWith("\n") ? merged : merged + "\n", { mode: 0o600 });
+      await akmVaultSetViaStdin(AKM_USER_VAULT_REF, key, value, env);
+      written.push(key);
     } catch (err) {
-      logger.warn("akm vault file write failed", {
-        vaultPath,
-        keyCount: written.length,
+      logger.warn("akm vault set failed", {
+        key,
         error: err instanceof Error ? err.message : String(err),
       });
-      return { ok: false, skipped: false, reason: "vault file write failed", written: [], unchanged };
+      return { ok: false, skipped: false, reason: "akm vault set failed", written, unchanged };
     }
   }
 
@@ -273,14 +322,78 @@ export async function mirrorUserVaultToAkm(state: ControlPlaneState): Promise<Mi
   return { ok: true, skipped: false, written, unchanged };
 }
 
+/**
+ * Phase 2 finalization step: after `mirrorUserVaultToAkm` has populated
+ * the akm vault, verify every non-empty key from the legacy user.env is
+ * present in the akm vault, and only then delete the legacy file.
+ *
+ * Returns:
+ *   - `{ deleted: true }`            when the legacy file was deleted
+ *   - `{ deleted: false, reason }`   when the file was kept (akm missing,
+ *                                    keys not yet mirrored, etc.) so the
+ *                                    operator can re-run upgrade safely
+ *
+ * Never throws — this is a best-effort migration step. The runtime path
+ * (entrypoint sources the akm vault directly) is independent of whether
+ * the legacy file lingers.
+ */
+export async function migrateAndCleanupLegacyUserEnv(
+  state: ControlPlaneState,
+): Promise<{ deleted: boolean; reason?: string }> {
+  const userEnvPath = `${state.vaultDir}/user/user.env`;
+  if (!existsSync(userEnvPath)) {
+    return { deleted: false, reason: "user.env already absent" };
+  }
+
+  const sourceEntries = parseEnvFile(userEnvPath);
+  const keys = Object.keys(sourceEntries).filter((k) => sourceEntries[k] !== "");
+  if (keys.length === 0) {
+    // No keys to migrate — safe to remove the empty placeholder so the
+    // assistant entrypoint stops finding it.
+    try {
+      unlinkSync(userEnvPath);
+      return { deleted: true };
+    } catch (err) {
+      return { deleted: false, reason: `unlink failed: ${err instanceof Error ? err.message : String(err)}` };
+    }
+  }
+
+  const env = buildAkmEnv(state);
+  if (!(await akmAvailable(env))) {
+    return { deleted: false, reason: "akm not on PATH" };
+  }
+  const vaultPath = await ensureAkmUserVault(state);
+  if (!vaultPath || !existsSync(vaultPath)) {
+    return { deleted: false, reason: "akm vault file missing" };
+  }
+
+  const akmEntries = parseEnvFile(vaultPath);
+  for (const key of keys) {
+    if (akmEntries[key] !== sourceEntries[key]) {
+      return { deleted: false, reason: `key not yet migrated: ${key}` };
+    }
+  }
+
+  try {
+    unlinkSync(userEnvPath);
+    logger.info("deleted legacy user.env after akm migration", {
+      userEnvPath,
+      migratedKeys: keys.length,
+    });
+    return { deleted: true };
+  } catch (err) {
+    return { deleted: false, reason: `unlink failed: ${err instanceof Error ? err.message : String(err)}` };
+  }
+}
+
 /** Return the parsed contents of the akm vault file (public API used by admin UI list endpoint). */
 export function readAkmUserVaultFile(vaultPath: string): Record<string, string> {
   if (!existsSync(vaultPath)) return {};
   try {
     return parseEnvFile(vaultPath);
   } catch {
+    // Fallback: hand-parse if dotenv chokes (e.g. file with stray BOM).
     const raw = readFileSync(vaultPath, "utf-8");
-    // Fallback: hand-parse if dotenv chokes (e.g. file with stray BOM)
     const out: Record<string, string> = {};
     for (const line of raw.split("\n")) {
       const m = line.match(/^([A-Za-z_][A-Za-z0-9_]*)=(.*)$/);

--- a/packages/lib/src/control-plane/compose-args.test.ts
+++ b/packages/lib/src/control-plane/compose-args.test.ts
@@ -98,13 +98,17 @@ describe("buildComposeOptions", () => {
   });
 
   it("returns env files in correct order", () => {
+    // Phase 2 of #388 (closes #406): vault/user/user.env is no longer a
+    // compose env_file. The runtime env file list is: stack.env, guardian.env.
+    // Even when a legacy user.env is present on disk, it is intentionally
+    // excluded from the compose args.
     seedEnvFiles({ stack: true, user: true, guardian: true });
     const state = makeState();
     const opts = buildComposeOptions(state);
-    expect(opts.envFiles).toHaveLength(3);
+    expect(opts.envFiles).toHaveLength(2);
     expect(opts.envFiles[0]).toContain("stack.env");
-    expect(opts.envFiles[1]).toContain("user.env");
-    expect(opts.envFiles[2]).toContain("guardian.env");
+    expect(opts.envFiles[1]).toContain("guardian.env");
+    expect(opts.envFiles.some((p) => p.endsWith("user/user.env"))).toBe(false);
   });
 
   it("excludes missing env files", () => {
@@ -136,8 +140,11 @@ describe("buildComposeCliArgs", () => {
   });
 
   it("includes --env-file flags for env files that exist", () => {
+    // Phase 2 of #388 (closes #406): vault/user/user.env is no longer
+    // listed in the compose env_file set. Only stack.env and guardian.env
+    // (when present) are passed via --env-file.
     seedCoreCompose();
-    seedEnvFiles({ stack: true, user: true });
+    seedEnvFiles({ stack: true, user: true, guardian: true });
     const state = makeState();
     const args = buildComposeCliArgs(state);
     const envFileIndices = args.reduce<number[]>((acc, arg, i) => {
@@ -145,6 +152,9 @@ describe("buildComposeCliArgs", () => {
       return acc;
     }, []);
     expect(envFileIndices).toHaveLength(2);
+    // Confirm user.env is NEVER in the args list, regardless of disk presence.
+    const envFilePaths = envFileIndices.map((i) => args[i + 1]);
+    expect(envFilePaths.some((p) => p.endsWith("user/user.env"))).toBe(false);
   });
 
   it("does not include --env-file for missing files", () => {

--- a/packages/lib/src/control-plane/config-persistence.ts
+++ b/packages/lib/src/control-plane/config-persistence.ts
@@ -27,12 +27,19 @@ const DEFAULT_IMAGE_TAG = process.env.OP_IMAGE_TAG ?? "latest";
  * Return the env files used for docker compose --env-file args.
  * These are the live vault env files.
  *
- * Order: stack.env -> user.env -> guardian.env
+ * Order: stack.env -> guardian.env
+ *
+ * Phase 2 of #388 (closes #406): `vault/user/user.env` is no longer a
+ * compose env_file. User-managed env secrets live in the akm
+ * `vault:user` store and are sourced by the assistant entrypoint at
+ * container startup. The legacy file is migrated into akm and deleted
+ * on upgrade; subsequent `docker compose` invocations must not reference
+ * it (compose interpolates `${VAR}` against the merged --env-file
+ * contents, and a stale user.env would shadow the akm-sourced values).
  */
 export function buildEnvFiles(state: ControlPlaneState): string[] {
   return [
     `${state.vaultDir}/stack/stack.env`,
-    `${state.vaultDir}/user/user.env`,
     `${state.vaultDir}/stack/guardian.env`,
   ].filter(existsSync);
 }

--- a/packages/lib/src/control-plane/install-edge-cases.test.ts
+++ b/packages/lib/src/control-plane/install-edge-cases.test.ts
@@ -176,8 +176,9 @@ describe("Fresh Install", () => {
     rmSync(homeDir, { recursive: true, force: true });
   });
 
-  // Scenario 1: ensureSecrets creates user.env as placeholder and stack.env with required keys
-  it("ensureSecrets creates user.env as placeholder and stack.env with required keys when files do not exist", () => {
+  // Scenario 1: ensureSecrets does NOT seed user.env (Phase 2 of #388) but
+  // does create stack.env with required keys when files do not exist.
+  it("ensureSecrets does NOT seed user.env on fresh install but creates stack.env with required keys (Phase 2 of #388)", () => {
     const state: ControlPlaneState = {
       adminToken: "",
       assistantToken: "",
@@ -194,16 +195,19 @@ describe("Fresh Install", () => {
       audit: [],
     };
 
-    // No user.env exists yet
+    // Sanity: nothing exists yet
     expect(existsSync(join(vaultDir, "user", "user.env"))).toBe(false);
 
     ensureSecrets(state);
 
-    // user.env is now a minimal placeholder
-    const userContent = readFileSync(join(vaultDir, "user", "user.env"), "utf-8");
-    expect(userContent).toContain("User Extensions");
+    // Phase 2 of #388 (closes #406): vault/user/user.env is no longer
+    // seeded — user-managed env secrets live in akm vault:user
+    // (data/stash/vaults/user.env). The vault/user directory itself is
+    // still created (other operational files mount from it).
+    expect(existsSync(join(vaultDir, "user"))).toBe(true);
+    expect(existsSync(join(vaultDir, "user", "user.env"))).toBe(false);
 
-    // API keys and owner info are seeded in stack.env
+    // API keys and owner info are seeded in stack.env (unchanged by Phase 2).
     const stackContent = readFileSync(join(vaultDir, "stack", "stack.env"), "utf-8");
     expect(stackContent).toContain("OPENAI_API_KEY=");
     expect(stackContent).toContain("OWNER_NAME=");

--- a/packages/lib/src/control-plane/lifecycle.ts
+++ b/packages/lib/src/control-plane/lifecycle.ts
@@ -12,7 +12,7 @@ import {
   resolveCacheHome,
 } from "./home.js";
 import { ensureSecrets, readStackEnv, updateSystemSecretsEnv } from "./secrets.js";
-import { mirrorUserVaultToAkm } from "./akm-vault.js";
+import { mirrorUserVaultToAkm, migrateAndCleanupLegacyUserEnv } from "./akm-vault.js";
 import {
   resolveRuntimeFiles,
   writeRuntimeFiles,
@@ -242,13 +242,17 @@ export async function applyUpgrade(
     const { backupDir, updated } = await refreshCoreAssets();
     const restarted = await reconcileCore(state, {});
 
-    // Phase 1 of #388: migrate existing `${OP_HOME}/vault/user/*.env` from
-    // pre-0.11 layouts into the shared akm `vault:user` store. The .env
-    // file is left in place — it remains the runtime source of truth for
-    // Compose env_file consumption until Phase 2 swaps the mount.
-    // Mirror is best-effort; the upgrade succeeds (or fails) on its own
-    // merits, and any akm-side error is captured by the mirror's logger.
+    // Phase 2 of #388 (closes #406): migrate existing
+    // `${OP_HOME}/vault/user/user.env` from pre-0.11 layouts into the
+    // shared akm `vault:user` store, then delete the legacy file once
+    // every key is verified present in akm. The assistant entrypoint
+    // sources the akm vault directly (no compose env_file dependency on
+    // user.env), so removing the file does not affect runtime env
+    // resolution. Mirror + cleanup are both best-effort: the upgrade
+    // succeeds on its own merits, and any akm-side error is logged so
+    // the operator can re-run upgrade after fixing the akm CLI.
     await mirrorUserVaultToAkm(state).catch(() => { /* best-effort */ });
+    await migrateAndCleanupLegacyUserEnv(state).catch(() => { /* best-effort */ });
 
     return { backupDir, updated, restarted };
   } finally {

--- a/packages/lib/src/control-plane/secrets.ts
+++ b/packages/lib/src/control-plane/secrets.ts
@@ -104,19 +104,21 @@ function ensureSystemSecrets(state: ControlPlaneState): void {
 export function ensureSecrets(state: ControlPlaneState): void {
   enforceVaultDirMode(state.vaultDir);
   mkdirSync(`${state.vaultDir}/stack`, { recursive: true, mode: VAULT_DIR_MODE });
+  // vault/user is still created — it holds operational files (apprise.yml,
+  // gcloud creds, gws/mgc auth dirs) that the assistant container mounts
+  // at /etc/vault/. Phase 2 of #388 only retired the .env file from this
+  // directory; the directory itself remains a service-side bind mount.
   mkdirSync(`${state.vaultDir}/user`, { recursive: true, mode: VAULT_DIR_MODE });
 
-  // user.env is an empty placeholder — users can add custom vars here.
-  // All standard config lives in stack.env.
+  // Phase 2 of #388 (closes #406): user-managed env secrets now live in
+  // the akm `vault:user` store at `${dataDir}/stash/vaults/user.env`.
+  // Fresh installs do NOT seed `vault/user/user.env` — the assistant
+  // entrypoint sources the akm vault file directly. A pre-existing legacy
+  // `user.env` is kept here so `migrateAndCleanupLegacyUserEnv()` (called
+  // from upgrade and setup) can read its contents into akm and then
+  // delete the file in a single atomic step.
   const userEnvPath = `${state.vaultDir}/user/user.env`;
-  if (!existsSync(userEnvPath)) {
-    writeVaultFile(userEnvPath, [
-      "# OpenPalm — User Extensions",
-      "# Add any custom environment variables here.",
-      "# These are loaded by compose alongside stack.env.",
-      "",
-    ].join("\n"));
-  } else {
+  if (existsSync(userEnvPath)) {
     try { chmodSync(userEnvPath, VAULT_FILE_MODE); } catch { /* best-effort */ }
   }
 

--- a/packages/lib/src/control-plane/setup.ts
+++ b/packages/lib/src/control-plane/setup.ts
@@ -25,7 +25,7 @@ import {
 } from "./secrets.js";
 import { ensureOpenCodeSystemConfig } from "./core-assets.js";
 import { createState } from "./lifecycle.js";
-import { mirrorUserVaultToAkm } from "./akm-vault.js";
+import { mirrorUserVaultToAkm, migrateAndCleanupLegacyUserEnv } from "./akm-vault.js";
 import { writeStackSpec } from "./stack-spec.js";
 import type { StackSpec, StackSpecCapabilities } from "./stack-spec.js";
 import { writeCapabilityVars } from "./spec-to-env.js";
@@ -272,12 +272,13 @@ export async function performSetup(
   const systemBase = existsSync(systemEnvPath) ? readFileSync(systemEnvPath, "utf-8") : "";
   writeFileSync(systemEnvPath, mergeEnvContent(systemBase, { OP_SETUP_COMPLETE: "true" }), { mode: 0o600 });
 
-  // Phase 1 of #388: mirror vault/user/user.env into the shared akm
-  // vault (vault:user) so the assistant and admin UI can browse/edit
-  // user secrets through the same `akm vault` interface used for every
-  // other shared secret. The .env file remains the runtime source of
-  // truth for Docker Compose env_file consumption. Best-effort: a
-  // failure here must never block setup completion.
+  // Phase 2 of #388 (closes #406): the akm `vault:user` store is now the
+  // sole runtime source of truth for user-managed env secrets. On a
+  // legacy install we migrate any `vault/user/user.env` content into akm
+  // and delete the file. On a fresh install no user.env is created, so
+  // the migration is a no-op (mirror reports `skipped: user.env missing`).
+  // Both steps are best-effort — a missing or wedged akm CLI must never
+  // block setup completion.
   try {
     const mirror = await mirrorUserVaultToAkm(state);
     if (mirror.skipped) {
@@ -287,6 +288,12 @@ export async function performSetup(
         written: mirror.written.length,
         unchanged: mirror.unchanged.length,
       });
+    }
+    const cleanup = await migrateAndCleanupLegacyUserEnv(state);
+    if (cleanup.deleted) {
+      logger.info("removed legacy vault/user/user.env after akm migration");
+    } else if (cleanup.reason && cleanup.reason !== "user.env already absent") {
+      logger.debug("legacy user.env retained", { reason: cleanup.reason });
     }
   } catch (err) {
     logger.warn("vault:user mirror failed", {

--- a/packages/lib/src/index.ts
+++ b/packages/lib/src/index.ts
@@ -258,13 +258,14 @@ export {
   performSetup,
 } from "./control-plane/setup.js";
 
-// ── AKM Vault Mirror (Phase 1 of #388) ───────────────────────────────────
+// ── AKM Vault Mirror (#388) ──────────────────────────────────────────────
 export type {
   MirrorResult,
 } from "./control-plane/akm-vault.js";
 export {
   AKM_USER_VAULT_REF,
   mirrorUserVaultToAkm,
+  migrateAndCleanupLegacyUserEnv,
   ensureAkmUserVault,
   writeAkmVaultKey,
   deleteAkmVaultKey,


### PR DESCRIPTION
## Summary

Closes two related deferred items:
- **Issue #406**: switch akm secret-store writes to the stdin pattern (akm 0.8.0-rc2 made stdin the default and removed the positional value form)
- **Phase 2 of issue #388**: drop the OP_HOME/vault/user → /etc/vault compose mount; entrypoint sources akm secret-store path; delete vault/user/

## Why

PR #404 implemented Phase 1 of #388 by mirroring vault/user/*.env into an akm secret store via direct .env file writes (bypassed the CLI to avoid the argv-leak vulnerability). Compose still mounted vault/user → /etc/vault for runtime env. With akm 0.8.0-rc2 (PR #408) shipping the stdin pattern, both the bypass and the mount can be retired.

## What changed

### Part 1: stdin migration (#406)
- `packages/lib/src/control-plane/akm-vault.ts`: new helper spawns akm with the appropriate subcommand and writes the value to stdin — value never crosses argv
- Same 2s `Promise.race` timeout from PR #404's hang fix is preserved
- The delete helper switched to the akm unset subcommand (already argv-safe)
- The direct .env file write code path is deleted
- Regression test verifies values flow via stdin (never argv)

### Part 2: Phase 2 mount removal (#388)
- `.openpalm/stack/core.compose.yml`: vault/user → /etc/vault mount removed from assistant
- `core/assistant/entrypoint.sh`: sources the akm secret-store path before launching OpenCode
- Install/upgrade flow:
  - On `openpalm upgrade` from 0.10.x: after the existing mirror runs, delete vault/user/
  - On fresh `openpalm install`: don't create vault/user/ at all
- `load_vault` assistant tool: fallback to /etc/vault/user.env removed (the mount no longer exists)
- Updated regression test for the 0.10.x → 0.11.0 upgrade migration

### Part 3: NON-CHANGES
- vault/stack/stack.env and vault/stack/guardian.env remain operator-managed
- Guardian's HMAC secrets stay in vault/stack/guardian.env (env_file with hot reload)

## Acceptance

- [x] `bun run test` — 877/0 pass
- [x] `bun run admin:check` — 0 errors / 0 warnings
- [x] argv-leak regression test asserts values flow via stdin only
- [x] 0.10.x → 0.11.0 migration test asserts vault/user/ is gone post-upgrade
- [x] Tests updated to reflect Phase 2 contract (user.env no longer expected)

## Breaking change for downstream tooling

Anyone with custom shell scripts reading OP_HOME/vault/user/user.env directly should switch to `akm vault path vault:user`.

## Refs

- Closes #406
- Completes Phase 2 of #388
- Refs #409 (deferred-items follow-up)