### PR TITLE
fix(guardian): container robustness — gosu, retry, start_period, named volume, validation guard

### DIFF
--- a/.openpalm/config/stack/portals.compose.yml
+++ b/.openpalm/config/stack/portals.compose.yml
@@ -117,6 +117,7 @@ services:
       - "${OP_CHAT_BIND_ADDRESS:-${OP_BIND_ADDRESS:-127.0.0.1}}:${OP_CHAT_PORT:-3820}:8182"
       - "${OP_API_BIND_ADDRESS:-${OP_BIND_ADDRESS:-127.0.0.1}}:${OP_API_PORT:-3821}:8182"
     volumes:
+      - guardian-cache:/opt/openpalm
       - ${OP_HOME}/data/guardian:/opt/openpalm/guardian
       - ${OP_HOME}/data/logs:/opt/openpalm/logs
       # OpenCode global config (opencode.jsonc, instructions). Operator-managed,
@@ -143,7 +144,7 @@ services:
       interval: 30s
       timeout: 5s
       retries: 3
-      start_period: 60s
+      start_period: 180s
 
 secrets:
   portal_chat_secret:
@@ -164,3 +165,10 @@ secrets:
     file: ${OP_HOME}/knowledge/secrets/op_guardian_admin_token
   op_guardian_mcp_token:
     file: ${OP_HOME}/knowledge/secrets/op_guardian_mcp_token
+
+volumes:
+  # Named volume for guardian npm artifact cache (/opt/openpalm).
+  # Replaces the anonymous volume that the Dockerfile previously declared via
+  # VOLUME ["/opt/openpalm"], which accumulated orphan volumes on every deploy.
+  # docker compose down --volumes will clean this up explicitly.
+  guardian-cache: {}

--- a/.openpalm/config/stack/portals.compose.yml
+++ b/.openpalm/config/stack/portals.compose.yml
@@ -71,7 +71,12 @@ services:
     profiles: ["addon.chat", "addon.api", "addon.discord", "addon.slack", "addon.gateway"]
     image: ${OP_IMAGE_NAMESPACE:-openpalm}/guardian:${OP_GUARDIAN_IMAGE_TAG:-${OP_IMAGE_TAG:-latest}}
     restart: unless-stopped
-    user: "${OP_UID:-1000}:${OP_GID:-1000}"
+    # No `user:` here. The container starts as root so the entrypoint can chown
+    # the root-owned guardian-cache named volume (/opt/openpalm) and the bun
+    # global install dir, then drops to OP_UID:OP_GID via gosu before starting
+    # the server processes. Setting `user:` would force a non-root start, the
+    # chown would be skipped, and `bun add -g` into /opt/openpalm/tools on a
+    # fresh volume would fail with EACCES. Matches the assistant service.
     environment:
       HOME: /opt/openpalm/guardian
       PORT: "8080"

