### PR TITLE
feat(guardian): make thin-host guardian package configurable (OP_GUARDIAN_PACKAGE)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- The guardian thin-host entrypoint can now install and boot a configurable
+  guardian composition package via `OP_GUARDIAN_PACKAGE` (default
+  `@openpalm/guardian`) with an overridable boot entry `OP_GUARDIAN_ENTRY`
+  (default `src/server.ts`). The OpenAI-compatible API server is resolved from
+  the public core `@openpalm/guardian`, and defaults are byte-for-byte unchanged.
+
 - **`@openpalm/guardian` is now importable as a library** (in addition to being
   a runnable thin host). It exposes composition seams so downstream
   distributions can extend the guardian without forking `server.ts`:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,13 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `@openpalm/guardian`) with an overridable boot entry `OP_GUARDIAN_ENTRY`
   (default `src/server.ts`). The OpenAI-compatible API server is resolved from
   the public core `@openpalm/guardian`, and defaults are byte-for-byte unchanged.
+  - The entrypoint can optionally install the guardian package from a **private,
+    authenticated npm registry**. Supply an `.npmrc` (registry + auth) via
+    `OP_GUARDIAN_NPMRC_FILE` (a mounted secret file — e.g. a Key Vault secret
+    volume; preferred) or `OP_GUARDIAN_NPMRC` (inline content). It is written to
+    `$HOME/.npmrc` (mode 600) so Bun applies it to every install; the token is
+    never logged. Purely opt-in — when neither is set, nothing is written and the
+    default public-registry behavior is byte-for-byte unchanged.
 
 - **`@openpalm/guardian` is now importable as a library** (in addition to being
   a runnable thin host). It exposes composition seams so downstream

--- a/containers/guardian/entrypoint.sh
+++ b/containers/guardian/entrypoint.sh
@@ -5,6 +5,17 @@ TARGET_UID="${OP_UID:-1000}"
 TARGET_GID="${OP_GID:-1000}"
 IS_ROOT=$([ "$(id -u)" = "0" ] && echo 1 || echo 0)
 
