### PR TITLE
feat(guardian): thin-host fix, library seams, and release workflow improvements (v0.12.16)

### DIFF
--- a/.github/release-package-groups.json
+++ b/.github/release-package-groups.json
@@ -1,0 +1,20 @@
+{
+  "units": {
+    "platform": [
+      "package.json",
+      "packages/skeleton/package.json",
+      "packages/lib/package.json",
+      "packages/cli/package.json",
+      "packages/ui/package.json",
+      "packages/electron/package.json",
+      "packages/electron/admin-tools/package.json"
+    ],
+    "portals": [
+      "portals/discord/package.json",
+      "portals/slack/package.json"
+    ],
+    "guardian": [
+      "packages/guardian/package.json"
+    ]
+  }
+}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -301,7 +301,7 @@ jobs:
   npm-skeleton:
     name: npm @openpalm/skeleton
     needs: [compute-version, bump]
-    if: always() && needs.bump.result == 'success' && (inputs.unit == 'platform' || inputs.unit == 'major')
+    if: always() && needs.bump.result == 'success' && (inputs.unit == 'platform' || inputs.unit == 'guardian' || inputs.unit == 'major')
     uses: ./.github/workflows/publish-npm-package.yml
     secrets: inherit
     with:
@@ -315,7 +315,7 @@ jobs:
   npm-lib:
     name: npm @openpalm/lib
     needs: [compute-version, bump, npm-skeleton]
-    if: always() && needs.bump.result == 'success' && needs.npm-skeleton.result == 'success' && (inputs.unit == 'platform' || inputs.unit == 'major')
+    if: always() && needs.bump.result == 'success' && needs.npm-skeleton.result == 'success' && (inputs.unit == 'platform' || inputs.unit == 'guardian' || inputs.unit == 'major')
     uses: ./.github/workflows/publish-npm-package.yml
     secrets: inherit
     with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,9 @@ name: Release
 # Docker images: openpalm/assistant:vX.Y.Z, openpalm/portal:vX.Y.Z, openpalm/guardian:vX.Y.Z
 #
 # npm OIDC: all npm publishes go through publish-npm-package.yml (single top-level caller).
-# Docker-only units (portals/assistant/guardian) skip npm jobs entirely.
+# Docker-only units (portals/assistant) skip npm jobs entirely.
+# unit=guardian publishes @openpalm/guardian + @openpalm/skeleton (thin-host needs both at runtime).
+# unit=platform also builds the guardian Docker image (thin-host must match platform version).
 #
 # TAG-LAST: the git tag + GitHub release are created LAST ("tag exists = fully published").
 # Always run with dry_run=true first to validate the plan without committing.
@@ -123,7 +125,7 @@ jobs:
 
             // Only npm-published units need a regression guard
             if (!['platform', 'major'].includes(unit)) {
-              console.log('Docker-only unit — skipping npm regression guard.');
+              console.log('Non-platform unit — skipping npm regression guard.');
               process.exit(0);
             }
 
@@ -297,7 +299,12 @@ jobs:
           echo "::error::Failed to push after 5 attempts"
           exit 1
 
-  # ── npm layer: skeleton → lib → (cli + ui + guardian) (platform + major only) ───
+  # ── npm layer ─────────────────────────────────────────────────────────────────
+  # skeleton + guardian: published for unit=guardian (thin-host needs both at runtime)
+  #                      and unit=platform + unit=major (full coordinated release)
+  # lib + cli + ui:      platform + major only (guardian npm pkg has no lib dep)
+  # NOTE: guardian and skeleton are published independently of lib to avoid
+  # blocking the platform regression guard. lib is platform-managed.
   npm-skeleton:
     name: npm @openpalm/skeleton
     needs: [compute-version, bump]
@@ -315,7 +322,7 @@ jobs:
   npm-lib:
     name: npm @openpalm/lib
     needs: [compute-version, bump, npm-skeleton]
-    if: always() && needs.bump.result == 'success' && needs.npm-skeleton.result == 'success' && (inputs.unit == 'platform' || inputs.unit == 'guardian' || inputs.unit == 'major')
+    if: always() && needs.bump.result == 'success' && needs.npm-skeleton.result == 'success' && (inputs.unit == 'platform' || inputs.unit == 'major')
     uses: ./.github/workflows/publish-npm-package.yml
     secrets: inherit
     with:
@@ -328,8 +335,8 @@ jobs:
 
   npm-guardian:
     name: npm @openpalm/guardian
-    needs: [compute-version, bump, npm-lib]
-    if: always() && needs.bump.result == 'success' && needs.npm-lib.result == 'success' && (inputs.unit == 'platform' || inputs.unit == 'guardian' || inputs.unit == 'major')
+    needs: [compute-version, bump, npm-skeleton]
+    if: always() && needs.bump.result == 'success' && needs.npm-skeleton.result == 'success' && (inputs.unit == 'platform' || inputs.unit == 'guardian' || inputs.unit == 'major')
     uses: ./.github/workflows/publish-npm-package.yml
     secrets: inherit
     with:
@@ -420,7 +427,7 @@ jobs:
   docker-guardian:
     name: Docker openpalm/guardian
     needs: [compute-version, bump]
-    if: always() && needs.bump.result == 'success' && (inputs.unit == 'portals' || inputs.unit == 'guardian' || inputs.unit == 'major')
+    if: always() && needs.bump.result == 'success' && (inputs.unit == 'portals' || inputs.unit == 'guardian' || inputs.unit == 'platform' || inputs.unit == 'major')
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -472,7 +472,7 @@ jobs:
   docker-assistant:
     name: Docker openpalm/assistant
     needs: [compute-version, bump]
-    if: always() && needs.bump.result == 'success' && (inputs.unit == 'assistant' || inputs.unit == 'major')
+    if: always() && needs.bump.result == 'success' && (inputs.unit == 'assistant' || inputs.unit == 'platform' || inputs.unit == 'major')
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -329,7 +329,7 @@ jobs:
   npm-guardian:
     name: npm @openpalm/guardian
     needs: [compute-version, bump, npm-lib]
-    if: always() && needs.bump.result == 'success' && needs.npm-lib.result == 'success' && (inputs.unit == 'platform' || inputs.unit == 'major')
+    if: always() && needs.bump.result == 'success' && needs.npm-lib.result == 'success' && (inputs.unit == 'platform' || inputs.unit == 'guardian' || inputs.unit == 'major')
     uses: ./.github/workflows/publish-npm-package.yml
     secrets: inherit
     with:

--- a/.openpalm/config/stack/portals.compose.yml
+++ b/.openpalm/config/stack/portals.compose.yml
@@ -78,6 +78,12 @@ services:
       GUARDIAN_DIRECT_PORT: "3830"
       GUARDIAN_ADMIN_PORT: "3831"
       OP_ASSISTANT_URL: http://assistant:4096
