### PR TITLE
fix: address findings from final review (3 medium, 4 low)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,6 +141,29 @@ jobs:
           fi
           echo "All stack files validated successfully"
 
+      - name: Validate AKM_CLI_VERSION sync between base and guardian Dockerfiles
+        run: |
+          set -euo pipefail
+          # Guardian uses oven/bun:1.3-slim and pins akm-cli independently from
+          # core/base/Dockerfile (the assistant + admin base). The two pins
+          # MUST stay in lockstep so a bump to the base image isn't silently
+          # left behind in guardian. See finding from 0.11.0 final review.
+          BASE_VERSION=$(grep -oP '^ARG AKM_CLI_VERSION=\K\S+' core/base/Dockerfile || true)
+          GUARDIAN_VERSION=$(grep -oP '^ARG AKM_CLI_VERSION=\K\S+' core/guardian/Dockerfile || true)
+          if [ -z "$BASE_VERSION" ]; then
+            echo "::error file=core/base/Dockerfile::Could not extract AKM_CLI_VERSION ARG"
+            exit 1
+          fi
+          if [ -z "$GUARDIAN_VERSION" ]; then
+            echo "::error file=core/guardian/Dockerfile::Could not extract AKM_CLI_VERSION ARG"
+            exit 1
+          fi
+          if [ "$BASE_VERSION" != "$GUARDIAN_VERSION" ]; then
+            echo "::error::AKM_CLI_VERSION mismatch: core/base/Dockerfile=$BASE_VERSION vs core/guardian/Dockerfile=$GUARDIAN_VERSION — bump both together"
+            exit 1
+          fi
+          echo "AKM_CLI_VERSION matches across base + guardian: $BASE_VERSION"
+
       - name: Validate platform version sync
         run: |
           set -euo pipefail

--- a/.openpalm/registry/addons/voice/.env.schema
+++ b/.openpalm/registry/addons/voice/.env.schema
@@ -1,17 +1,16 @@
 # Voice channel configuration
 # ---
-
-# HMAC secret used to sign messages sent to the guardian.
-# Auto-generated during instance creation if left blank.
-# @required @sensitive
-CHANNEL_VOICE_SECRET=
-
-# ---
+#
+# Note: The voice addon serves a static web app that talks directly to
+# OpenCode's session API in the browser — it does NOT round-trip through
+# the guardian, so no CHANNEL_VOICE_SECRET HMAC is needed.
 
 # Speech-to-Text (STT) settings
 # ---
 
-# Base URL for the STT API provider.
+# Base URL for the STT API provider. The voice browser app posts audio
+# blobs to `${STT_BASE_URL}/v1/audio/transcriptions` for transcription.
+# @required
 STT_BASE_URL=https://api.openai.com
 
 # API key for the STT provider.

