### PR TITLE
fix(skeleton): tools.json uses opencode-ai, the real npm package (#524)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,13 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **`packages/skeleton/tools.json` now installs the real `opencode-ai` npm
+  package.** It referenced `opencode`, which does not exist on npm (404), so the
+  tool install never produced the `opencode` binary. With
+  `GUARDIAN_CONTENT_VALIDATION` enabled, the guardian entrypoint's
+  `command -v opencode` check then hard-failed the boot. `opencode-ai`
+  (the official OpenCode package) ships the `opencode` bin and resolves the same
+  `^1.17.0` range. (#524)
 - **Guardian thin-host container boots again.** The entrypoint installed the
   exact-pinned `@openpalm/guardian` / `@openpalm/skeleton` artifacts with
   `npm`, but the image is `FROM oven/bun:1.3-slim`, which ships no node/npm —

--- a/packages/skeleton/tools.json
+++ b/packages/skeleton/tools.json
@@ -1,11 +1,11 @@
 {
   "global": [
-    { "package": "opencode",                  "envKey": "OP_TOOL_OPENCODE_VERSION",    "default": "^1.17.0" },
+    { "package": "opencode-ai",               "envKey": "OP_TOOL_OPENCODE_VERSION",    "default": "^1.17.0" },
     { "package": "@anthropic-ai/claude-code", "envKey": "OP_TOOL_CLAUDE_CODE_VERSION", "default": "^1.5.0" },
     { "package": "@openai/codex",             "envKey": "OP_TOOL_CODEX_VERSION",       "default": "^0.1.0" }
   ],
   "guardian": [
-    { "package": "opencode", "envKey": "OP_TOOL_OPENCODE_VERSION", "default": "^1.17.0" },
+    { "package": "opencode-ai", "envKey": "OP_TOOL_OPENCODE_VERSION", "default": "^1.17.0" },
     { "package": "akm-cli",  "envKey": "OP_TOOL_AKM_VERSION",      "default": "^0.8.14" }
   ]
 }


### PR DESCRIPTION
## Problem

`packages/skeleton/tools.json` referenced the npm package `opencode`, which **does not exist on npm** — `GET https://registry.npmjs.org/opencode` returns 404. As a result the tool install step never produces an `opencode` binary.

It appeared twice: in both the `global` and `guardian` arrays.

## Root cause

The official OpenCode package is **`opencode-ai`** (maintainer `thdxr <d@ironbay.co>`, the OpenCode author; latest `1.17.9`). It ships `bin: { opencode: ... }`, so it provides the `opencode` binary, and it resolves the existing `^1.17.0` range. This was simply a wrong package-name bug; the version range was already correct.

## Impact (higher priority than a warning)

The guardian thin-host entrypoint (`containers/guardian/entrypoint.sh`) **hard-fails the boot** when `GUARDIAN_CONTENT_VALIDATION` is enabled: it runs `command -v opencode` and `exit 1`s with "Cannot start" if the binary is missing. Because `opencode` is supplied by this tools.json entry and the package didn't exist, the guardian would **fail to start** (not just log a warning) under a common/default config. Installing `opencode-ai` provides the `opencode` bin and satisfies that check.

## Fix

Renamed `"package": "opencode"` → `"package": "opencode-ai"` in both occurrences. `envKey`, `default` (`^1.17.0`), and all other tools are unchanged.

## Verification

```
$ npm view opencode-ai version bin
version = '1.17.9'
bin = { opencode: 'bin/opencode.exe' }
```

`tools.json` validated as JSON after the edit (`python3 -m json.tool`).

Fixes #524

🤖 Generated with [Claude Code](https://claude.com/claude-code)