### PR TITLE
fix(lib): migration robustness — fail-loud patch, unified addon IDs, rollback scope, layout version

### DIFF
--- a/packages/lib/src/control-plane/addon-ids.ts
+++ b/packages/lib/src/control-plane/addon-ids.ts
@@ -1,0 +1,12 @@
+/**
+ * Canonical list of built-in addon IDs.
+ *
+ * Single source of truth — imported by both addons.ts and migrations.ts.
+ * Update THIS file (and only this file) when adding or removing a built-in addon.
+ *
+ * Intentionally a pure-constants file with no imports so it can be safely
+ * imported from anywhere without risk of circular dependencies.
+ */
+export const BUILTIN_ADDON_IDS: ReadonlyArray<string> = [
+  'api', 'chat', 'discord', 'gateway', 'ollama', 'slack', 'ssh', 'voice',
+] as const;

--- a/packages/lib/src/control-plane/addons.test.ts
+++ b/packages/lib/src/control-plane/addons.test.ts
@@ -39,7 +39,10 @@ afterEach(() => {
 
 describe('builtin addon metadata', () => {
   it('returns static built-in addon ids', () => {
-    expect(listAvailableAddonIds()).toEqual(['api', 'discord', 'ollama', 'slack', 'voice']);
+    // Canonical list from BUILTIN_ADDON_IDS (addon-ids.ts — single source of truth).
+    // chat, gateway, ssh were previously missing from BUILTIN_ADDONS in addons.ts
+    // but present in KNOWN_ADDON_IDS in migrations.ts; H6 unified them.
+    expect(listAvailableAddonIds()).toEqual(['api', 'chat', 'discord', 'gateway', 'ollama', 'slack', 'ssh', 'voice']);
   });
 
   it('returns built-in addon schemas without registry materialization', () => {

--- a/packages/lib/src/control-plane/addons.ts
+++ b/packages/lib/src/control-plane/addons.ts
@@ -19,10 +19,10 @@ import { parseEnabledAddons } from './env.js';
 import type { ControlPlaneState } from './types.js';
 import { resolveStashDir } from './home.js';
 import { BUILTIN_ADDON_ENV_SCHEMAS } from './addon-env-schemas.js';
+import { BUILTIN_ADDON_IDS } from './addon-ids.js';
 
 const VALID_NAME_RE = /^[a-z0-9][a-z0-9-]{0,62}$/;
 const logger = createLogger('registry');
-const BUILTIN_ADDONS = ['api', 'discord', 'ollama', 'slack', 'voice'] as const;
 
 export type RegistryAddonConfig = {
   schemaPath: string;
@@ -61,7 +61,7 @@ export function getRegistryAddonConfig(name: string): RegistryAddonConfig {
 }
 
 export function listAvailableAddonIds(): string[] {
-  return [...BUILTIN_ADDONS].sort();
+  return [...BUILTIN_ADDON_IDS].sort();
 }
 
 export function listEnabledAddonIds(homeDir: string): string[] {

--- a/packages/lib/src/control-plane/lifecycle.ts
+++ b/packages/lib/src/control-plane/lifecycle.ts
@@ -664,10 +664,23 @@ export type UpgradeResult = {
 
 async function withStackEnvRollback<T>(state: ControlPlaneState, run: () => Promise<T>): Promise<T> {
   const stackEnvPath = `${state.stashDir}/env/stack.env`;
+  // Release migrations (ensureReleaseMigrated) may also write these compose files,
+  // so snapshot them alongside stack.env for full rollback coverage.
+  const portalsComposePath = `${state.stackDir}/portals.compose.yml`;
+  const customComposePath = `${state.stackDir}/custom.compose.yml`;
+
   let originalStackEnv: string | null = null;
+  let originalPortalsCompose: string | null = null;
+  let originalCustomCompose: string | null = null;
   try {
     originalStackEnv = readFileSync(stackEnvPath, 'utf-8');
   } catch { /* stack.env may not exist yet */ }
+  try {
+    originalPortalsCompose = readFileSync(portalsComposePath, 'utf-8');
+  } catch { /* portals.compose.yml may not exist yet */ }
+  try {
+    originalCustomCompose = readFileSync(customComposePath, 'utf-8');
+  } catch { /* custom.compose.yml may not exist yet */ }
 
   // Persist the PRE-upgrade state for `openpalm rollback`. Without this, the
   // snapshot taken later inside reconcileCore captures stack.env AFTER the new
@@ -681,6 +694,16 @@ async function withStackEnvRollback<T>(state: ControlPlaneState, run: () => Prom
     if (originalStackEnv !== null) {
       try {
         writeFileSync(stackEnvPath, originalStackEnv);
+      } catch { /* best effort */ }
+    }
+    if (originalPortalsCompose !== null) {
+      try {
+        writeFileSync(portalsComposePath, originalPortalsCompose);
+      } catch { /* best effort */ }
+    }
+    if (originalCustomCompose !== null) {
+      try {
+        writeFileSync(customComposePath, originalCustomCompose);
       } catch { /* best effort */ }
     }
     throw e;

--- a/packages/lib/src/control-plane/migrations.test.ts
+++ b/packages/lib/src/control-plane/migrations.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from "bun:test";
 import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, existsSync, rmSync, readdirSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { ensureMigrated, ensureReleaseMigrated, MigrationError, BackupSpaceError, CURRENT_LAYOUT_VERSION } from "./migrations.js";
+import { ensureMigrated, ensureReleaseMigrated, MigrationError, BackupSpaceError, CURRENT_LAYOUT_VERSION, selectPendingReleaseMigrations, releaseMigrationVersions } from "./migrations.js";
 
 // The harness resolves all paths from OP_HOME; point it at a synthetic 0.10 home.
 let home: string;
@@ -713,5 +713,47 @@ describe('release migration v0.12.3-rc.1: purge stale addon IDs from OP_ENABLED_
     const stackEnv = readFileSync(join(home, 'knowledge', 'env', 'stack.env'), 'utf-8');
     // stale ID still present — migration was not run
     expect(stackEnv).toContain('OP_ENABLED_ADDONS=discord,stale,voice');
+  });
+});
+
+describe('M2: readLayoutVersion case 4 — pre-stamp 0.11.0 home runs 1→2 migration', () => {
+  it('stamps CURRENT_LAYOUT_VERSION=2 and runs the 1→2 layout migration for a pre-stamp 0.11.0 home', () => {
+    // A home that has knowledge/env/stack.env but no OP_LAYOUT_VERSION stamp
+    // and no vault/ — the "0.11.0 installed before the stamp was added" case.
+    // Fix (M2): readLayoutVersion must return 1 (not CURRENT_LAYOUT_VERSION) so
+    // the 1→2 migration runs (removing inert pre-0.12.0 system files).
+    mkdirSync(join(home, 'knowledge', 'env'), { recursive: true });
+    mkdirSync(join(home, 'config', 'stack'), { recursive: true });
+    mkdirSync(join(home, 'data'), { recursive: true });
+    writeFileSync(join(home, 'knowledge', 'env', 'stack.env'), 'OP_IMAGE_TAG=v0.11.5\n');
+    // Plant an inert system file that the 1→2 migration removes.
+    writeFileSync(join(home, 'config', 'stack', 'channels.compose.yml'), 'services: {}\n');
+
+    const report = ensureMigrated();
+
+    expect(report.migrated).toBe(true);
+    expect(report.from).toBe(1);
+    expect(report.to).toBe(CURRENT_LAYOUT_VERSION);
+
+    const stackEnv = readFileSync(join(home, 'knowledge', 'env', 'stack.env'), 'utf-8');
+    expect(stackEnv).toContain(`OP_LAYOUT_VERSION=${CURRENT_LAYOUT_VERSION}`);
+
+    // The 1→2 migration must have run — channels.compose.yml is an inert system file.
+    expect(existsSync(join(home, 'config', 'stack', 'channels.compose.yml'))).toBe(false);
+  });
+});
+
+describe('RELEASE_MIGRATIONS uniqueness', () => {
+  it('has no duplicate describe strings in RELEASE_MIGRATIONS', () => {
+    const versions = releaseMigrationVersions();
+    // releaseMigrationVersions() returns one entry per migration in order.
+    // Use selectPendingReleaseMigrations with a far-future target to obtain the
+    // full list, and check describes via the exported versions + internal shape.
+    // Since we only export versions here, check there are no duplicate (version, describe)
+    // pairs by running the selector for a target beyond all known versions.
+    const all = selectPendingReleaseMigrations(null, 'v99.0.0');
+    const describes = all.map((m) => m.describe);
+    const unique = new Set(describes);
+    expect(unique.size).toBe(describes.length);
   });
 });

--- a/packages/lib/src/control-plane/migrations.ts
+++ b/packages/lib/src/control-plane/migrations.ts
@@ -34,6 +34,7 @@ import { upsertEnvValue, parseEnabledAddons } from "./env.js";
 import { nonSensitiveAddonEnvKeys } from "./addon-env-schemas.js";
 import { PLATFORM_IMAGE_TAG_KEYS, buildPlatformImageTagEnv } from './image-tags.js';
 import { compareComparableVersions, isComparableSemver } from './versioning.js';
+import { BUILTIN_ADDON_IDS } from './addon-ids.js';
 
 export const LAYOUT_VERSION_KEY = "OP_LAYOUT_VERSION";
 /** Bump when the on-disk layout changes and add a Migration to MIGRATIONS. */
@@ -246,7 +247,7 @@ function readLayoutVersion(ctx: { homeDir: string; stashDir: string }): number {
   }
   if (existsSync(join(ctx.homeDir, "vault"))) return 0;            // (2) 0.10.x / crash-recovery
   if (existsSync(join(ctx.homeDir, "config", "system.env"))) return 0; // (3) 0.9.x
-  if (envExists) return CURRENT_LAYOUT_VERSION;                    // (4) 0.11.0 pre-stamp
+  if (envExists) return 1;                                         // (4) 0.11.0 pre-stamp — must run 1→2 migration
   if (!hasOpenPalmContent(ctx.homeDir)) return CURRENT_LAYOUT_VERSION; // (5) fresh install
   throw new UnrecognizedLayoutError(ctx.homeDir);                  // (6) fail loud
 }
@@ -925,11 +926,11 @@ export function releaseMigrationVersions(): string[] {
 // ── Release migration v0.12.3: remove stale addon IDs from OP_ENABLED_ADDONS ───
 
 /**
- * The hardcoded builtin addon IDs from addons.ts. Inlined here to avoid an
- * import cycle (addons.ts → config-persistence.ts → … which itself may call
- * migrations). These must stay in sync with BUILTIN_ADDONS in addons.ts.
+ * Set of valid built-in addon IDs for fast membership checks.
+ * Derived from BUILTIN_ADDON_IDS (addon-ids.ts — the single source of truth).
+ * To add or remove an addon, update addon-ids.ts only.
  */
-const KNOWN_ADDON_IDS = new Set(['api', 'chat', 'discord', 'gateway', 'ollama', 'slack', 'ssh', 'voice']);
+const KNOWN_ADDON_IDS = new Set(BUILTIN_ADDON_IDS);
 
 /**
  * Strip any addon IDs from OP_ENABLED_ADDONS that are not in the current
@@ -983,13 +984,11 @@ function patchPortalsComposeForThinHost(ctx: MigrationCtx): void {
   // insertion point in the guardian service (not the discord/slack services).
   const ANCHOR = '      OP_ASSISTANT_URL: http://assistant:4096';
   if (!content.includes(ANCHOR)) {
-    ctx.log('WARN: portals.compose.yml does not contain expected anchor line; skipping thin-host env patch — apply manually');
-    ctx.notes.push(
-      'portals.compose.yml could not be auto-patched for the guardian thin-host. ' +
-      'Add OP_GUARDIAN_VERSION and PLATFORM_VERSION to the guardian service environment manually ' +
-      '(see packages/skeleton/config/stack/portals.compose.yml for the reference values).',
+    throw new Error(
+      `Migration patchPortalsComposeForThinHost: anchor line not found in ${path}. ` +
+      `The guardian thin-host env vars cannot be injected. ` +
+      `Manual fix: add OP_GUARDIAN_VERSION and PLATFORM_VERSION env vars to the guardian service in portals.compose.yml.`,
     );
-    return;
   }
 
   const INSERTION = [
@@ -1113,6 +1112,13 @@ const RELEASE_MIGRATIONS: ReleaseMigration[] = [
       const content = readFileSync(path, 'utf-8');
       if (!content.includes('OP_GUARDIAN_VERSION:')) {
         throw new Error('post-migration check failed: OP_GUARDIAN_VERSION still missing from portals.compose.yml');
+      }
+      const ANCHOR = '      OP_ASSISTANT_URL: http://assistant:4096';
+      if (!content.includes(ANCHOR)) {
+        throw new Error(
+          'post-migration check failed: portals.compose.yml is missing the expected anchor line ' +
+          '(OP_ASSISTANT_URL: http://assistant:4096). The file may be structurally corrupt.',
+        );
       }
     },
   },
@@ -1356,9 +1362,11 @@ export function ensureReleaseMigrated(
       if (!lock) {
         throw new MigrationError('Another install/upgrade is in progress.', RECOVERY_GUIDANCE, null);
       }
-      // Release migrations only edit knowledge/env/stack.env, so back up just
-      // that file — a full OP_HOME copy (data/ can be gigabytes) is the layout
-      // migration's job, not warranted for an env-file append.
+      // Release migrations primarily edit knowledge/env/stack.env; some also write
+      // portals.compose.yml and custom.compose.yml. Back up stack.env here as a
+      // targeted safety copy — lifecycle callers wrap ensureReleaseMigrated in
+      // withStackEnvRollback which snapshots and restores all three files on error.
+      // A full OP_HOME copy (data/ can be gigabytes) is the layout migration's job.
       const envPath = stackEnvFile(paths.stashDir);
       if (existsSync(envPath)) {
         log('Backing up stack.env before migrating…');

--- a/packages/lib/src/index.ts
+++ b/packages/lib/src/index.ts
@@ -66,6 +66,7 @@ export type {
   AddonProfileAvailability,
   RegistryAddonConfig,
 } from "./control-plane/addons.js";
+export { BUILTIN_ADDON_IDS } from "./control-plane/addon-ids.js";
 export {
   getRegistryAutomation,
   getRegistryAddonConfig,


### PR DESCRIPTION
## Summary

- **H5**: `patchPortalsComposeForThinHost` now throws (instead of warn+continue) when the anchor line is missing. A missing anchor means guardian thin-host env vars weren't injected, causing a boot failure. Verify step also checks anchor presence to guard against structural corruption.
- **H6**: Created `addon-ids.ts` as single source of truth for built-in addon IDs. Removes dual `BUILTIN_ADDONS` (addons.ts, 5 IDs) / `KNOWN_ADDON_IDS` (migrations.ts, 8 IDs) that had drifted. Unified list has 8 IDs (`chat`, `gateway`, `ssh` were missing from `addons.ts`). Both files import from `addon-ids.ts`; exported via `index.ts` barrel.
- **H7**: `withStackEnvRollback` in lifecycle.ts now snapshots `portals.compose.yml` and `custom.compose.yml` alongside `stack.env`. Release migrations may write these compose files; without snapshots a mid-migration failure left them partially patched.
- **M2**: `readLayoutVersion` case 4 (pre-stamp 0.11.0 home: has `stack.env`, no stamp, no vault) now returns `1` instead of `CURRENT_LAYOUT_VERSION`. Returning 2 skipped the 1→2 layout migration, leaving `channels.compose.yml` (an inert system file) un-removed.
- **Tests**: New test for M2 case-4 regression (verifies 1→2 migration runs and stamps correctly). New `RELEASE_MIGRATIONS` uniqueness assertion (`Set` size vs array length). Updated `addons.test.ts` to match expanded canonical list.

## Test plan

- [x] `bun test packages/lib/src/control-plane/` — 700 pass, 0 fail
- [x] All 45 migration tests pass including 2 new tests
- [x] All 21 addons tests pass with updated canonical list assertion

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019VSa1Rx132xfKoEzBc83JG