### PR TITLE
fix(ci): release workflow — ordering, regression guard, preflight, and CLI deps

### DIFF
--- a/.github/workflows/publish-npm-package.yml
+++ b/.github/workflows/publish-npm-package.yml
@@ -41,6 +41,11 @@ on:
         required: false
         type: boolean
         default: true
+      allow-existing:
+        description: 'When true, treat an already-published version as a warning instead of an error.'
+        required: false
+        type: boolean
+        default: false
   workflow_call:
     inputs:
       package-dir:
@@ -70,6 +75,11 @@ on:
         default: false
       dry-run:
         description: 'Pack + validate but do NOT npm publish or commit.'
+        required: false
+        type: boolean
+        default: false
+      allow-existing:
+        description: 'When true, treat an already-published version as a warning instead of an error. Default false — accidental re-publishes fail loudly.'
         required: false
         type: boolean
         default: false
@@ -209,6 +219,7 @@ jobs:
         working-directory: ${{ inputs.package-dir }}
         env:
           DRY_RUN: ${{ inputs.dry-run }}
+          ALLOW_EXISTING: ${{ inputs.allow-existing }}
         run: |
           VERSION=$(node -p "require('./package.json').version")
           if [ "${DRY_RUN}" = 'true' ]; then
@@ -225,9 +236,14 @@ jobs:
           fi
           npm publish "${TARBALL}" --provenance --access public ${TAG_ARGS} || {
             EXIT_CODE=$?
-            # Treat "already published" as success so version bump commit still happens
+            # Check if the version is already published
             if npm view "${{ inputs.package-name }}@${VERSION}" version 2>/dev/null; then
-              echo "::warning::Version ${VERSION} already published — skipping"
+              if [ "${ALLOW_EXISTING}" = 'true' ]; then
+                echo "::warning::Version ${VERSION} already published — skipping (allow-existing=true)"
+              else
+                echo "::error::Version ${VERSION} is already published on npm. Set allow-existing=true to treat this as a warning instead of an error."
+                exit 1
+              fi
             else
               exit $EXIT_CODE
             fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,14 +124,15 @@ jobs:
             const unit = process.env.UNIT;
 
             // Only npm-published units need a regression guard
-            if (!['platform', 'major'].includes(unit)) {
-              console.log('Non-platform unit — skipping npm regression guard.');
+            if (!['platform', 'major', 'guardian'].includes(unit)) {
+              console.log('Non-npm unit — skipping npm regression guard.');
               process.exit(0);
             }
 
             const npmPackages = {
               platform: ['@openpalm/lib', 'openpalm', '@openpalm/ui'],
               major: ['@openpalm/lib', 'openpalm', '@openpalm/ui'],
+              guardian: ['@openpalm/guardian', '@openpalm/skeleton'],
             };
             const packages = npmPackages[unit] || [];
 
@@ -184,11 +185,11 @@ jobs:
             }
           "
 
-  # ── Preflight gate (platform + major only) ────────────────────────────────────
+  # ── Preflight gate (platform + major + guardian) ─────────────────────────────
   preflight:
     name: Preflight (test gate)
     needs: compute-version
-    if: inputs.unit == 'platform' || inputs.unit == 'major'
+    if: inputs.unit == 'platform' || inputs.unit == 'major' || inputs.unit == 'guardian'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -206,12 +207,20 @@ jobs:
             exit 1
           fi
 
-      - name: Install + test
+      - name: Install + test (platform / major)
+        if: inputs.unit == 'platform' || inputs.unit == 'major'
         run: |
           bun install --frozen-lockfile
           bun run test
           bun run ui:check
+          bun run ui:test:unit
           bun run electron:test
+
+      - name: Install + test (guardian)
+        if: inputs.unit == 'guardian'
+        run: |
+          bun install --frozen-lockfile
+          bun test packages/guardian
 
   # ── Stamp + commit + push the new version ─────────────────────────────────────
   bump:
@@ -426,8 +435,13 @@ jobs:
 
   docker-guardian:
     name: Docker openpalm/guardian
-    needs: [compute-version, bump]
-    if: always() && needs.bump.result == 'success' && (inputs.unit == 'portals' || inputs.unit == 'guardian' || inputs.unit == 'platform' || inputs.unit == 'major')
+    needs: [compute-version, bump, npm-guardian, npm-skeleton]
+    if: |
+      always() &&
+      needs.bump.result == 'success' &&
+      (inputs.unit == 'guardian' || inputs.unit == 'platform' || inputs.unit == 'major') &&
+      needs.npm-guardian.result != 'failure' &&
+      needs.npm-skeleton.result != 'failure'
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
@@ -526,8 +540,8 @@ jobs:
   # ── CLI native binaries (platform + major) ────────────────────────────────────
   cli:
     name: CLI binary (${{ matrix.artifact }})
-    needs: [compute-version, bump, npm-skeleton, npm-lib, npm-cli, npm-ui, npm-guardian]
-    if: always() && needs.bump.result == 'success' && needs.npm-skeleton.result == 'success' && needs.npm-lib.result == 'success' && needs.npm-cli.result == 'success' && needs.npm-ui.result == 'success' && needs.npm-guardian.result == 'success' && (inputs.unit == 'platform' || inputs.unit == 'major')
+    needs: [compute-version, bump, npm-skeleton, npm-lib, npm-cli]
+    if: always() && needs.bump.result == 'success' && needs.npm-skeleton.result == 'success' && needs.npm-lib.result == 'success' && needs.npm-cli.result == 'success' && (inputs.unit == 'platform' || inputs.unit == 'major')
     runs-on: ${{ matrix.os }}
     timeout-minutes: 20
     strategy:


### PR DESCRIPTION
## Summary

Batch of correctness and safety fixes to the release orchestrator and npm publish reusable workflow.

### C1 + C2 — `docker-guardian` ordering and trigger scope

- **C1**: `docker-guardian` now lists `npm-guardian` and `npm-skeleton` in its `needs` so the Docker image is never pushed before the npm packages it downloads at startup are live. Skipped npm jobs (e.g. when unit=portals was a trigger) are handled via `!= 'failure'` guards rather than a hard dependency.
- **C2**: Removed `inputs.unit == 'portals'` from the `docker-guardian` if-condition. Portals releases don't publish `@openpalm/guardian` to npm, so building the image for them creates a version mismatch at startup. The job now fires only for `guardian`, `platform`, and `major`.

### C3 — Regression guard covers `unit=guardian`

The inline node regression-guard script previously exited 0 for any unit that wasn't `platform` or `major`. Added `guardian` to the checked units with packages `['@openpalm/guardian', '@openpalm/skeleton']`.

### C4 — `publish-npm-package.yml`: 409 / already-published is now an error

Added a new `allow-existing` boolean input (default `false`) to both `workflow_dispatch` and `workflow_call` interfaces. When `false` (the new default), an already-published version emits `::error::` and exits 1. Set `allow-existing: true` to restore the previous warning-only behaviour for situations where idempotent re-publish is intentional.

### M5 — `bun run ui:test:unit` added to preflight gate

The `preflight` job for `platform` and `major` now also runs `bun run ui:test:unit` after the existing `bun run test`, `bun run ui:check`, and `bun run electron:test` steps.

### M6 — CLI binary job no longer depends on `npm-guardian`

Removed `npm-guardian` (and `npm-ui`, which was also in the list) from the `cli` job's `needs`. The CLI binary is a statically-linked Bun binary — it depends on `npm-cli` (its own package), `npm-lib`, and `npm-skeleton`, but not on the guardian or UI packages.

### H2 — Preflight gate now runs for `unit=guardian`

Extended the `preflight` if-condition to include `guardian`. For guardian releases a separate step runs `bun test packages/guardian` (scoped, no full monorepo test suite which would pull in UI and electron).

## Test plan

- [ ] Dry-run `unit=guardian` release: preflight fires, regression guard checks `@openpalm/guardian` + `@openpalm/skeleton`, docker-guardian waits for npm jobs
- [ ] Dry-run `unit=portals` release: `docker-guardian` is skipped (no longer in trigger list)
- [ ] Dry-run `unit=platform` release: preflight runs full suite including `ui:test:unit`; CLI binary job runs without waiting for `npm-guardian`
- [ ] Manually trigger `publish-npm-package.yml` with an already-published version and confirm it exits 1 (not a green warning)
- [ ] Same with `allow-existing: true` — confirm it warns and exits 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019VSa1Rx132xfKoEzBc83JG