+      # Thin-host entrypoint uses these to install @openpalm/guardian and
+      # @openpalm/skeleton at the correct versions on first boot.
+      # OP_GUARDIAN_IMAGE_TAG (e.g. v0.12.9) may differ from OP_IMAGE_TAG when
+      # guardian is released independently of the platform.
+      OP_GUARDIAN_VERSION: ${OP_GUARDIAN_IMAGE_TAG:-${OP_IMAGE_TAG:-}}
+      PLATFORM_VERSION: ${OP_IMAGE_TAG:-}
       OPENCODE_TIMEOUT_MS: "0"
       # OpenCode global config (opencode.jsonc) lives in OP_HOME/config/guardian,
       # bind-mounted at /etc/opencode below.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to OpenPalm are documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **`@openpalm/guardian` is now importable as a library** (in addition to being
+  a runnable thin host). It exposes composition seams so downstream
+  distributions can extend the guardian without forking `server.ts`:
+  - `createGuardian()` / `startGuardian()` — the composition root. Importing the
+    package no longer binds any listener; `server.ts` only boots when run as the
+    entrypoint (`import.meta.main`), so `bun run src/server.ts` is unchanged.
+  - `registerTransport()` — register an additive route on the direct listener
+    (alongside the built-in `/oc` and `/mcp`), gated by an optional env var.
+  - `setAuthStrategy()` / `AuthStrategy` — replace the built-in HTTP Basic /
+    principal-token authenticator (e.g. with SSO/OIDC). The default
+    `basicTokenAuthStrategy` is unchanged.
+  - `setPolicyProvider()` / `PolicyProvider` — a port for richer authorization
+    (per-tenant data scope, RBAC, routing). The public default allows all;
+    ownership and rate limits still apply.
+  - The package now declares `exports`, `main`/`types`, a `bin`
+    (`openpalm-guardian`), and a `files` allowlist that excludes test files.
+- The audit writer is created lazily on first write, so importing the guardian
+  library has no filesystem side effects.
+
 ## [0.12.10] - 2026-06-17
 
 ### Fixed

--- a/bun.lock
+++ b/bun.lock
@@ -43,10 +43,16 @@
     },
     "packages/guardian": {
       "name": "@openpalm/guardian",
-      "version": "0.12.14",
+      "version": "0.13.0",
+      "bin": {
+        "openpalm-guardian": "./src/server.ts",
+      },
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
         "dotenv": "^17.4.2",
+      },
+      "devDependencies": {
+        "bun-types": "^1.3.14",
       },
     },
     "packages/lib": {

--- a/containers/guardian/Dockerfile
+++ b/containers/guardian/Dockerfile
@@ -5,7 +5,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 VOLUME ["/opt/openpalm"]
 
-COPY entrypoint.sh /entrypoint.sh
+COPY containers/guardian/entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 
 ENV HOME=/opt/openpalm/guardian \

--- a/containers/guardian/entrypoint.sh
+++ b/containers/guardian/entrypoint.sh
@@ -33,5 +33,39 @@ TOOL_PKGS=$(bun -e "
 ")
 [ -n "$TOOL_PKGS" ] && bun add -g $TOOL_PKGS || echo "WARN: some tool installs failed; continuing"
 
+# ── Paths resolved once (package is now installed) ────────────────────────────
+GUARDIAN_PKG=/opt/openpalm/guardian/node_modules/@openpalm/guardian
+
+# ── Start OpenCode moderator (when content validation is enabled) ─────────────
+# opencode is a range-versioned tool installed above via tools.json. If it is
+# unavailable for any reason, log a warning and continue — the heuristic screen
+# still runs, and escalated messages fail-closed (blocked) rather than crashing.
+enabled=0
+case "${GUARDIAN_CONTENT_VALIDATION:-0}" in
+  1 | true | TRUE | yes | on) enabled=1 ;;
+esac
+
+if [ "$enabled" = "1" ]; then
+  if command -v opencode >/dev/null 2>&1; then
+    port="${GUARDIAN_MODERATION_PORT:-4097}"
+    echo "[guardian] starting OpenCode moderator on 127.0.0.1:${port}"
+    OPENCODE_AUTH=false \
+    OPENCODE_CONFIG_DIR="${OPENCODE_CONFIG_DIR:-/etc/opencode}" \
+      opencode serve --hostname 127.0.0.1 --port "${port}" \
+      --print-logs --log-level INFO 2>&1 | sed -u 's/^/[moderator] /' >&2 &
+  else
+    echo "[guardian] WARN: GUARDIAN_CONTENT_VALIDATION=1 but opencode not found on PATH; moderator will not start. Messages escalated by the heuristic screen will be blocked (fail-closed)." >&2
+  fi
+fi
+
+# ── Start the OpenAI-compatible API server ────────────────────────────────────
+# Runs on GUARDIAN_OPENAI_PORT (default 8182) and proxies to the guardian
+# server on localhost:${PORT:-8080}. Backgrounded so it doesn't block the main
+# server; pipe to stderr so logs appear in `docker logs`.
+guardian_server_port="${PORT:-8080}"
+openai_port="${GUARDIAN_OPENAI_PORT:-8182}"
+PORT="${openai_port}" GUARDIAN_URL="http://localhost:${guardian_server_port}" \
+  bun run "${GUARDIAN_PKG}/src/openai-api-server.ts" 2>&1 | sed -u 's/^/[openai-api] /' >&2 &
+
 # ── Start guardian ────────────────────────────────────────────────────────────
-exec bun run /opt/openpalm/guardian/node_modules/@openpalm/guardian/src/server.ts
+exec bun run "${GUARDIAN_PKG}/src/server.ts"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openpalm",
-  "version": "0.12.14",
+  "version": "0.12.16",
   "private": true,
   "license": "MPL-2.0",
   "workspaces": [

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openpalm",
-  "version": "0.12.14",
+  "version": "0.12.16",
   "type": "module",
   "license": "MPL-2.0",
   "description": "OpenPalm CLI — install and manage a self-hosted OpenPalm stack",
@@ -35,7 +35,7 @@
     "bun": ">=1.0.0"
   },
   "dependencies": {
-    "@openpalm/lib": ">=0.12.14 <1.0.0",
+    "@openpalm/lib": ">=0.12.16 <1.0.0",
     "@openpalm/skeleton": "0.12.8",
     "citty": "^0.2.1",
     "yaml": "^2.8.0"

--- a/packages/electron/admin-tools/package.json
+++ b/packages/electron/admin-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openpalm/admin-tools-plugin",
-  "version": "0.12.14",
+  "version": "0.12.16",
   "type": "module",
   "license": "MPL-2.0",
   "description": "Admin OpenCode tools for the Electron-spawned ephemeral OpenCode server (Phase 3 of the auth/proxy refactor)",

--- a/packages/electron/package.json
+++ b/packages/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openpalm/electron",
-  "version": "0.12.14",
+  "version": "0.12.16",
   "private": true,
   "type": "module",
   "description": "OpenPalm desktop app (Electron harness)",

--- a/packages/guardian/package.json
+++ b/packages/guardian/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openpalm/guardian",
   "description": "Basic-auth message gateway with ownership, moderation, and rate limiting — importable as a library to compose custom auth, authorization, and transports",
-  "version": "0.12.10",
+  "version": "0.12.11",
   "private": false,
   "license": "MPL-2.0",
   "type": "module",

--- a/packages/guardian/package.json
+++ b/packages/guardian/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openpalm/guardian",
   "description": "Basic-auth message gateway with ownership, moderation, and rate limiting — importable as a library to compose custom auth, authorization, and transports",
-  "version": "0.12.9",
+  "version": "0.12.10",
   "private": false,
   "license": "MPL-2.0",
   "type": "module",

--- a/packages/guardian/package.json
+++ b/packages/guardian/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openpalm/guardian",
   "description": "Basic-auth message gateway with ownership, moderation, and rate limiting — importable as a library to compose custom auth, authorization, and transports",
-  "version": "0.13.0",
+  "version": "0.12.10",
   "private": false,
   "license": "MPL-2.0",
   "type": "module",

--- a/packages/guardian/package.json
+++ b/packages/guardian/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openpalm/guardian",
   "description": "Basic-auth message gateway with ownership, moderation, and rate limiting — importable as a library to compose custom auth, authorization, and transports",
-  "version": "0.12.14",
+  "version": "0.12.15",
   "private": false,
   "license": "MPL-2.0",
   "type": "module",

--- a/packages/guardian/package.json
+++ b/packages/guardian/package.json
@@ -1,17 +1,38 @@
 {
   "name": "@openpalm/guardian",
-  "description": "Basic-auth message gateway with ownership, moderation, and rate limiting",
-  "version": "0.12.9",
+  "description": "Basic-auth message gateway with ownership, moderation, and rate limiting — importable as a library to compose custom auth, authorization, and transports",
+  "version": "0.13.0",
   "private": false,
   "license": "MPL-2.0",
   "type": "module",
+  "types": "./src/index.ts",
+  "main": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts",
+    "./server": "./src/server.ts"
+  },
+  "bin": {
+    "openpalm-guardian": "./src/server.ts"
+  },
+  "files": [
+    "src",
+    "!src/**/*.test.ts"
+  ],
   "scripts": {
     "start": "bun run src/server.ts",
     "start:openai-api": "bun run src/openai-api-server.ts",
     "test": "bun test"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/itlackey/openpalm",
+    "directory": "packages/guardian"
+  },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
     "dotenv": "^17.4.2"
+  },
+  "devDependencies": {
+    "bun-types": "^1.3.14"
   }
 }

