### PR TITLE
fix(guardian): thin-host installs artifacts with bun, not npm (#518)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,16 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - The audit writer is created lazily on first write, so importing the guardian
   library has no filesystem side effects.
 
+### Fixed
+
+- **Guardian thin-host container boots again.** The entrypoint installed the
+  exact-pinned `@openpalm/guardian` / `@openpalm/skeleton` artifacts with
+  `npm`, but the image is `FROM oven/bun:1.3-slim`, which ships no node/npm —
+  the container exited 127 with `npm: command not found`. It now installs with
+  `bun add ... --production` (the runtime it already uses), keeping the exact
+  version pin and the `$prefix/node_modules/@openpalm/...` layout the final
+  `bun run` depends on. (#518)
+
 ## [0.12.10] - 2026-06-17
 
 ### Fixed

--- a/containers/guardian/entrypoint.sh
+++ b/containers/guardian/entrypoint.sh
@@ -13,7 +13,12 @@ resolve_version() {
 install_artifact() {
   local pkg="$1" version="$2" prefix="$3"
   echo "Installing ${pkg}@${version}..."
-  npm install --prefix "$prefix" "${pkg}@${version}" --omit=dev --prefer-offline
+  # The image is FROM oven/bun:1.3-slim, which ships no node/npm. Use bun, the
+  # runtime this entrypoint already relies on. bun installs into the cwd's
+  # node_modules, so cd into the prefix; the exact-version pin (${version}) is a
+  # security boundary and must not be loosened to a range.
+  mkdir -p "$prefix"
+  ( cd "$prefix" && bun add "${pkg}@${version}" --production )
 }
 
 GUARDIAN_VERSION=$(resolve_version "${OP_GUARDIAN_VERSION:-}" "${PLATFORM_VERSION:-}" "GUARDIAN")

--- a/scripts/setup.ps1
+++ b/scripts/setup.ps1
@@ -12,7 +12,7 @@ if ($PSVersionTable.PSVersion.Major -lt 7) {
 
 $Repo = 'itlackey/openpalm'
 $Binary = 'openpalm-cli-windows-x64.exe'
-$ScriptVersion = '0.12.14'
+$ScriptVersion = '0.12.16'
 
 function Normalize-Version {
     param(

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -7,7 +7,7 @@
 set -euo pipefail
 
 # Updated automatically by release workflow — do not edit manually
-SCRIPT_VERSION="0.12.14"
+SCRIPT_VERSION="0.12.16"
 
 # ── Colors ────────────────────────────────────────────────────────────
 RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; BLUE='\033[0;34m'; NC='\033[0m'


### PR DESCRIPTION
## Root cause

The guardian thin-host entrypoint (`containers/guardian/entrypoint.sh`) installs the exact-pinned `@openpalm/guardian` and `@openpalm/skeleton` artifacts via `npm install --prefix ...`. But the image is `FROM oven/bun:1.3-slim`, whose apt layer installs only `curl bash ca-certificates` — there is **no node or npm**. So the container fails at boot with `npm: command not found` and exits 127.

Reproduced live on ACA with `openpalm/guardian:v0.12.16`; the entrypoint and Dockerfile on `main` are unchanged, so latest is affected too.

## Fix

Install the artifacts with `bun add ... --production` instead — Bun is already the runtime this entrypoint relies on (it uses `bun add -g` for tools and the final `exec bun run .../server.ts`). Bun installs into the cwd's `node_modules`, so we `cd` into the prefix:

```sh
install_artifact() {
  local pkg="$1" version="$2" prefix="$3"
  echo "Installing ${pkg}@${version}..."
  mkdir -p "$prefix"
  ( cd "$prefix" && bun add "${pkg}@${version}" --production )
}
```

No Dockerfile change needed — the Bun-only fix is preferred since Bun is the runtime.

## Why this is correct

- **Preserves the exact-version pin.** `bun add ${pkg}@${version}` keeps the exact pin (verified: generated `package.json` records `"@openpalm/guardian": "0.12.17"`, no caret/range). This is a security boundary and is not loosened.
- **Preserves the layout the entrypoint depends on.** The final `exec bun run "${GUARDIAN_PKG}/src/server.ts"` resolves `GUARDIAN_PKG=/opt/openpalm/guardian/node_modules/@openpalm/guardian`. `bun add` inside the prefix lands the package at exactly `$prefix/node_modules/@openpalm/<pkg>`.
- **`--production`** skips devDependencies (the Bun equivalent of `--omit=dev`).

## Verification

Smoke-tested locally with Bun 1.3.14 against a real package in an empty prefix (no pre-existing `package.json`):

```
$ ( cd /tmp/prefix && bun add @openpalm/guardian@0.12.17 --production )
installed @openpalm/guardian@0.12.17 ...
$ ls /tmp/prefix/node_modules/@openpalm/guardian/src/server.ts
-> exists
$ grep guardian /tmp/prefix/package.json
-> "@openpalm/guardian": "0.12.17"   (exact pin, no range)
```

The `$prefix/node_modules/@openpalm/guardian/src/server.ts` path the final `bun run` needs is produced, pinned to the exact requested version. `bash -n` on the modified entrypoint passes.

Fixes #518

🤖 Generated with [Claude Code](https://claude.com/claude-code)