### PR TITLE
fix(packages): fix CLI skeleton version pin and add harness contract CI assertion

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -7,13 +7,13 @@
     },
     "packages/cli": {
       "name": "openpalm",
-      "version": "0.12.14",
+      "version": "0.12.16",
       "bin": {
         "openpalm": "./bin/openpalm.js",
       },
       "dependencies": {
-        "@openpalm/lib": ">=0.12.14 <1.0.0",
-        "@openpalm/skeleton": "0.12.8",
+        "@openpalm/lib": ">=0.12.16 <1.0.0",
+        "@openpalm/skeleton": ">=0.12.0 <1.0.0",
         "citty": "^0.2.1",
         "yaml": "^2.8.0",
       },
@@ -24,7 +24,7 @@
     },
     "packages/electron": {
       "name": "@openpalm/electron",
-      "version": "0.12.14",
+      "version": "0.12.16",
       "devDependencies": {
         "@openpalm/lib": "workspace:*",
         "@types/node": "^25.9.1",
@@ -36,14 +36,14 @@
     },
     "packages/electron/admin-tools": {
       "name": "@openpalm/admin-tools-plugin",
-      "version": "0.12.14",
+      "version": "0.12.16",
       "dependencies": {
         "@opencode-ai/plugin": "^1.17.7",
       },
     },
     "packages/guardian": {
       "name": "@openpalm/guardian",
-      "version": "0.13.0",
+      "version": "0.12.17",
       "bin": {
         "openpalm-guardian": "./src/server.ts",
       },
@@ -57,7 +57,7 @@
     },
     "packages/lib": {
       "name": "@openpalm/lib",
-      "version": "0.12.14",
+      "version": "0.12.16",
       "dependencies": {
         "dotenv": "^17.4.2",
         "tar": "^7.5.15",
@@ -70,11 +70,11 @@
     },
     "packages/skeleton": {
       "name": "@openpalm/skeleton",
-      "version": "0.12.14",
+      "version": "0.12.16",
     },
     "packages/ui": {
       "name": "@openpalm/ui",
-      "version": "0.12.14",
+      "version": "0.12.16",
       "devDependencies": {
         "@axe-core/playwright": "^4.11.3",
         "@eslint/compat": "^2.0.2",
@@ -1506,8 +1506,6 @@
     "node-gyp/undici": ["undici@6.25.0", "", {}, "sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg=="],
 
     "node-gyp/which": ["which@6.0.1", "", { "dependencies": { "isexe": "^4.0.0" }, "bin": { "node-which": "bin/which.js" } }, "sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg=="],
-
-    "openpalm/@openpalm/skeleton": ["@openpalm/skeleton@0.12.8", "", {}, "sha512-v8I8SX4Zv2Kq16z4JUVg9mgCMCyQfYdYRFuhvMCUYiEU25BtCO15nZObn9IR5Zr+567AlO6bvHYF1ezHasFrAA=="],
 
     "p-queue/eventemitter3": ["eventemitter3@4.0.7", "", {}, "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="],
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "@openpalm/lib": ">=0.12.16 <1.0.0",
-    "@openpalm/skeleton": "0.12.8",
+    "@openpalm/skeleton": ">=0.12.0 <1.0.0",
     "citty": "^0.2.1",
     "yaml": "^2.8.0"
   },

--- a/packages/electron/test/harness-contract.test.ts
+++ b/packages/electron/test/harness-contract.test.ts
@@ -1,0 +1,40 @@
+// CI assertion: the UI build's `minHarnessContract` must be <= the Electron
+// harness's `HARNESS_CONTRACT_VERSION`. A mismatch only manifests at runtime
+// (users see a "please re-download" prompt) so this test catches it in CI.
+//
+// `minHarnessContract` lives in packages/ui/package.json (not a source
+// constant) because it travels with the published @openpalm/ui build. We read
+// it from the source package.json here so the assertion fires on every commit.
+//
+// Run via vitest (Node): bun run --cwd packages/electron test
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { HARNESS_CONTRACT_VERSION } from '../src/harness-contract.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const uiPkgPath = resolve(__dirname, '../../ui/package.json');
+const uiPkg = JSON.parse(readFileSync(uiPkgPath, 'utf-8')) as {
+  minHarnessContract?: number;
+  version?: string;
+};
+
+describe('harness contract compatibility', () => {
+  it('packages/ui/package.json declares minHarnessContract', () => {
+    expect(typeof uiPkg.minHarnessContract).toBe('number');
+  });
+
+  it('UI minHarnessContract <= Electron HARNESS_CONTRACT_VERSION', () => {
+    // If this fails, either:
+    //   (a) The UI added a dependency on a new IPC method / spawn env key and
+    //       bumped minHarnessContract without a matching HARNESS_CONTRACT_VERSION
+    //       bump in packages/electron/src/harness-contract.ts, OR
+    //   (b) The Electron harness was downgraded without lowering the UI contract.
+    //
+    // Fix: bump HARNESS_CONTRACT_VERSION in harness-contract.ts to match, then
+    // update the snapshot test in main.test.ts, and release a new Electron build.
+    const minHarnessContract = uiPkg.minHarnessContract ?? 0;
+    expect(minHarnessContract).toBeLessThanOrEqual(HARNESS_CONTRACT_VERSION);
+  });
+});

--- a/scripts/set-version.mjs
+++ b/scripts/set-version.mjs
@@ -3,9 +3,12 @@
 //
 // Sets `version` and keeps any internal `@openpalm/lib` *floor range* dependency
 // (e.g. ">=X <N.0.0") in lockstep so the floor never goes stale (CI enforces
-// this; the test suite covers it). `workspace:*` and exact/non-range refs are
-// left untouched. Used by scripts/bump-platform.sh and the release workflows so
-// there is exactly one place that understands how a version is written.
+// this; the test suite covers it). Also stamps any `@openpalm/skeleton` range
+// dependency (e.g. ">=X.Y.0 <N.0.0") to an exact pin matching the new version
+// so the CLI and skeleton are always shipped in lockstep. `workspace:*` and
+// exact/non-range refs for other packages are left untouched. Used by
+// scripts/bump-platform.sh and the release workflows so there is exactly one
+// place that understands how a version is written.
 //
 // Usage: node scripts/set-version.mjs <path/to/package.json> <version>
 import { readFileSync, writeFileSync } from 'node:fs';
@@ -23,9 +26,16 @@ export function setVersion(file, version) {
   pkg.version = version;
   const major = Number.parseInt(version.split('.')[0], 10);
   for (const field of ['dependencies', 'peerDependencies']) {
-    const dep = pkg[field]?.['@openpalm/lib'];
-    if (typeof dep === 'string' && dep.startsWith('>=')) {
+    // Keep @openpalm/lib floor range in lockstep with the package version.
+    const libDep = pkg[field]?.['@openpalm/lib'];
+    if (typeof libDep === 'string' && libDep.startsWith('>=')) {
       pkg[field]['@openpalm/lib'] = `>=${version} <${major + 1}.0.0`;
+    }
+    // Stamp @openpalm/skeleton range to an exact pin matching this version so
+    // the CLI and skeleton are always published and consumed in lockstep.
+    const skeletonDep = pkg[field]?.['@openpalm/skeleton'];
+    if (typeof skeletonDep === 'string' && skeletonDep.startsWith('>=')) {
+      pkg[field]['@openpalm/skeleton'] = version;
     }
   }
   writeFileSync(file, JSON.stringify(pkg, null, 2) + '\n');


### PR DESCRIPTION
## Summary

- **H1 Part A**: Changed `@openpalm/skeleton` in `packages/cli/package.json` from a stale exact pin (`0.12.8`) to a range (`>=0.12.0 <1.0.0`). This ensures `npm install openpalm@latest` resolves the latest published skeleton instead of the stale pinned version.

- **H1 Part B**: Updated `scripts/set-version.mjs` to detect and stamp `@openpalm/skeleton` range dependencies to an exact pin matching the new version at release time. The stamping logic mirrors how `@openpalm/lib` floor ranges are handled — range triggers a stamp to the exact version, exact pins are left untouched.

- **M7**: Added `packages/electron/test/harness-contract.test.ts` that reads `minHarnessContract` from `packages/ui/package.json` and asserts `minHarnessContract <= HARNESS_CONTRACT_VERSION` from the Electron harness constant. This catches the class of runtime "please re-download" regressions in CI before they reach users.

## Test plan

- [x] `bun run electron:test` — 72 tests across 5 files, all pass (including 2 new harness-contract tests)
- [x] Manual dry-run of `set-version.mjs` with a skeleton range dep confirms it stamps to exact version
- [x] Manual dry-run confirms exact skeleton pins are left untouched (backward compatible)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019VSa1Rx132xfKoEzBc83JG