--- a/packages/guardian/package.json
+++ b/packages/guardian/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openpalm/guardian",
   "description": "Basic-auth message gateway with ownership, moderation, and rate limiting — importable as a library to compose custom auth, authorization, and transports",
-  "version": "0.12.15",
+  "version": "0.12.16",
   "private": false,
   "license": "MPL-2.0",
   "type": "module",

--- a/packages/guardian/package.json
+++ b/packages/guardian/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openpalm/guardian",
   "description": "Basic-auth message gateway with ownership, moderation, and rate limiting — importable as a library to compose custom auth, authorization, and transports",
-  "version": "0.12.11",
+  "version": "0.12.12",
   "private": false,
   "license": "MPL-2.0",
   "type": "module",

--- a/packages/guardian/package.json
+++ b/packages/guardian/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openpalm/guardian",
   "description": "Basic-auth message gateway with ownership, moderation, and rate limiting — importable as a library to compose custom auth, authorization, and transports",
-  "version": "0.12.12",
+  "version": "0.12.13",
   "private": false,
   "license": "MPL-2.0",
   "type": "module",

--- a/packages/guardian/package.json
+++ b/packages/guardian/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openpalm/guardian",
   "description": "Basic-auth message gateway with ownership, moderation, and rate limiting — importable as a library to compose custom auth, authorization, and transports",
-  "version": "0.12.13",
+  "version": "0.12.14",
   "private": false,
   "license": "MPL-2.0",
   "type": "module",

--- a/packages/guardian/package.json
+++ b/packages/guardian/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openpalm/guardian",
   "description": "Basic-auth message gateway with ownership, moderation, and rate limiting — importable as a library to compose custom auth, authorization, and transports",
-  "version": "0.12.10",
+  "version": "0.12.9",
   "private": false,
   "license": "MPL-2.0",
   "type": "module",

--- a/packages/guardian/src/audit.ts
+++ b/packages/guardian/src/audit.ts
@@ -15,22 +15,33 @@ const logger = createLogger("guardian:audit");
 const AUDIT_PATH = Bun.env.GUARDIAN_AUDIT_PATH ?? "/opt/openpalm/logs/guardian-audit.log";
 const FLUSH_INTERVAL_MS = 5_000;
 
-// Ensure audit directory exists
 import { mkdirSync } from "node:fs";
 import { dirname } from "node:path";
-const auditDir = dirname(AUDIT_PATH);
-if (auditDir) {
-  try { mkdirSync(auditDir, { recursive: true }); } catch {
-    logger.error("Failed to create audit directory", { path: auditDir });
-  }
-}
 
-// Use Bun.file().writer() for efficient append-only audit logging
-const auditWriter = Bun.file(AUDIT_PATH).writer();
+// Append-only audit writer, created lazily on first write. Deferring the
+// directory creation + file open keeps importing this module (and the
+// @openpalm/guardian library entrypoint that transitively pulls it in) free of
+// filesystem side effects — only a running guardian touches the audit log.
+type AuditWriter = ReturnType<ReturnType<typeof Bun.file>["writer"]>;
+let auditWriter: AuditWriter | null = null;
 let dirty = false;
 