--- a/containers/guardian/Dockerfile
+++ b/containers/guardian/Dockerfile
@@ -1,9 +1,7 @@
 FROM oven/bun:1.3-slim
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    curl bash ca-certificates && rm -rf /var/lib/apt/lists/*
-
-VOLUME ["/opt/openpalm"]
+    curl bash ca-certificates gosu && rm -rf /var/lib/apt/lists/*
 
 COPY containers/guardian/entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
@@ -15,5 +13,9 @@ ENV HOME=/opt/openpalm/guardian \
 EXPOSE 8080
 HEALTHCHECK --interval=30s --timeout=5s --start-period=120s --retries=3 \
   CMD curl -sf http://localhost:8080/health/ready || exit 1
+
+# Container starts as root so the entrypoint can chown /opt/openpalm and then
+# drop to OP_UID:OP_GID via gosu before starting the server.
+USER root
 
 CMD ["/entrypoint.sh"]

--- a/containers/guardian/entrypoint.sh
+++ b/containers/guardian/entrypoint.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 set -euo pipefail
 
+TARGET_UID="${OP_UID:-1000}"
+TARGET_GID="${OP_GID:-1000}"
+IS_ROOT=$([ "$(id -u)" = "0" ] && echo 1 || echo 0)
+
 resolve_version() {
   local override="$1" platform="$2" name="$3"
   [ -n "$override" ] && echo "$override" && return
@@ -9,12 +13,48 @@ resolve_version() {
   exit 1
 }
 
+# ── Privilege setup: chown the artifact volume then drop to OP_UID:OP_GID ──────
+# The compose service sets user: "${OP_UID}:${OP_GID}", but named volumes are
+# initialised as root-owned. We start as root, fix ownership of /opt/openpalm,
+# then re-exec via gosu at the target uid so bun add can write into it.
+ensure_volume_ownership() {
+  if [ "$IS_ROOT" = "0" ]; then return 0; fi
+
+  mkdir -p /opt/openpalm
+  chown -R "${TARGET_UID}:${TARGET_GID}" /opt/openpalm 2>/dev/null || true
+}
+
 # ── Exact-pinned components ───────────────────────────────────────────────────
+# install_artifact: skip if already at target version, retry on transient failures.
 install_artifact() {
   local pkg="$1" version="$2" prefix="$3"
-  echo "Installing ${pkg}@${version}..."
-  npm install --prefix "$prefix" "${pkg}@${version}" --omit=dev --prefer-offline
+  local manifest="${prefix}/node_modules/${pkg}/package.json"
+  local installed_version=""
+
+  if [ -f "$manifest" ]; then
+    installed_version=$(bun -e "try { const p = require('$manifest'); console.log(p.version); } catch { console.log(''); }" 2>/dev/null || true)
+  fi
+
+  if [ "$installed_version" = "$version" ]; then
+    echo "  ${pkg}@${version} already installed, skipping"
+    return 0
+  fi
+
+  local attempt=0
+  while [ $attempt -lt 3 ]; do
+    attempt=$((attempt + 1))
+    echo "Installing ${pkg}@${version} (attempt ${attempt})..."
+    mkdir -p "$prefix"
+    if ( cd "$prefix" && bun add "${pkg}@${version}" --production ); then
+      return 0
+    fi
+    [ $attempt -lt 3 ] && echo "  Install failed, retrying in 5s..." && sleep 5
+  done
+  echo "ERROR: Failed to install ${pkg}@${version} after 3 attempts" >&2
+  exit 1
 }
+
+ensure_volume_ownership
 
 GUARDIAN_VERSION=$(resolve_version "${OP_GUARDIAN_VERSION:-}" "${PLATFORM_VERSION:-}" "GUARDIAN")
 install_artifact "@openpalm/guardian" "$GUARDIAN_VERSION" /opt/openpalm/guardian
@@ -33,18 +73,40 @@ TOOL_PKGS=$(bun -e "
 ")
 [ -n "$TOOL_PKGS" ] && bun add -g $TOOL_PKGS || echo "WARN: some tool installs failed; continuing"
 
-# ── Paths resolved once (package is now installed) ────────────────────────────
-GUARDIAN_PKG=/opt/openpalm/guardian/node_modules/@openpalm/guardian
-
-# ── Start OpenCode moderator (when content validation is enabled) ─────────────
-# opencode is a range-versioned tool installed above via tools.json. If it is
-# unavailable for any reason, log a warning and continue — the heuristic screen
-# still runs, and escalated messages fail-closed (blocked) rather than crashing.
+# ── Fix M3: Hard-fail when content validation is enabled but opencode is missing
 enabled=0
 case "${GUARDIAN_CONTENT_VALIDATION:-0}" in
   1 | true | TRUE | yes | on) enabled=1 ;;
 esac
 
+if [ "$enabled" = "1" ] && ! command -v opencode >/dev/null 2>&1; then
+  echo "ERROR: GUARDIAN_CONTENT_VALIDATION=1 but opencode is not on PATH after tool install. Cannot start." >&2
+  exit 1
+fi
+
+# ── Paths resolved once (package is now installed) ────────────────────────────
+GUARDIAN_PKG=/opt/openpalm/guardian/node_modules/@openpalm/guardian
+
+# ── Drop privileges before starting servers ───────────────────────────────────
+# All artifact installs ran as root (needed to write /opt/openpalm on a
+# fresh named volume). Now drop to the target uid:gid for the server processes.
+# Re-exec this script as the target user so the remaining sections run
+# non-privileged. The GUARDIAN_ENTRYPOINT_DROPPED marker prevents infinite loops.
+if [ "$IS_ROOT" = "1" ] && [ "${GUARDIAN_ENTRYPOINT_DROPPED:-0}" != "1" ]; then
+  if ! command -v gosu >/dev/null 2>&1; then
+    echo "ERROR: gosu not found — cannot drop privileges. Install gosu in the Dockerfile." >&2
+    exit 1
+  fi
+  export GUARDIAN_ENTRYPOINT_DROPPED=1
+  exec gosu "${TARGET_UID}:${TARGET_GID}" \
+    env HOME=/opt/openpalm/guardian GUARDIAN_ENTRYPOINT_DROPPED=1 \
+    "$0" "$@"
+fi
+
+# ── Start OpenCode moderator (when content validation is enabled) ─────────────
+# opencode is a range-versioned tool installed above via tools.json. The
+# hard-fail check above guarantees we only reach here if opencode is present
+# when content validation is enabled.
 if [ "$enabled" = "1" ]; then
   if command -v opencode >/dev/null 2>&1; then
     port="${GUARDIAN_MODERATION_PORT:-4097}"
@@ -53,8 +115,6 @@ if [ "$enabled" = "1" ]; then
     OPENCODE_CONFIG_DIR="${OPENCODE_CONFIG_DIR:-/etc/opencode}" \
       opencode serve --hostname 127.0.0.1 --port "${port}" \
       --print-logs --log-level INFO 2>&1 | sed -u 's/^/[moderator] /' >&2 &
-  else
-    echo "[guardian] WARN: GUARDIAN_CONTENT_VALIDATION=1 but opencode not found on PATH; moderator will not start. Messages escalated by the heuristic screen will be blocked (fail-closed)." >&2
   fi
 fi
 

--- a/containers/guardian/entrypoint.sh
+++ b/containers/guardian/entrypoint.sh
@@ -14,14 +14,27 @@ resolve_version() {
 }
 
 # ── Privilege setup: chown the artifact volume then drop to OP_UID:OP_GID ──────
-# The compose service sets user: "${OP_UID}:${OP_GID}", but named volumes are
-# initialised as root-owned. We start as root, fix ownership of /opt/openpalm,
-# then re-exec via gosu at the target uid so bun add can write into it.
+# /opt/openpalm is the guardian-cache named volume, initialised root-owned on
+# first boot. There is no `user:` in the compose service, so the container
+# starts as root; we fix ownership of the container-private paths on that
+# volume, then re-exec via gosu at the target uid for the server processes.
+#
+# Chown ONLY the named-volume paths. The nested bind mounts
+# (/opt/openpalm/guardian -> OP_HOME/data/guardian, /opt/openpalm/logs ->
+# OP_HOME/data/logs, and the read-only auth.json under guardian/) are
+# host-owned; recursively chowning a bind mount rewrites host file ownership on
+# every boot (a data-ownership hazard) and the :ro auth.json chown would fail.
+# The host owner is OP_UID:OP_GID, so the gosu'd process reads/writes those
+# bind mounts directly. Same reasoning as the assistant entrypoint.
 ensure_volume_ownership() {
   if [ "$IS_ROOT" = "0" ]; then return 0; fi
 
-  mkdir -p /opt/openpalm
-  chown -R "${TARGET_UID}:${TARGET_GID}" /opt/openpalm 2>/dev/null || true
+  mkdir -p /opt/openpalm/tools /opt/openpalm/skeleton /opt/openpalm/guardian
+  # Volume root + guardian/ bind-mount mountpoint: non-recursive (just the dir,
+  # so the gosu'd user can traverse). tools/ (bun global install root) and
+  # skeleton/ live on the named volume: recursive.
+  chown "${TARGET_UID}:${TARGET_GID}" /opt/openpalm /opt/openpalm/guardian 2>/dev/null || true
+  chown -R "${TARGET_UID}:${TARGET_GID}" /opt/openpalm/tools /opt/openpalm/skeleton 2>/dev/null || true
 }
 
 # ── Exact-pinned components ───────────────────────────────────────────────────

--- a/packages/skeleton/config/stack/portals.compose.yml
+++ b/packages/skeleton/config/stack/portals.compose.yml
@@ -117,6 +117,7 @@ services:
       - "${OP_CHAT_BIND_ADDRESS:-${OP_BIND_ADDRESS:-127.0.0.1}}:${OP_CHAT_PORT:-3820}:8182"
       - "${OP_API_BIND_ADDRESS:-${OP_BIND_ADDRESS:-127.0.0.1}}:${OP_API_PORT:-3821}:8182"
     volumes:
+      - guardian-cache:/opt/openpalm
       - ${OP_HOME}/data/guardian:/opt/openpalm/guardian
       - ${OP_HOME}/data/logs:/opt/openpalm/logs
       # OpenCode global config (opencode.jsonc, instructions). Operator-managed,
@@ -143,7 +144,7 @@ services:
       interval: 30s
       timeout: 5s
       retries: 3
-      start_period: 60s
+      start_period: 180s
 
 secrets:
   portal_chat_secret:
@@ -164,3 +165,10 @@ secrets:
     file: ${OP_HOME}/knowledge/secrets/op_guardian_admin_token
   op_guardian_mcp_token:
     file: ${OP_HOME}/knowledge/secrets/op_guardian_mcp_token
+
+volumes:
+  # Named volume for guardian npm artifact cache (/opt/openpalm).
+  # Replaces the anonymous volume that the Dockerfile previously declared via
+  # VOLUME ["/opt/openpalm"], which accumulated orphan volumes on every deploy.
+  # docker compose down --volumes will clean this up explicitly.
+  guardian-cache: {}

--- a/packages/skeleton/config/stack/portals.compose.yml
+++ b/packages/skeleton/config/stack/portals.compose.yml
@@ -71,7 +71,12 @@ services:
     profiles: ["addon.chat", "addon.api", "addon.discord", "addon.slack", "addon.gateway"]
     image: ${OP_IMAGE_NAMESPACE:-openpalm}/guardian:${OP_GUARDIAN_IMAGE_TAG:-${OP_IMAGE_TAG:-latest}}
     restart: unless-stopped
-    user: "${OP_UID:-1000}:${OP_GID:-1000}"
+    # No `user:` here. The container starts as root so the entrypoint can chown
+    # the root-owned guardian-cache named volume (/opt/openpalm) and the bun
+    # global install dir, then drops to OP_UID:OP_GID via gosu before starting
+    # the server processes. Setting `user:` would force a non-root start, the
+    # chown would be skipped, and `bun add -g` into /opt/openpalm/tools on a
+    # fresh volume would fail with EACCES. Matches the assistant service.
     environment:
       HOME: /opt/openpalm/guardian
       PORT: "8080"


### PR DESCRIPTION
## Summary

Five container-robustness fixes for the guardian thin-host container, building on top of the `bun add --production` change from PR #519.

### C5 — gosu privilege drop
- Added `gosu` to the Dockerfile apt-get install line
- Removed `USER` directive override (container now starts as root by default per the `USER root` line, which is the baseline for `oven/bun:1.3-slim`)
- Entrypoint chowns `/opt/openpalm` to `OP_UID:OP_GID` as root, then re-execs itself via `gosu` to drop privileges before starting any servers
- Fixes EACCES failures when `bun add` tries to write into a root-owned named volume on first boot

### H4 — Version-check skip + retry for artifact installs
- `install_artifact()` now reads `$prefix/node_modules/$pkg/package.json` and skips `bun add` if the installed version already matches the target (fast warm starts)
- Wraps `bun add` in a 3-attempt retry loop with a 5 s back-off; exits 1 with a clear message if all attempts fail
- Switches from `npm install` to `bun add --production` throughout (aligns with PR #519)

### M1 — Raise healthcheck `start_period`
- Changed `start_period: 60s` → `start_period: 180s` in both `portals.compose.yml` files
- Cold starts (first boot, package download) on slow networks need more than 60 s before Docker marks the container unhealthy

### M3 — Hard-fail when content validation is enabled but opencode is missing
- Added a check immediately after the tool install phase: if `GUARDIAN_CONTENT_VALIDATION=1` and `opencode` is not on PATH, the entrypoint exits 1 with a clear error message instead of silently continuing with every escalated message fail-closed blocked

### M4 — Named volume for guardian artifact cache
- Removed `VOLUME ["/opt/openpalm"]` from `containers/guardian/Dockerfile`
- Added `guardian-cache:/opt/openpalm` to the guardian service volumes in both `portals.compose.yml` files
- Added the `volumes: guardian-cache: {}` top-level declaration in both files
- Named volumes are cleaned up by `docker compose down --volumes`; the previous anonymous `VOLUME` declaration accumulated orphan volumes silently across every deploy

## Files changed
- `containers/guardian/Dockerfile`
- `containers/guardian/entrypoint.sh`
- `packages/skeleton/config/stack/portals.compose.yml`
- `.openpalm/config/stack/portals.compose.yml`

Both `portals.compose.yml` files are identical in all changed sections (verified via `diff`).

## Test plan
- [ ] Shell syntax: `bash -n containers/guardian/entrypoint.sh` passes (verified in CI)
- [ ] Cold boot: remove the `guardian-cache` volume, start the stack — guardian reaches healthy within `start_period`
- [ ] Warm boot: restart guardian with an unchanged version — logs show `already installed, skipping` for both packages
- [ ] UID mismatch: set `OP_UID=1234` in stack.env, start stack — verify guardian process runs as 1234 (not root)
- [ ] Content-validation guard: set `GUARDIAN_CONTENT_VALIDATION=1` with no opencode in tools.json — container should exit immediately with the ERROR message

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019VSa1Rx132xfKoEzBc83JG