--- a/core/assistant/entrypoint.sh
+++ b/core/assistant/entrypoint.sh
@@ -132,6 +132,22 @@ maybe_proxy_lmstudio() {
     target_port=80
   fi
 
+  # Sanity-check both fields BEFORE handing them to socat. Even though the
+  # values are double-quoted, socat parses commas inside an address spec as
+  # option separators (e.g. `TCP:host,connect-timeout=...`). A maliciously
+  # crafted LMSTUDIO_BASE_URL like `http://evil,verify=0:1234` would smuggle
+  # extra socat options into the connection. Restricting to a strict
+  # hostname/IP and numeric-port character class makes such injection
+  # impossible without changing observed behaviour for any valid URL.
+  if ! printf '%s' "$target_host" | grep -qE '^[a-zA-Z0-9._-]+$'; then
+    echo "lmstudio-proxy: invalid host in LMSTUDIO_BASE_URL: $target_host" >&2
+    return 1
+  fi
+  if ! printf '%s' "$target_port" | grep -qE '^[0-9]+$'; then
+    echo "lmstudio-proxy: invalid port in LMSTUDIO_BASE_URL: $target_port" >&2
+    return 1
+  fi
+
   if command -v socat >/dev/null 2>&1; then
     echo "Starting LLM proxy: 127.0.0.1:1234 → ${target_host}:${target_port}"
     (while true; do

--- a/core/assistant/opencode/system.md
+++ b/core/assistant/opencode/system.md
@@ -24,7 +24,7 @@ For information about managing OpenPalm view @openpalm.md
 
 ## Secrets & Environment
 
-- Use `load_vault` to load user secrets (prefers the shared akm `vault:user` store, falls back to `/etc/vault/user.env`) — this is the primary tool for accessing API keys, owner info, and other user-configured secrets.
+- Use `load_vault` to load user secrets — resolves the user-managed env namespace via `akm vault path vault:user` and sources the resulting file. Primary tool for accessing API keys, owner info, and other user-configured secrets.
 - Use `load_env` only for ad-hoc `.env` files in the `/work` directory (workspace). It cannot read files outside `/work`.
 - Never display, log, or store secret values.
 

--- a/core/base/Dockerfile
+++ b/core/base/Dockerfile
@@ -6,7 +6,10 @@
 # and AKM_CLI_VERSION across the admin and assistant images.
 #
 # Guardian uses oven/bun:1.3-slim and only needs akm-cli + bun, so it does NOT
-# inherit from this image. Its AKM_CLI_VERSION is kept manually in sync.
+# inherit from this image. Its AKM_CLI_VERSION ARG must match the value
+# below — CI enforces the lockstep via the
+# "Validate AKM_CLI_VERSION sync between base and guardian Dockerfiles" step
+# in `.github/workflows/ci.yml`.
 #
 # Built locally via `docker compose --profile build build openpalm-base`.
 # Not published to a registry as part of normal releases — CI publishes a

--- a/packages/channel-voice/README.md
+++ b/packages/channel-voice/README.md
@@ -20,7 +20,7 @@ mic -> STT -> assistant -> TTS -> speaker
 - Enabled runtime overlay: `~/.openpalm/stack/addons/voice/compose.yml`
 - Default host URL: `http://localhost:3810`
 - Container port: `8186`
-- System-managed HMAC secret: `CHANNEL_VOICE_SECRET` in `~/.openpalm/vault/stack/guardian.env`
+- The deployed voice addon serves a static web app and talks directly to OpenCode's session API in the browser; it does not round-trip through the guardian, so no `CHANNEL_VOICE_SECRET` HMAC is needed in the addon overlay.
 
 Manual start example:
 

--- a/packages/lib/src/control-plane/akm-vault.test.ts
+++ b/packages/lib/src/control-plane/akm-vault.test.ts
@@ -11,7 +11,7 @@
  * enumeration, idempotency diff, argv-leak guard, cleanup pre-conditions)
  * is covered unconditionally via Bun.spawn stubs.
  */
-import { describe, expect, it, beforeEach, afterEach } from "bun:test";
+import { describe, expect, it, beforeEach, afterEach, mock } from "bun:test";
 import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -194,13 +194,165 @@ describe("mirrorUserVaultToAkm", () => {
     }
   });
 