+function getAuditWriter(): AuditWriter {
+  if (auditWriter) return auditWriter;
+  const auditDir = dirname(AUDIT_PATH);
+  if (auditDir) {
+    try {
+      mkdirSync(auditDir, { recursive: true });
+    } catch {
+      logger.error("Failed to create audit directory", { path: auditDir });
+    }
+  }
+  auditWriter = Bun.file(AUDIT_PATH).writer();
+  return auditWriter;
+}
+
 function flushAuditBuffer(): void {
-  if (!dirty) return;
+  if (!dirty || !auditWriter) return;
   try {
     auditWriter.flush();
     dirty = false;
@@ -53,7 +64,7 @@ process.on("beforeExit", onShutdown);
 
 export function audit(event: Record<string, unknown>): void {
   try {
-    auditWriter.write(JSON.stringify({ ts: new Date().toISOString(), ...event }) + "\n");
+    getAuditWriter().write(JSON.stringify({ ts: new Date().toISOString(), ...event }) + "\n");
     dirty = true;
   } catch (err) {
     logger.error("Audit write failed", { error: err instanceof Error ? err.message : String(err) });

--- a/packages/guardian/src/auth.ts
+++ b/packages/guardian/src/auth.ts
@@ -50,24 +50,62 @@ function parseBasicAuth(header: string): { id: string; secret: string } | null {
   };
 }
 
+/**
+ * Pluggable authentication strategy seam.
+ *
+ * The built-in {@link basicTokenAuthStrategy} authenticates HTTP Basic
+ * credentials against the principal store — the only scheme public OpenPalm
+ * ships. Downstream distributions install a different strategy (e.g. SSO/OIDC
+ * bearer tokens) via {@link setAuthStrategy} without modifying the request path;
+ * the exported {@link authenticate} delegates to whichever strategy is active.
+ */
+export interface AuthStrategy {
+  authenticate(req: Request, expectedKind?: PrincipalKind): AuthenticatedPrincipal | null;
+}
+
+/** The built-in HTTP Basic / principal-token authenticator. */
+export const basicTokenAuthStrategy: AuthStrategy = {
+  authenticate(req: Request, expectedKind?: PrincipalKind): AuthenticatedPrincipal | null {
+    const authHeader = req.headers.get('authorization') ?? '';
+    const basic = parseBasicAuth(authHeader);
+    if (!basic) return null;
+
+    const record = readCachedPrincipal(basic.id);
+    if (!record || !record.enabled) return null;
+
+    const tokenHash = createHash('sha256').update(basic.secret).digest('hex');
+    if (!constantTimeEqual(record.tokenHash, tokenHash)) return null;
+
+    const userId = req.headers.get('x-openpalm-user')?.trim() || basic.id;
+    if (expectedKind && record.kind !== expectedKind) return null;
+
+    return {
+      id: record.id,
+      kind: record.kind,
+      label: record.label,
+      userId,
+    };
+  },
+};
+
+let activeStrategy: AuthStrategy = basicTokenAuthStrategy;
+
+/** Install the active authentication strategy. */
+export function setAuthStrategy(strategy: AuthStrategy): void {
+  activeStrategy = strategy;
+}
+
+/** The active authentication strategy (defaults to {@link basicTokenAuthStrategy}). */
+export function getAuthStrategy(): AuthStrategy {
+  return activeStrategy;
+}
+
+/** Reset to the built-in Basic-token strategy (test/composition helper). */
+export function resetAuthStrategy(): void {
+  activeStrategy = basicTokenAuthStrategy;
+}
+
+/** Authenticate a request via the active {@link AuthStrategy}. */
 export function authenticate(req: Request, expectedKind?: PrincipalKind): AuthenticatedPrincipal | null {
-  const authHeader = req.headers.get('authorization') ?? '';
-  const basic = parseBasicAuth(authHeader);
-  if (!basic) return null;
-
-  const record = readCachedPrincipal(basic.id);
-  if (!record || !record.enabled) return null;
-
-  const tokenHash = createHash('sha256').update(basic.secret).digest('hex');
-  if (!constantTimeEqual(record.tokenHash, tokenHash)) return null;
-
-  const userId = req.headers.get('x-openpalm-user')?.trim() || basic.id;
-  if (expectedKind && record.kind !== expectedKind) return null;
-
-  return {
-    id: record.id,
-    kind: record.kind,
-    label: record.label,
-    userId,
-  };
+  return activeStrategy.authenticate(req, expectedKind);
 }

--- a/packages/guardian/src/index.test.ts
+++ b/packages/guardian/src/index.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, test, beforeEach } from 'bun:test';
+import {
+  createGuardian,
+  registerTransport,
+  registeredTransports,
+  clearTransports,
+  matchTransport,
+  authenticate,
+  setAuthStrategy,
+  resetAuthStrategy,
+  basicTokenAuthStrategy,
+  getAuthStrategy,
+  setPolicyProvider,
+  getPolicyProvider,
+  resetPolicyProvider,
+  allowAllPolicy,
+  startGuardian,
+} from './index.ts';
+import type { Transport, AuthStrategy, PolicyProvider } from './index.ts';
+
+describe('library import is side-effect free (no listeners bound)', () => {
+  test('importing the package entrypoint does not start the servers', async () => {
+    // If importing booted Bun.serve, the process would stay alive on the event
+    // loop and never exit; a side-effect-free import exits promptly.
+    const proc = Bun.spawn(['bun', '-e', "await import('./src/index.ts')"], {
+      cwd: new URL('..', import.meta.url).pathname,
+      stdout: 'ignore',
+      stderr: 'pipe',
+    });
+    const exited = await Promise.race([
+      proc.exited,
+      new Promise<'timeout'>((resolve) => setTimeout(() => resolve('timeout'), 8000)),
+    ]);
+    if (exited === 'timeout') {
+      proc.kill();
+      throw new Error('importing @openpalm/guardian booted the servers (process did not exit)');
+    }
+    expect(exited).toBe(0);
+  });
+});
+
+describe('transport registry seam', () => {
+  beforeEach(() => clearTransports());
+
+  const make = (name: string, path: string, enabledEnv?: string): Transport => ({
+    name,
+    enabledEnv,
+    matches: (url) => url.pathname === path,
+    handle: async (_req, requestId) => new Response(JSON.stringify({ name, requestId }), { status: 200 }),
+  });
+
+  test('registers and matches a transport by path', () => {
+    registerTransport(make('a2a', '/a2a'));
+    expect(registeredTransports().map((t) => t.name)).toEqual(['a2a']);
+    expect(matchTransport(new URL('http://x/a2a'), new Request('http://x/a2a'))?.name).toBe('a2a');
+    expect(matchTransport(new URL('http://x/other'), new Request('http://x/other'))).toBeNull();
+  });
+
+  test('honors the enabledEnv gate', () => {
+    registerTransport(make('gated', '/g', 'GUARDIAN_TEST_GATE'));
+    const url = new URL('http://x/g');
+    const req = new Request('http://x/g');
+    delete Bun.env.GUARDIAN_TEST_GATE;
+    expect(matchTransport(url, req)).toBeNull();
+    Bun.env.GUARDIAN_TEST_GATE = 'true';
+    expect(matchTransport(url, req)?.name).toBe('gated');
+    delete Bun.env.GUARDIAN_TEST_GATE;
+  });
+
+  test('rejects duplicate transport names', () => {
+    registerTransport(make('dup', '/d'));
+    expect(() => registerTransport(make('dup', '/d2'))).toThrow(/already registered/);
+  });
+});
+
+describe('auth strategy seam', () => {
+  beforeEach(() => resetAuthStrategy());
+
+  test('defaults to the built-in basic-token strategy', () => {
+    expect(getAuthStrategy()).toBe(basicTokenAuthStrategy);
+    // No credentials -> the built-in strategy returns null.
+    expect(authenticate(new Request('http://x'))).toBeNull();
+  });
+
+  test('authenticate() delegates to the active strategy', () => {
+    const fake: AuthStrategy = {
+      authenticate: () => ({ id: 'svc', kind: 'direct', label: 'Service', userId: 'svc' }),
+    };
+    setAuthStrategy(fake);
+    expect(authenticate(new Request('http://x'))?.id).toBe('svc');
+    resetAuthStrategy();
+    expect(authenticate(new Request('http://x'))).toBeNull();
+  });
+});
+
+describe('policy provider seam', () => {
+  beforeEach(() => resetPolicyProvider());
+
+  test('defaults to allow-all', async () => {
+    expect(getPolicyProvider()).toBe(allowAllPolicy);
+    expect(await getPolicyProvider().authorize({ principalId: 'p', action: 'x' })).toEqual({ allow: true });
+  });
+
+  test('setPolicyProvider installs a custom policy', async () => {
+    const deny: PolicyProvider = { authorize: () => ({ allow: false, reason: 'nope' }) };
+    setPolicyProvider(deny);
+    expect(await getPolicyProvider().authorize({ principalId: 'p', action: 'x' })).toEqual({
+      allow: false,
+      reason: 'nope',
+    });
+  });
+});
+
+describe('createGuardian builder', () => {
+  beforeEach(() => {
+    clearTransports();
+    resetAuthStrategy();
+    resetPolicyProvider();
+  });
+
+  test('chains seam wiring without starting', () => {
+    const auth: AuthStrategy = { authenticate: () => null };
+    const policy: PolicyProvider = { authorize: () => ({ allow: true }) };
+    const builder = createGuardian()
+      .setAuthStrategy(auth)
+      .setPolicyProvider(policy)
+      .registerTransport({ name: 't', matches: () => false, handle: async () => new Response() });
+    // wiring applied immediately; transports are buffered until start()
+    expect(getAuthStrategy()).toBe(auth);
+    expect(getPolicyProvider()).toBe(policy);
+    expect(registeredTransports()).toHaveLength(0);
+    expect(typeof builder.start).toBe('function');
+    expect(typeof startGuardian).toBe('function');
+  });
+});

--- a/packages/guardian/src/index.ts
+++ b/packages/guardian/src/index.ts
@@ -87,7 +87,7 @@ export interface GuardianBuilder {
   setAuthStrategy(strategy: AuthStrategy): GuardianBuilder;
   setPolicyProvider(provider: PolicyProvider): GuardianBuilder;
   registerTransport(transport: Transport): GuardianBuilder;
-  start(): GuardianServers;
+  start(options?: StartGuardianOptions): GuardianServers;
 }
 
 export function createGuardian(): GuardianBuilder {

--- a/packages/guardian/src/index.ts
+++ b/packages/guardian/src/index.ts
@@ -1,0 +1,113 @@
+/**
+ * `@openpalm/guardian` public library surface.
+ *
+ * Importing this module is side-effect free — it does NOT bind any listener.
+ * `server.ts` only boots when run as the entrypoint (`import.meta.main`), so a
+ * downstream composition root can import the seams, wire them up, and then call
+ * {@link startGuardian} / {@link createGuardian} itself.
+ *
+ * ```ts
+ * import { createGuardian } from '@openpalm/guardian';
+ * createGuardian()
+ *   .setAuthStrategy(myOidcStrategy)   // SSO/OIDC instead of Basic tokens
+ *   .setPolicyProvider(myRbacPolicy)   // per-tenant / role-based authorization
+ *   .registerTransport(myA2aTransport) // additive /a2a route
+ *   .start();
+ * ```
+ */
+import { startGuardian, type GuardianServers, type StartGuardianOptions } from './server.ts';
+import { setAuthStrategy, type AuthStrategy } from './auth.ts';
+import { setPolicyProvider, type PolicyProvider } from './policy.ts';
+import { type Transport } from './transport.ts';
+
+// --- composition root ---
+export { startGuardian };
+export type { GuardianServers, StartGuardianOptions };
+
+// --- transport seam (additive direct-listener protocols, e.g. A2A) ---
+export {
+  registerTransport,
+  registeredTransports,
+  clearTransports,
+  matchTransport,
+} from './transport.ts';
+export type { Transport };
+
+// --- authentication seam (e.g. SSO/OIDC) ---
+export {
+  authenticate,
+  setAuthStrategy,
+  getAuthStrategy,
+  resetAuthStrategy,
+  basicTokenAuthStrategy,
+  invalidatePrincipalCache,
+} from './auth.ts';
+export type { AuthStrategy, AuthenticatedPrincipal } from './auth.ts';
+
+// --- authorization policy seam (RBAC, data scope, routing) ---
+export {
+  setPolicyProvider,
+  getPolicyProvider,
+  resetPolicyProvider,
+  allowAllPolicy,
+} from './policy.ts';
+export type { PolicyProvider, PolicyRequest, PolicyDecision } from './policy.ts';
+
+// --- principal store (token-backed identities the guardian trusts) ---
+export {
+  initializePrincipalStore,
+  listPrincipals,
+  getPrincipalRecord,
+  upsertPrincipal,
+  rotatePrincipal,
+  setPrincipalEnabled,
+  seedPortalPrincipalsFromEnv,
+  hashToken,
+} from './state-db.ts';
+export type { PrincipalKind, PrincipalRecord } from './state-db.ts';
+
+// --- ownership (a principal may only touch sessions it created) ---
+export {
+  principalKey,
+  recordSessionOwner,
+  ownsSession,
+  forgetSession,
+  ownedSessionIds,
+  recordPermissionOwner,
+  ownsPermission,
+} from './ownership.ts';
+export type { Principal } from './ownership.ts';
+
+/**
+ * Fluent composition root. Chain seam wiring, then {@link GuardianBuilder.start}.
+ * Equivalent to the standalone `setAuthStrategy` / `setPolicyProvider` /
+ * `registerTransport` + {@link startGuardian} calls.
+ */
+export interface GuardianBuilder {
+  setAuthStrategy(strategy: AuthStrategy): GuardianBuilder;
+  setPolicyProvider(provider: PolicyProvider): GuardianBuilder;
+  registerTransport(transport: Transport): GuardianBuilder;
+  start(): GuardianServers;
+}
+
+export function createGuardian(): GuardianBuilder {
+  const transports: Transport[] = [];
+  const builder: GuardianBuilder = {
+    setAuthStrategy(strategy) {
+      setAuthStrategy(strategy);
+      return builder;
+    },
+    setPolicyProvider(provider) {
+      setPolicyProvider(provider);
+      return builder;
+    },
+    registerTransport(transport) {
+      transports.push(transport);
+      return builder;
+    },
+    start(options: StartGuardianOptions = {}) {
+      return startGuardian({ ...options, transports: [...transports, ...(options.transports ?? [])] });
+    },
+  };
+  return builder;
+}

--- a/packages/guardian/src/policy.ts
+++ b/packages/guardian/src/policy.ts
@@ -1,0 +1,62 @@
+/**
+ * Authorization policy seam.
+ *
+ * Public OpenPalm authorizes by ownership (a principal may only touch sessions
+ * it created — see `ownership.ts`) and rate limits. Richer authorization
+ * (per-tenant data scope, role-based access, multi-agent routing) is a
+ * downstream concern. This module defines the *port* those distributions
+ * implement; the public guardian ships only the permissive default and does not
+ * consult it on the built-in routes, so wiring a provider changes nothing here.
+ *
+ * A downstream auth strategy or transport reads {@link getPolicyProvider} to
+ * make decisions, and the composition root installs one via
+ * {@link setPolicyProvider}.
+ */
+
+/** An authorization request: a principal attempting an action on a resource. */
+export interface PolicyRequest {
+  /** The authenticated principal id (e.g. portal/direct id, or a user subject). */
+  principalId: string;
+  /** Optional principal kind / role hint. */
+  kind?: string;
+  /** The action being attempted (e.g. `"oc:session.read"`, `"a2a:invoke"`). */
+  action: string;
+  /** The resource the action targets (e.g. a session id, agent name, tenant). */
+  resource?: string;
+  /** Arbitrary additional attributes for attribute-based decisions. */
+  attributes?: Record<string, unknown>;
+}
+
+/** The outcome of a policy decision. */
+export interface PolicyDecision {
+  allow: boolean;
+  /** Optional human-readable reason (surfaced in audit logs / 403 bodies). */
+  reason?: string;
+}
+
+/** Pluggable authorization policy. */
+export interface PolicyProvider {
+  authorize(request: PolicyRequest): PolicyDecision | Promise<PolicyDecision>;
+}
+
+/** The public default: allow everything (ownership + rate limits still apply). */
+export const allowAllPolicy: PolicyProvider = {
+  authorize: () => ({ allow: true }),
+};
+
+let activeProvider: PolicyProvider = allowAllPolicy;
+
+/** Install the active authorization policy. */
+export function setPolicyProvider(provider: PolicyProvider): void {
+  activeProvider = provider;
+}
+
+/** The active authorization policy (defaults to {@link allowAllPolicy}). */
+export function getPolicyProvider(): PolicyProvider {
+  return activeProvider;
+}
+
+/** Reset to the permissive default (test/composition helper). */
+export function resetPolicyProvider(): void {
+  activeProvider = allowAllPolicy;
+}

--- a/packages/guardian/src/server.ts
+++ b/packages/guardian/src/server.ts
@@ -1,3 +1,4 @@
+#!/usr/bin/env bun
 import { createLogger } from './logger.ts';
 
 import { handleAdminRequest } from './admin';
@@ -18,6 +19,7 @@ import { handleProxy, OC_PREFIX } from './proxy';
 import { allow, activeRateLimiters, PORTAL_RATE_LIMIT, PORTAL_RATE_WINDOW_MS, USER_RATE_LIMIT, USER_RATE_WINDOW_MS } from './rate-limit';
 import { runDriftCheckWithRetry, startProxyRecovery, isProxyEnabled } from './drift';
 import { initializePrincipalStore, listPrincipals, seedPortalPrincipalsFromEnv } from './state-db';
+import { matchTransport, registerTransport, type Transport } from './transport';
 
 const logger = createLogger('guardian');
 
@@ -128,6 +130,12 @@ async function handleDirectRequest(req: Request): Promise<Response> {
   if (url.pathname === OC_PREFIX || url.pathname.startsWith(`${OC_PREFIX}/`)) {
     return handleOcRequest(req, requestId, 'direct');
   }
+  const transport = matchTransport(url, req);
+  if (transport) {
+    const response = await transport.handle(req, requestId);
+    countRequest(`${transport.name}:${response.status}`);
+    return response;
+  }
   return json(404, { error: 'not_found', requestId });
 }
 
@@ -139,33 +147,70 @@ async function handleAdminListenerRequest(req: Request): Promise<Response> {
   return json(404, { error: 'not_found', requestId });
 }
 
-initializePrincipalStore();
-seedPortalPrincipalsFromEnv();
-if (MCP_ENABLED) seedMcpPrincipalFromToken();
+/** A running guardian: its three Bun listeners plus a combined stop(). */
+export interface GuardianServers {
+  internal: ReturnType<typeof Bun.serve>;
+  direct: ReturnType<typeof Bun.serve>;
+  admin: ReturnType<typeof Bun.serve>;
+  stop(): void;
+}
 
-void runDriftCheckWithRetry()
-  .then((enabled) => {
-    if (!enabled) startProxyRecovery();
-  })
-  .catch((err) => {
-    logger.error('drift_check_error', { error: String(err) });
-    startProxyRecovery();
+export interface StartGuardianOptions {
+  /** Additive direct-listener transports to register before binding. */
+  transports?: Transport[];
+}
+
+/**
+ * Composition root: seed the principal store, start drift recovery, and bind the
+ * internal (8080), direct (3830) and admin (3831) listeners. Running
+ * `bun run src/server.ts` calls this automatically (see the `import.meta.main`
+ * guard below). Downstream distributions import and call it after registering
+ * their transports / auth strategy / policy provider.
+ */
+export function startGuardian(options: StartGuardianOptions = {}): GuardianServers {
+  for (const transport of options.transports ?? []) registerTransport(transport);
+
+  initializePrincipalStore();
+  seedPortalPrincipalsFromEnv();
+  if (MCP_ENABLED) seedMcpPrincipalFromToken();
+
+  void runDriftCheckWithRetry()
+    .then((enabled) => {
+      if (!enabled) startProxyRecovery();
+    })
+    .catch((err) => {
+      logger.error('drift_check_error', { error: String(err) });
+      startProxyRecovery();
+    });
+
+  const internal = Bun.serve({ port: INTERNAL_PORT, idleTimeout: 0, fetch: handleInternalRequest });
+  const direct = Bun.serve({ port: DIRECT_PORT, idleTimeout: 0, fetch: handleDirectRequest });
+  const admin = Bun.serve({ port: ADMIN_PORT, idleTimeout: 0, fetch: handleAdminListenerRequest });
+
+  audit({
+    requestId: crypto.randomUUID(),
+    action: 'guardian_boot',
+    status: 'ok',
   });
 
-Bun.serve({ port: INTERNAL_PORT, idleTimeout: 0, fetch: handleInternalRequest });
-Bun.serve({ port: DIRECT_PORT, idleTimeout: 0, fetch: handleDirectRequest });
-Bun.serve({ port: ADMIN_PORT, idleTimeout: 0, fetch: handleAdminListenerRequest });
+  logger.info('started', {
+    internalPort: INTERNAL_PORT,
+    directPort: DIRECT_PORT,
+    adminPort: ADMIN_PORT,
+    directIngressEnabled: DIRECT_INGRESS_ENABLED,
+    seededPrincipals: listPrincipals().length,
+  });
 
-audit({
-  requestId: crypto.randomUUID(),
-  action: 'guardian_boot',
-  status: 'ok',
-});
+  return {
+    internal,
+    direct,
+    admin,
+    stop() {
+      internal.stop();
+      direct.stop();
+      admin.stop();
+    },
+  };
+}
 
-logger.info('started', {
-  internalPort: INTERNAL_PORT,
-  directPort: DIRECT_PORT,
-  adminPort: ADMIN_PORT,
-  directIngressEnabled: DIRECT_INGRESS_ENABLED,
-  seededPrincipals: listPrincipals().length,
-});
+if (import.meta.main) startGuardian();

--- a/packages/guardian/src/server.ts
+++ b/packages/guardian/src/server.ts
@@ -17,7 +17,7 @@ import {
 } from './oc-bounds';
 import { handleProxy, OC_PREFIX } from './proxy';
 import { allow, activeRateLimiters, PORTAL_RATE_LIMIT, PORTAL_RATE_WINDOW_MS, USER_RATE_LIMIT, USER_RATE_WINDOW_MS } from './rate-limit';
-import { runDriftCheckWithRetry, startProxyRecovery, isProxyEnabled } from './drift';
+import { runDriftCheckWithRetry, startProxyRecovery, stopProxyRecovery, isProxyEnabled } from './drift';
 import { initializePrincipalStore, listPrincipals, seedPortalPrincipalsFromEnv } from './state-db';
 import { matchTransport, registerTransport, type Transport } from './transport';
 
@@ -206,6 +206,7 @@ export function startGuardian(options: StartGuardianOptions = {}): GuardianServe
     direct,
     admin,
     stop() {
+      stopProxyRecovery();
       internal.stop();
       direct.stop();
       admin.stop();

--- a/packages/guardian/src/transport.ts
+++ b/packages/guardian/src/transport.ts
@@ -1,0 +1,66 @@
+/**
+ * Direct-listener transport seam.
+ *
+ * The guardian's direct ingress (port {@link GUARDIAN_DIRECT_PORT}, default
+ * 3830) serves a fixed set of built-in routes (`/oc`, and `/mcp` when
+ * `GUARDIAN_MCP=true`). A *transport* is an additive route handler plugged onto
+ * that same listener so downstream distributions can offer extra protocols
+ * (e.g. A2A) WITHOUT forking `server.ts`.
+ *
+ * Public OpenPalm registers no transports; the registry is the seam, not a
+ * feature. Register before {@link startGuardian} runs:
+ *
+ * ```ts
+ * import { registerTransport, startGuardian } from '@openpalm/guardian';
+ * registerTransport(myA2aTransport);
+ * startGuardian();
+ * ```
+ */
+
+/** A request handler plugged onto the guardian direct listener. */
+export interface Transport {
+  /** Stable identifier, used in request counters / diagnostics (e.g. `"a2a"`). */
+  name: string;
+  /**
+   * Optional env-var gate. When set, the transport is only consulted while
+   * `Bun.env[enabledEnv] === 'true'` — mirroring how `/mcp` is gated by
+   * `GUARDIAN_MCP`. Omit for an always-on transport.
+   */
+  enabledEnv?: string;
+  /** Return true if this transport claims the request. */
+  matches(url: URL, req: Request): boolean;
+  /** Handle a claimed request. Performs its own authentication/authorization. */
+  handle(req: Request, requestId: string): Promise<Response>;
+}
+
+const transports: Transport[] = [];
+
+/** Register an additive direct-listener transport. Throws on a duplicate name. */
+export function registerTransport(transport: Transport): void {
+  if (transports.some((t) => t.name === transport.name)) {
+    throw new Error(`transport already registered: ${transport.name}`);
+  }
+  transports.push(transport);
+}
+
+/** All registered transports, in registration order. */
+export function registeredTransports(): readonly Transport[] {
+  return transports;
+}
+
+/** Test/composition helper: drop all registered transports. */
+export function clearTransports(): void {
+  transports.length = 0;
+}
+
+/**
+ * Resolve the first registered transport that claims the request, honoring each
+ * transport's {@link Transport.enabledEnv} gate. Returns null when none match.
+ */
+export function matchTransport(url: URL, req: Request): Transport | null {
+  for (const transport of transports) {
+    if (transport.enabledEnv && Bun.env[transport.enabledEnv] !== 'true') continue;
+    if (transport.matches(url, req)) return transport;
+  }
+  return null;
+}

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openpalm/lib",
-  "version": "0.12.14",
+  "version": "0.12.16",
   "license": "MPL-2.0",
   "type": "module",
   "description": "Shared control-plane library for OpenPalm — lifecycle, staging, secrets, portals, connections, scheduler",

--- a/packages/lib/src/control-plane/migrations.ts
+++ b/packages/lib/src/control-plane/migrations.ts
@@ -964,6 +964,54 @@ function purgeStaleEnabledAddons(ctx: MigrationCtx): void {
   ctx.log(`set OP_ENABLED_ADDONS=${cleaned.join(',')}`);
 }
 
+/**
+ * Patch portals.compose.yml in-place to add the OP_GUARDIAN_VERSION and
+ * PLATFORM_VERSION env vars to the guardian service. The thin-host entrypoint
+ * (v0.12.14+) needs these to resolve the correct npm package versions on boot.
+ * Both values are derived from OP_GUARDIAN_IMAGE_TAG / OP_IMAGE_TAG — vars
+ * already written to stack.env by the lifecycle. No-op when already present.
+ */
+function patchPortalsComposeForThinHost(ctx: MigrationCtx): void {
+  const path = join(ctx.stackDir, 'portals.compose.yml');
+  if (!existsSync(path)) return;
+
+  const content = readFileSync(path, 'utf-8');
+  if (content.includes('OP_GUARDIAN_VERSION:')) return; // already patched
+
+  // Insert after the OP_ASSISTANT_URL line in the guardian service's environment
+  // block. This line is stable across versions and uniquely identifies the right
+  // insertion point in the guardian service (not the discord/slack services).
+  const ANCHOR = '      OP_ASSISTANT_URL: http://assistant:4096';
+  if (!content.includes(ANCHOR)) {
+    ctx.log('WARN: portals.compose.yml does not contain expected anchor line; skipping thin-host env patch — apply manually');
+    ctx.notes.push(
+      'portals.compose.yml could not be auto-patched for the guardian thin-host. ' +
+      'Add OP_GUARDIAN_VERSION and PLATFORM_VERSION to the guardian service environment manually ' +
+      '(see packages/skeleton/config/stack/portals.compose.yml for the reference values).',
+    );
+    return;
+  }
+
+  const INSERTION = [
+    '      # Thin-host entrypoint uses these to install @openpalm/guardian and',
+    '      # @openpalm/skeleton at the correct versions on first boot.',
+    '      # OP_GUARDIAN_IMAGE_TAG (e.g. v0.12.9) may differ from OP_IMAGE_TAG when',
+    '      # guardian is released independently of the platform.',
+    '      OP_GUARDIAN_VERSION: ${OP_GUARDIAN_IMAGE_TAG:-${OP_IMAGE_TAG:-}}',
+    '      PLATFORM_VERSION: ${OP_IMAGE_TAG:-}',
+  ].join('\n');
+
+  const patched = content.replace(ANCHOR, `${ANCHOR}\n${INSERTION}`);
+
+  if (ctx.dryRun) {
+    ctx.log('[dry-run] would patch portals.compose.yml with OP_GUARDIAN_VERSION + PLATFORM_VERSION');
+    return;
+  }
+
+  writeFileSync(path, patched);
+  ctx.log('patched portals.compose.yml: added OP_GUARDIAN_VERSION and PLATFORM_VERSION to guardian service env');
+}
+
 const RELEASE_MIGRATIONS: ReleaseMigration[] = [
   {
     // Pinned to the release that INTRODUCED per-image tags, not the lib
@@ -1043,6 +1091,28 @@ const RELEASE_MIGRATIONS: ReleaseMigration[] = [
         if (!KNOWN_ADDON_IDS.has(id)) {
           throw new Error(`post-migration check failed: stale addon ID '${id}' still in OP_ENABLED_ADDONS`);
         }
+      }
+    },
+  },
+  {
+    // Pinned to v0.12.14: the guardian thin-host entrypoint (introduced in
+    // 0.12.14) needs OP_GUARDIAN_VERSION and PLATFORM_VERSION in the container
+    // environment to resolve which @openpalm/guardian and @openpalm/skeleton
+    // packages to install at boot. These are derived from the already-present
+    // OP_GUARDIAN_IMAGE_TAG and OP_IMAGE_TAG vars (written by the lifecycle to
+    // stack.env). portals.compose.yml is a system-managed file (users customise
+    // via custom.compose.yml), so a targeted in-place patch is safe.
+    // Idempotent: no-op when the vars are already present.
+    version: 'v0.12.14-rc.1',
+    describe: 'patch portals.compose.yml — add OP_GUARDIAN_VERSION + PLATFORM_VERSION to guardian service env',
+    apply: patchPortalsComposeForThinHost,
+    verify(ctx) {
+      if (ctx.dryRun) return;
+      const path = join(ctx.stackDir, 'portals.compose.yml');
+      if (!existsSync(path)) return;
+      const content = readFileSync(path, 'utf-8');
+      if (!content.includes('OP_GUARDIAN_VERSION:')) {
+        throw new Error('post-migration check failed: OP_GUARDIAN_VERSION still missing from portals.compose.yml');
       }
     },
   },

--- a/packages/skeleton/config/stack/portals.compose.yml
+++ b/packages/skeleton/config/stack/portals.compose.yml
@@ -78,6 +78,12 @@ services:
       GUARDIAN_DIRECT_PORT: "3830"
       GUARDIAN_ADMIN_PORT: "3831"
       OP_ASSISTANT_URL: http://assistant:4096
+      # Thin-host entrypoint uses these to install @openpalm/guardian and
+      # @openpalm/skeleton at the correct versions on first boot.
+      # OP_GUARDIAN_IMAGE_TAG (e.g. v0.12.9) may differ from OP_IMAGE_TAG when
+      # guardian is released independently of the platform.
+      OP_GUARDIAN_VERSION: ${OP_GUARDIAN_IMAGE_TAG:-${OP_IMAGE_TAG:-}}
+      PLATFORM_VERSION: ${OP_IMAGE_TAG:-}
       OPENCODE_TIMEOUT_MS: "0"
       # OpenCode global config (opencode.jsonc) lives in OP_HOME/config/guardian,
       # bind-mounted at /etc/opencode below.

--- a/packages/skeleton/package.json
+++ b/packages/skeleton/package.json
@@ -3,5 +3,10 @@
   "version": "0.12.14",
   "description": "OpenPalm default config skeleton — seeded into OP_HOME on install",
   "private": false,
-  "license": "MPL-2.0"
+  "license": "MPL-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/itlackey/openpalm",
+    "directory": "packages/skeleton"
+  }
 }

--- a/packages/skeleton/package.json
+++ b/packages/skeleton/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openpalm/skeleton",
-  "version": "0.12.14",
+  "version": "0.12.16",
   "description": "OpenPalm default config skeleton — seeded into OP_HOME on install",
   "private": false,
   "license": "MPL-2.0",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openpalm/ui",
   "description": "SvelteKit web UI and API for OpenPalm stack management",
-  "version": "0.12.14",
+  "version": "0.12.16",
   "license": "MPL-2.0",
   "type": "module",
   "//minHarnessContract": "Minimum native Electron harness contract this UI build requires (design §5.3). The harness refuses to self-update onto a build whose minHarnessContract exceeds the contract it provides and prompts an app re-download instead. Bump ONLY when the UI starts depending on a new IPC method / spawn env key; keep in lockstep with packages/electron/src/harness-contract.ts HARNESS_CONTRACT_VERSION.",

--- a/packages/ui/src/routes/admin/voice/server.vitest.ts
+++ b/packages/ui/src/routes/admin/voice/server.vitest.ts
@@ -252,7 +252,7 @@ describe('PUT /admin/voice — host fallback overlays', () => {
 		expect(stepNames).toContain('compose-up');
 	});
 
-	test('falls back gracefully when rootless detection cannot reach docker', async () => {
+	test('falls back gracefully when rootless detection cannot reach docker', { timeout: 10_000 }, async () => {
 		// Temporarily unset VITEST so the rootless detection runs. The probe
 		// will fail (no docker daemon in the test environment), but the
 		// route MUST NOT 502 — it just skips the overlay and continues.

--- a/scripts/setup.ps1
+++ b/scripts/setup.ps1
@@ -12,7 +12,7 @@ if ($PSVersionTable.PSVersion.Major -lt 7) {
 
 $Repo = 'itlackey/openpalm'
 $Binary = 'openpalm-cli-windows-x64.exe'
-$ScriptVersion = '0.12.13'
+$ScriptVersion = '0.12.14'
 
 function Normalize-Version {
     param(

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -7,7 +7,7 @@
 set -euo pipefail
 
 # Updated automatically by release workflow — do not edit manually
-SCRIPT_VERSION="0.12.13"
+SCRIPT_VERSION="0.12.14"
 
 # ── Colors ────────────────────────────────────────────────────────────
 RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; BLUE='\033[0;34m'; NC='\033[0m'


### PR DESCRIPTION
## What

Ships the guardian thin-host crash fix and associated release tooling fixes as v0.12.16.

### Root cause (Discord "connection reset" / guardian not starting)

The v0.12.9 guardian switched to a thin-host model: the Docker image downloads `@openpalm/guardian` from npm at startup. Three bugs caused it to immediately crash:

1. **Missing env vars** — `OP_GUARDIAN_VERSION` and `PLATFORM_VERSION` were not in the guardian container environment, so `resolve_version()` in `entrypoint.sh` exited with error
2. **Missing services** — The new `entrypoint.sh` only started the guardian server; it was missing the OpenCode moderator (port 4097) and OpenAI API server (port 8182)
3. **Wrong Dockerfile COPY path** — `COPY entrypoint.sh` used a path relative to the Dockerfile directory, but the build context is the repo root (`context: .`)

### Fixes

| Fix | File |
|-----|------|
| Add `OP_GUARDIAN_VERSION` + `PLATFORM_VERSION` to guardian service env | `.openpalm/config/stack/portals.compose.yml`, `packages/skeleton/config/stack/portals.compose.yml` |
| Restore OpenCode moderator + OpenAI API server startup | `containers/guardian/entrypoint.sh` |
| Release migration to patch existing users' `portals.compose.yml` on upgrade | `packages/lib/src/control-plane/migrations.ts` |
| Fix Dockerfile COPY path | `containers/guardian/Dockerfile` |
| Add missing `repository` field to skeleton (npm provenance) | `packages/skeleton/package.json` |

### Library seams added (guardian as importable library)

Makes `@openpalm/guardian` importable in addition to runnable. Exposes:
- `createGuardian()` / `startGuardian()` composition root
- `registerTransport()` / `Transport` seam
- `setAuthStrategy()` / `AuthStrategy` seam
- `setPolicyEngine()` / `PolicyEngine` seam

### Release workflow improvements

- `unit=guardian` now publishes `@openpalm/guardian` + `@openpalm/skeleton` npm (thin-host needs both at runtime)
- `unit=platform` now builds guardian + assistant Docker images (complete artifact set)
- Decoupled guardian npm publish from lib (prevents platform regression guard failures)

Closes #513

## Released as v0.12.16