+# ── Configurable guardian composition package ─────────────────────────────────
+# This thin host installs and boots a guardian composition package. The package
+# is overridable so downstream distributions built on the published library
+# seams can run on the stock image without forking this entrypoint. Defaults to
+# the public core so existing behavior is unchanged. Version resolution
+# (OP_GUARDIAN_VERSION / PLATFORM_VERSION) is independent of which package is
+# installed; the exact-version pin remains a security boundary (no ranges).
+OP_GUARDIAN_PACKAGE="${OP_GUARDIAN_PACKAGE:-@openpalm/guardian}"
+# Boot entry within the configured package, overridable for alternate packages.
+OP_GUARDIAN_ENTRY="${OP_GUARDIAN_ENTRY:-src/server.ts}"
+
 resolve_version() {
   local override="$1" platform="$2" name="$3"
   [ -n "$override" ] && echo "$override" && return
@@ -74,7 +85,7 @@ install_artifact() {
 ensure_volume_ownership
 
 GUARDIAN_VERSION=$(resolve_version "${OP_GUARDIAN_VERSION:-}" "${PLATFORM_VERSION:-}" "GUARDIAN")
-install_artifact "@openpalm/guardian" "$GUARDIAN_VERSION" /opt/openpalm/guardian
+install_artifact "$OP_GUARDIAN_PACKAGE" "$GUARDIAN_VERSION" /opt/openpalm/guardian
 
 SKELETON_VERSION=$(resolve_version "${OP_SKELETON_VERSION:-}" "${PLATFORM_VERSION:-}" "SKELETON")
 install_artifact "@openpalm/skeleton" "$SKELETON_VERSION" /opt/openpalm/skeleton
@@ -102,7 +113,8 @@ if [ "$enabled" = "1" ] && ! command -v opencode >/dev/null 2>&1; then
 fi
 
 # ── Paths resolved once (package is now installed) ────────────────────────────
-GUARDIAN_PKG=/opt/openpalm/guardian/node_modules/@openpalm/guardian
+# Boot path resolves from the configured composition package.
+GUARDIAN_PKG="/opt/openpalm/guardian/node_modules/${OP_GUARDIAN_PACKAGE}"
 
 # ── Drop privileges before starting servers ───────────────────────────────────
 # All artifact installs ran as root (needed to write /opt/openpalm on a
@@ -139,10 +151,18 @@ fi
 # Runs on GUARDIAN_OPENAI_PORT (default 8182) and proxies to the guardian
 # server on localhost:${PORT:-8080}. Backgrounded so it doesn't block the main
 # server; pipe to stderr so logs appear in `docker logs`.
+#
+# The OpenAI-compatible API server lives in the public core @openpalm/guardian.
+# When OP_GUARDIAN_PACKAGE is an alternate package, the core is still present as
+# a (transitive) dependency, so resolve the core package dir robustly via
+# require.resolve and run openai-api from there rather than from $GUARDIAN_PKG.
+# In the default case GUARDIAN_CORE_PKG == GUARDIAN_PKG, so behavior is identical.
+GUARDIAN_CORE_PKG=$(cd /opt/openpalm/guardian && bun -e "console.log(require('node:path').dirname(require.resolve('@openpalm/guardian/package.json')))" 2>/dev/null || echo "/opt/openpalm/guardian/node_modules/@openpalm/guardian")
 guardian_server_port="${PORT:-8080}"
 openai_port="${GUARDIAN_OPENAI_PORT:-8182}"
 PORT="${openai_port}" GUARDIAN_URL="http://localhost:${guardian_server_port}" \
-  bun run "${GUARDIAN_PKG}/src/openai-api-server.ts" 2>&1 | sed -u 's/^/[openai-api] /' >&2 &
+  bun run "${GUARDIAN_CORE_PKG}/src/openai-api-server.ts" 2>&1 | sed -u 's/^/[openai-api] /' >&2 &
 
 # ── Start guardian ────────────────────────────────────────────────────────────
-exec bun run "${GUARDIAN_PKG}/src/server.ts"
+# Boot the configured composition package at its (overridable) entry point.
+exec bun run "${GUARDIAN_PKG}/${OP_GUARDIAN_ENTRY}"

--- a/containers/guardian/entrypoint.sh
+++ b/containers/guardian/entrypoint.sh
@@ -82,7 +82,37 @@ install_artifact() {
   exit 1
 }
 
+# ── Optional private-registry auth ────────────────────────────────────────────
+# To install the guardian package (OP_GUARDIAN_PACKAGE) from a private,
+# authenticated registry, supply an .npmrc. Bun reads $HOME/.npmrc for registry
+# + auth (registry=, @scope:registry=, //host/:_authToken=, _auth). Prefer a
+# mounted secret file (OP_GUARDIAN_NPMRC_FILE — e.g. a Key Vault secret volume);
+# OP_GUARDIAN_NPMRC (inline content) is a convenience that puts the token in an
+# env var. The token is never logged.
+setup_npmrc() {
+  local dest="${HOME:-/opt/openpalm/guardian}/.npmrc"
+  # This runs on the root pass (before installs) and again after the gosu drop.
+  # When invoked as root, hand the file to the target uid:gid so the second,
+  # non-privileged pass can re-place it without an EACCES on its own mode-600 file.
+  if [ -n "${OP_GUARDIAN_NPMRC_FILE:-}" ]; then
+    if [ -f "${OP_GUARDIAN_NPMRC_FILE}" ]; then
+      install -m 600 "${OP_GUARDIAN_NPMRC_FILE}" "$dest"
+      [ "$IS_ROOT" = "1" ] && chown "${TARGET_UID}:${TARGET_GID}" "$dest" 2>/dev/null || true
+      echo "[guardian] using private-registry .npmrc from \$OP_GUARDIAN_NPMRC_FILE"
+    else
+      echo "ERROR: OP_GUARDIAN_NPMRC_FILE is set but not found: ${OP_GUARDIAN_NPMRC_FILE}" >&2
+      exit 1
+    fi
+  elif [ -n "${OP_GUARDIAN_NPMRC:-}" ]; then
+    printf '%s\n' "${OP_GUARDIAN_NPMRC}" > "$dest"
+    chmod 600 "$dest"
+    [ "$IS_ROOT" = "1" ] && chown "${TARGET_UID}:${TARGET_GID}" "$dest" 2>/dev/null || true
+    echo "[guardian] using private-registry .npmrc from \$OP_GUARDIAN_NPMRC"
+  fi
+}
+
 ensure_volume_ownership
+setup_npmrc
 
 GUARDIAN_VERSION=$(resolve_version "${OP_GUARDIAN_VERSION:-}" "${PLATFORM_VERSION:-}" "GUARDIAN")
 install_artifact "$OP_GUARDIAN_PACKAGE" "$GUARDIAN_VERSION" /opt/openpalm/guardian


### PR DESCRIPTION
Fixes #526

## What

The guardian thin-host entrypoint (`containers/guardian/entrypoint.sh`) hardcoded the package it installs and boots (`@openpalm/guardian`). Downstream distributions built on the published library seams had to fork the entire entrypoint to swap that package. This makes the thin host package-agnostic via env:

- `OP_GUARDIAN_PACKAGE` (default `@openpalm/guardian`) — which guardian composition package is installed (exact-version pinned) and booted.
- `OP_GUARDIAN_ENTRY` (default `src/server.ts`) — overridable boot entry within that package.

## Default-unchanged guarantee

With no `OP_GUARDIAN_PACKAGE` / `OP_GUARDIAN_ENTRY` set, the boot path is byte-for-byte unchanged. Version resolution (`OP_GUARDIAN_VERSION` / `PLATFORM_VERSION`) and the exact-version pin are untouched, as are install retry/skip, the gosu privilege drop, `ensure_volume_ownership`, the content-validation hard-fail, and the skeleton/tools install.

## openai-api core resolution

The OpenAI-compatible API server lives in the public core `@openpalm/guardian` (`src/openai-api-server.ts`). When `OP_GUARDIAN_PACKAGE` is an alternate package, the core remains present as a (transitive) dependency, so the entrypoint resolves the core package dir robustly via `require.resolve('@openpalm/guardian/package.json')` and starts openai-api from there rather than from the configured package dir, falling back to the conventional path if resolution fails. In the default case the resolved core dir equals `GUARDIAN_PKG`, so behavior is identical.

## Verification

- `bash -n containers/guardian/entrypoint.sh` — clean.
- `docker build -t guardian-seam-test:local -f containers/guardian/Dockerfile .` from repo root — succeeds.
- **Regression (default):** `docker run -d -e PLATFORM_VERSION=0.12.17 guardian-seam-test:local` — confirmed it installs `@openpalm/guardian@0.12.17`, the `[openai-api] ... started` line appears (proving `GUARDIAN_CORE_PKG` resolution works), and `{"service":"guardian","msg":"started"...}` appears:
  ```
  Installing @openpalm/guardian@0.12.17 (attempt 1)...
  [openai-api] {"...","service":"guardian:openai-api","msg":"started","extra":{"port":8182,"guardianUrl":"http://localhost:8080"}}
  {"...","service":"guardian","msg":"started","extra":{"internalPort":8080,"directPort":3830,"adminPort":3831,"directIngressEnabled":false,"seededPrincipals":0}}
  ```
- **Override smoke (explicit default):** `docker run -d -e PLATFORM_VERSION=0.12.17 -e OP_GUARDIAN_PACKAGE=@openpalm/guardian guardian-seam-test:local` — identical startup markers.

A true alternate-package boot can't be exercised here because no alternate guardian package is published to npm; verification covers the default + explicit-default paths and the path-resolution logic.

## Private-registry auth

The configurable `OP_GUARDIAN_PACKAGE` is only useful if the thin host can install that package, and downstream guardian packages will live in a **private, authenticated registry** (private npm, GitHub Packages, Azure Artifacts, JFrog, etc.). The entrypoint installs via `bun add`, and Bun reads `.npmrc` (`registry=`, `@scope:registry=`, `//host/:_authToken=`, `_auth`) from `$HOME/.npmrc`. A new opt-in `setup_npmrc` step supplies that file:

- `OP_GUARDIAN_NPMRC_FILE` — path to a mounted secret `.npmrc` (e.g. a Key Vault secret volume). **Preferred** (no token in env). Fails fast if set but missing.
- `OP_GUARDIAN_NPMRC` — inline `.npmrc` content (convenience).

`setup_npmrc` runs after `ensure_volume_ownership` and before the first `install_artifact`, so the auth is in place for every `bun add` (guardian, skeleton, tools) regardless of cwd. The file is written to `$HOME/.npmrc` at mode `600` and, on the root pass, chowned to the target uid:gid so the post-gosu non-root pass can re-place it without `EACCES`. The token is never logged — only the source-selection line.

**Purely additive / opt-in:** when neither var is set, no `.npmrc` is written and the default public-registry behavior is byte-for-byte unchanged. File source takes precedence over inline.

### Verification

- `bash -n containers/guardian/entrypoint.sh` — clean.
- **Default regression (no npmrc vars):** install of `@openpalm/guardian@0.12.17` + guardian `started` line unchanged; `test -f "$HOME/.npmrc"` → **ABSENT**.
- **Inline `.npmrc` smoke** (dummy non-secret value, scoped `@dummy` entry): `$HOME/.npmrc` exists as `-rw------- bun bun` (mode 600), exactly **2 lines**; public guardian install + boot still succeed. Token contents never printed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