-  it.skipIf(!AKM_AVAILABLE)("never passes secret values via Bun.spawn argv (no /proc/cmdline leak)", async () => {
-    // Phase 2 regression test for the security finding on PR #404. We now
-    // route every write through `akm vault set <ref> <key>` with the value
-    // delivered on stdin. Wrap Bun.spawn with a spy that records every
-    // argv it sees while delegating to the real akm binary, then assert
-    // no secret appeared on argv and that the value did transit through
-    // the spawn `stdin: "pipe"` channel.
+  it("never passes secret values via spawn argv (no /proc/cmdline leak) — mocked", async () => {
+    // SECURITY INVARIANT — must run on every CI environment, even ones
+    // without akm-cli on PATH. Phase 2 regression test for the security
+    // finding on PR #404 / #421: every write must route through
+    // `akm vault set <ref> <key>` with the value delivered via stdin.
+    //
+    // Strategy: stub `Bun.spawn` (and through it, the `child_process.execFile`
+    // path used by `execAkm`, since Bun's execFile is implemented on top of
+    // Bun.spawn). The stub records every argv + stdin write it observes and
+    // synthesizes a believable akm response for each invocation — version
+    // probe, vault create, vault path, vault set. Then we replay the
+    // production write path (`mirrorUserVaultToAkm`) and assert:
+    //   1. The secret value never appears on any argv element.
+    //   2. The secret value DID arrive via stdin on the `vault set` call.
+    //   3. The `vault set` invocation requested a stdin pipe.
+    const secret = "secret-payload-12345-do-not-leak";
+    writeFileSync(
+      join(state.vaultDir, "user", "user.env"),
+      `LEAK_CHECK_KEY=${secret}\n`,
+    );
+
+    const argvCalls: Array<{ cmd: string; args: readonly string[] }> = [];
+    const stdinWrites: string[] = [];
+    let stdinPipedOnSet = false;
+
+    const originalSpawn = Bun.spawn;
+
+    // Bun.spawn is called two ways inside akm-vault.ts:
+    //   1. From `akmVaultSetViaStdin`: `Bun.spawn(argv, opts)` directly.
+    //   2. From `execAkm` via `child_process.execFile`: Bun's execFile shim
+    //      calls `Bun.spawn({ cmd, stdio, env, onExit, ... })` with a
+    //      single options object. The onExit callback drives the
+    //      promisified execFile resolution — the spawn return value's
+    //      `exited` Promise is NOT awaited by execFile, so we MUST invoke
+    //      `opts.onExit(child, exitCode, signalCode, error)` to unblock it.
+    //
+    // The dispatcher below normalises both call shapes, records argv
+    // (security-relevant), captures stdin writes, and synthesises a
+    // believable response per akm subcommand.
+    function fakeChild(exitCode: number, stdoutText: string, wantsStdin: boolean) {
+      const stdinSink = wantsStdin
+        ? {
+            write: (chunk: string | Buffer) => {
+              stdinWrites.push(typeof chunk === "string" ? chunk : chunk.toString("utf8"));
+              return Promise.resolve();
+            },
+            end: () => Promise.resolve(),
+            flush: () => Promise.resolve(),
+          }
+        : null;
+      return {
+        pid: 12345,
+        exited: Promise.resolve(exitCode),
+        exitCode,
+        signalCode: null,
+        killed: false,
+        stdin: stdinSink,
+        stdout: new Response(stdoutText).body,
+        stderr: new Response("").body,
+        kill: () => {},
+        ref: () => {},
+        unref: () => {},
+        [Symbol.asyncDispose]: async () => {},
+        resourceUsage: () => undefined,
+      };
+    }
+
+    function responseFor(argv: readonly string[]) {
+      // akm --version → availability probe success
+      if (argv[0] === "akm" && argv[1] === "--version") {
+        return { exitCode: 0, stdout: "akm 0.8.0-rc2\n" };
+      }
+      // akm vault create vault:user → idempotent success
+      if (argv[0] === "akm" && argv[1] === "vault" && argv[2] === "create") {
+        return { exitCode: 0, stdout: "" };
+      }
+      // akm vault path vault:user → return a deterministic path
+      if (argv[0] === "akm" && argv[1] === "vault" && argv[2] === "path") {
+        return { exitCode: 0, stdout: `${state.dataDir}/stash/vaults/user.env\n` };
+      }
+      // akm vault set vault:user <key> → must pipe stdin and never carry value on argv
+      if (argv[0] === "akm" && argv[1] === "vault" && argv[2] === "set") {
+        return { exitCode: 0, stdout: "" };
+      }
+      return { exitCode: 0, stdout: "" };
+    }
+
+    (Bun as unknown as { spawn: typeof Bun.spawn }).spawn = ((arg1: unknown, arg2?: unknown) => {
+      // Normalise: direct (argv, opts) vs object form ({ cmd, ... }) used by
+      // the node:child_process.execFile shim in Bun.
+      let argv: string[];
+      let wantsStdin = false;
+      let onExit: ((child: unknown, code: number, signal: unknown, err: unknown) => void) | undefined;
+      if (Array.isArray(arg1)) {
+        argv = arg1 as string[];
+        const opts = (arg2 ?? {}) as Record<string, unknown>;
+        wantsStdin = opts.stdin === "pipe";
+      } else {
+        const opts = arg1 as Record<string, unknown>;
+        argv = (opts?.cmd as string[] | undefined) ?? [];
+        const stdio = opts?.stdio as unknown[] | undefined;
+        // execFile's spawn opts use stdio: ["pipe", "pipe", "pipe"] — the
+        // first slot is stdin. The akm-vault stdin-write path uses the
+        // direct argv form and sets stdin: "pipe" explicitly, so this
+        // branch never wants stdin capture.
+        wantsStdin = Array.isArray(stdio) && stdio[0] === "pipe" && argv[1] === "vault" && argv[2] === "set";
+        onExit = opts?.onExit as typeof onExit;
+      }
+
+      argvCalls.push({ cmd: argv[0] ?? "", args: argv.slice(1) });
+
+      const { exitCode, stdout } = responseFor(argv);
+      if (argv[0] === "akm" && argv[1] === "vault" && argv[2] === "set" && wantsStdin) {
+        stdinPipedOnSet = true;
+      }
+      const child = fakeChild(exitCode, stdout, wantsStdin);
+
+      // execFile path: drive resolution via onExit. Use queueMicrotask so
+      // the caller has a chance to attach handlers.
+      if (onExit) {
+        queueMicrotask(() => {
+          try { onExit!(child, exitCode, null, null); } catch { /* swallow */ }
+        });
+      }
+      return child as unknown as ReturnType<typeof Bun.spawn>;
+    }) as typeof Bun.spawn;
+
+    try {
+      const result = await mirrorUserVaultToAkm(state);
+      expect(result.ok).toBe(true);
+      // The mirror should have written the key (mock claims success).
+      expect(result.written).toContain("LEAK_CHECK_KEY");
+
+      // SECURITY ASSERTION (1): the secret value MUST NOT appear on any
+      // observed argv across every spawn we intercepted.
+      for (const call of argvCalls) {
+        for (const arg of call.args) {
+          expect(arg).not.toContain(secret);
+        }
+      }
+
+      // SECURITY ASSERTION (2): the value DID transit through stdin —
+      // proving the production write path used the stdin channel rather
+      // than argv. Concatenate writes in case the sink was called multiple
+      // times.
+      expect(stdinWrites.join("")).toContain(secret);
+
+      // POSITIVE: at least one `akm vault set` invocation requested a
+      // stdin pipe — i.e. the value path used stdin, not argv.
+      expect(stdinPipedOnSet).toBe(true);
+    } finally {
+      (Bun as unknown as { spawn: typeof Bun.spawn }).spawn = originalSpawn;
+    }
+  });
+
+  it.skipIf(!AKM_AVAILABLE)("never passes secret values via Bun.spawn argv (no /proc/cmdline leak) — live akm sanity", async () => {
+    // Live sanity check against the real akm binary. The mocked test above
+    // is the unconditional security gate; this one verifies the contract
+    // also holds end-to-end on environments that have akm installed.
     const secret = "secret-payload-12345-do-not-leak";
     writeFileSync(
       join(state.vaultDir, "user", "user.env"),
@@ -223,21 +375,14 @@ describe("mirrorUserVaultToAkm", () => {
       const result = await mirrorUserVaultToAkm(state);
       expect(result.ok).toBe(true);
 
-      // SECURITY ASSERTION: the secret value MUST NOT appear on any
-      // observed argv (including argv to akm or any subprocess akm
-      // itself spawned via the wrapped Bun.spawn).
       for (const call of argvCalls) {
         for (const arg of call.args) {
           expect(arg).not.toContain(secret);
         }
       }
 
-      // POSITIVE: at least one `akm vault set` invocation requested a
-      // stdin pipe — i.e. the value path used stdin, not argv.
       expect(stdinPiped).toBe(true);
 
-      // The value still landed in the vault file (proves stdin actually
-      // delivered it end-to-end through the real akm binary).
       const vaultPath = `${state.dataDir}/stash/vaults/user.env`;
       expect(existsSync(vaultPath)).toBe(true);
       const stored = readAkmUserVaultFile(vaultPath);

--- a/packages/lib/src/control-plane/akm-vault.ts
+++ b/packages/lib/src/control-plane/akm-vault.ts
@@ -386,6 +386,43 @@ export async function migrateAndCleanupLegacyUserEnv(
   }
 }
 
+/**
+ * Synchronously resolve the canonical akm `vault:user` file path for a given
+ * control-plane state. Used by sync read paths (e.g. plaintext secret backend
+ * `list`/`exists`) that cannot await `ensureAkmUserVault`.
+ *
+ * The path is deterministic: `buildAkmEnv` pins `AKM_STASH_DIR` to
+ * `${state.dataDir}/stash`, and akm-cli (>= 0.8.0) materializes vault files
+ * at `${AKM_STASH_DIR}/vaults/<ref>.env`. The `mirrorUserVaultToAkm` test
+ * (`packages/lib/src/control-plane/akm-vault.test.ts`) pins this layout.
+ *
+ * Returns the path string regardless of whether the file currently exists —
+ * callers should `existsSync` if presence matters.
+ */
+export function akmUserVaultPathSync(state: ControlPlaneState): string {
+  return `${state.dataDir}/stash/vaults/user.env`;
+}
+
+/**
+ * Read the user-managed env namespace, preferring the akm `vault:user` store
+ * (canonical post-#421) and falling back to the legacy
+ * `${vaultDir}/user/user.env` file when akm hasn't materialized the vault
+ * yet (fresh installs that have not run the mirror, or upgrades mid-flight).
+ *
+ * Returns `{}` when neither source exists. Pure sync — no subprocess spawn.
+ */
+export function readUserVaultSync(state: ControlPlaneState): Record<string, string> {
+  const akmPath = akmUserVaultPathSync(state);
+  if (existsSync(akmPath)) {
+    return readAkmUserVaultFile(akmPath);
+  }
+  const legacyPath = `${state.vaultDir}/user/user.env`;
+  if (existsSync(legacyPath)) {
+    return parseEnvFile(legacyPath);
+  }
+  return {};
+}
+
 /** Return the parsed contents of the akm vault file (public API used by admin UI list endpoint). */
 export function readAkmUserVaultFile(vaultPath: string): Record<string, string> {
   if (!existsSync(vaultPath)) return {};

--- a/packages/lib/src/control-plane/secret-backend.test.ts
+++ b/packages/lib/src/control-plane/secret-backend.test.ts
@@ -9,6 +9,8 @@ import {
   validatePassEntryName,
 } from '../index.js';
 import { writeSecretProviderConfig } from './provider-config.js';
+import { akmUserVaultPathSync } from './akm-vault.js';
+import { dirname } from 'node:path';
 
 let rootDir = '';
 
@@ -218,6 +220,37 @@ describe('plaintext backend (via detectSecretBackend)', () => {
     expect(userEnvParsed).toContain('OPENAI_API_KEY=user-env-openai');
     expect(stackEnvParsed).toContain('OPENAI_API_KEY=stack-env-openai');
     expect(stackEnvParsed).not.toContain('user-env-openai');
+  });
+
+  test('list/exists resolve user-scope secrets from akm vault after legacy user.env is deleted', async () => {
+    // Regression test for the post-#421 correctness bug: Phase 2 of #388
+    // (`migrateAndCleanupLegacyUserEnv`) deletes `${vaultDir}/user/user.env`
+    // after migrating its contents into the akm `vault:user` store. If the
+    // plaintext backend keeps reading the legacy file, user-scope secrets
+    // appear absent post-upgrade. The backend MUST resolve them through the
+    // akm vault file (`${dataDir}/stash/vaults/user.env`).
+    const state = createState();
+    ensureSecrets(state);
+    const backend = detectSecretBackend(state);
+
+    // Simulate the post-migration state: legacy user.env is gone, the akm
+    // vault file holds the user-managed secret.
+    const legacyPath = join(state.vaultDir, 'user', 'user.env');
+    rmSync(legacyPath, { force: true });
+
+    const akmPath = akmUserVaultPathSync(state);
+    mkdirSync(dirname(akmPath), { recursive: true });
+    writeFileSync(akmPath, 'OPENAI_API_KEY=migrated-akm-value\n');
+
+    // exists() must report the user-scope secret as present.
+    expect(await backend.exists('openpalm/openai/api-key')).toBe(true);
+
+    // list() must enumerate it with present: true.
+    const entries = await backend.list('openpalm/openai/');
+    const openai = entries.find((e) => e.key === 'openpalm/openai/api-key');
+    expect(openai).toBeDefined();
+    expect(openai?.scope).toBe('user');
+    expect(openai?.present).toBe(true);
   });
 });
 

--- a/packages/lib/src/control-plane/secret-backend.ts
+++ b/packages/lib/src/control-plane/secret-backend.ts
@@ -21,16 +21,20 @@ import {
   updateSecretsEnv,
   updateSystemSecretsEnv,
 } from './secrets.js';
-import { parseEnvFile } from './env.js';
+import { readUserVaultSync } from './akm-vault.js';
 
 /**
- * Read parsed key/value pairs from `vault/user/user.env`.
- * Returns {} if the file does not exist. Used for user-scope secret reads
- * so they consult the user-managed env file rather than the system stack
- * env file.
+ * Read parsed key/value pairs from the user-managed env namespace.
+ *
+ * Post-#421 the canonical home is the akm `vault:user` store
+ * (`${dataDir}/stash/vaults/user.env`), since `migrateAndCleanupLegacyUserEnv`
+ * deletes the legacy `${vaultDir}/user/user.env` file after upgrade. We
+ * delegate to the shared `readUserVaultSync` helper which prefers the akm
+ * file and falls back to the legacy path for fresh installs that have not
+ * yet seeded the akm store.
  */
-function readUserEnv(vaultDir: string): Record<string, string> {
-  return parseEnvFile(`${vaultDir}/user/user.env`);
+function readUserEnv(state: ControlPlaneState): Record<string, string> {
+  return readUserVaultSync(state);
 }
 
 const execFile = promisify(execFileCb);
@@ -101,9 +105,10 @@ function currentValueForTarget(state: ControlPlaneState, target: ResolvedSecretT
   if (target.scope === 'system') {
     return readStackEnv(state.vaultDir)[target.envKey] ?? '';
   }
-  // User scope: user.env is the canonical user-managed env file. Fall back to
-  // stack.env for legacy/consolidated secrets so older layouts keep resolving.
-  const userEnv = readUserEnv(state.vaultDir);
+  // User scope: the akm `vault:user` store is the canonical user-managed env
+  // namespace post-#421. Fall back to stack.env for legacy/consolidated
+  // secrets so older layouts keep resolving.
+  const userEnv = readUserEnv(state);
   if (target.envKey in userEnv) return userEnv[target.envKey];
   return readStackEnv(state.vaultDir)[target.envKey] ?? '';
 }
@@ -112,9 +117,9 @@ function currentValueForTarget(state: ControlPlaneState, target: ResolvedSecretT
 
 export async function plaintextList(state: ControlPlaneState, prefix = 'openpalm/'): Promise<SecretEntryMetadata[]> {
   const systemEnv = readStackEnv(state.vaultDir);
-  const userEnvFile = readUserEnv(state.vaultDir);
+  const userEnvFile = readUserEnv(state);
   // Legacy/consolidated secrets may live in stack.env even for user scope.
-  // Layer user.env on top so explicit user-managed values win.
+  // Layer the user vault on top so explicit user-managed values win.
   const userEnv: Record<string, string> = { ...systemEnv, ...userEnvFile };
   const index = readPlaintextSecretIndex(state);
   const entries: SecretEntryMetadata[] = [];

--- a/packages/lib/src/index.ts
+++ b/packages/lib/src/index.ts
@@ -109,6 +109,7 @@ export {
   detectSecretBackend,
   validatePassEntryName,
 } from "./control-plane/secret-backend.js";
+export type { SecretBackend } from "./control-plane/secret-backend.js";
 // ── Setup Status ────────────────────────────────────────────────────────
 export {
   isSetupComplete,
@@ -271,4 +272,6 @@ export {
   deleteAkmVaultKey,
   buildAkmEnv,
   readAkmUserVaultFile,
+  akmUserVaultPathSync,
+  readUserVaultSync,
 } from "./control-plane/akm-vault.js";


### PR DESCRIPTION
## Summary

Final 3-reviewer audit on `release/0.11.0` surfaced 3 medium and 4 low findings against the akm vault migration (PR #421) and adjacent surfaces. This PR fixes all of them.

## Findings fixed

### Medium

- **secret-backend reads deleted legacy path.** `readUserEnv()` was reading `${vaultDir}/user/user.env` — the file Phase 2 of #388 deletes via `migrateAndCleanupLegacyUserEnv`. After upgrade, plaintext backend's `list()`, `exists()`, and `currentValueForTarget()` returned empty/absent for user-scope secrets. Added `akmUserVaultPathSync` + `readUserVaultSync` helpers in `akm-vault.ts` that prefer the akm `vault:user` store and fall back to the legacy file for fresh installs that have not yet seeded akm. New regression test `list/exists resolve user-scope secrets from akm vault after legacy user.env is deleted` simulates the post-migration state.
- **socat option injection in `maybe_proxy_lmstudio`.** Added strict character-class validation on `target_host` (hostname/IP) and `target_port` (digits) before handing them to `socat`, blocking comma-separated socat option smuggling via crafted `LMSTUDIO_BASE_URL` values.
- **argv-leak regression test silently skipped in CI.** The security invariant test for PR #421 (secret values never appear in argv) only ran when akm was on PATH. Made the test unconditional by stubbing `Bun.spawn` (which Bun's `child_process.execFile` shim delegates through) to synthesize akm responses end-to-end. Captures stdin writes + argv calls and asserts the secret value never appears on argv. Live-akm sanity test retained as a gated sanity check.

### Low

- **`system.md` references removed fallback.** Dropped the stale "falls back to `/etc/vault/user.env`" claim for `load_vault` — post-#421 the only resolver is `akm vault path vault:user`.
- **`SecretBackend` type not re-exported from lib barrel.** Added `export type { SecretBackend }`. Also re-exported the new `akmUserVaultPathSync` + `readUserVaultSync` helpers.
- **Voice addon dead `CHANNEL_VOICE_SECRET` schema entry.** Voice serves static assets and never round-trips through the guardian. Removed the dead var; documented the design inline in the schema and the channel README. Promoted `STT_BASE_URL` to `@required` so the registry-components contract test (which requires at least one `@required` var per full addon) keeps passing.
- **Guardian `AKM_CLI_VERSION` not enforced in sync with base.** Added a CI step that asserts the `AKM_CLI_VERSION` ARG values in `core/base/Dockerfile` and `core/guardian/Dockerfile` match. Updated the comment in `core/base/Dockerfile` to point at the new gate.

## Test plan

- [x] `bun run test` — 889 pass, 0 fail
- [x] `bun run admin:test:unit` — 505 pass, 0 fail
- [x] `bun run admin:check` — 0 errors, 0 warnings
- [x] `./scripts/validate-registry.sh` — 8 addons, 0 errors
- [x] New regression tests:
  - `secret-backend.test.ts > list/exists resolve user-scope secrets from akm vault after legacy user.env is deleted`
  - `akm-vault.test.ts > never passes secret values via spawn argv (no /proc/cmdline leak) — mocked` (unconditional)
- [ ] Stack-dependent integration tests (`bun run admin:test:stack`, `bun run admin:test:llm`) — not run here; gated on a running compose stack

🤖 Generated with [Claude Code](https://claude.com/claude-code)