### PR TITLE
fix(ui): update tests for expanded BUILTIN_ADDON_IDS (8 addon IDs)

### DIFF
--- a/packages/ui/src/hooks.server.vitest.ts
+++ b/packages/ui/src/hooks.server.vitest.ts
@@ -149,10 +149,12 @@ describe('hooks.server — sliding renewal', () => {
   test('not_installed + an accessible remote (no migration) skips splash → /chat', async () => {
     // Fresh home, nothing installed, but a reachable remote assistant is configured:
     // the user should land in chat, not on the splash.
+    // OP_LAYOUT_VERSION=2 prevents the version-1→2 migration from being detected as
+    // pending (a stack.env with no stamp is treated as layout 1, which triggers migration).
     const state = resetState('test-admin-pw');
     const kvDir = join(state.stackDir, '..', '..', 'knowledge', 'env');
     mkdirSync(kvDir, { recursive: true });
-    writeFileSync(join(kvDir, 'stack.env'), 'OP_SETUP_COMPLETE=false\n');
+    writeFileSync(join(kvDir, 'stack.env'), 'OP_SETUP_COMPLETE=false\nOP_LAYOUT_VERSION=2\n');
     vi.mocked(listRemoteStatuses).mockResolvedValue([
       { id: 'r1', name: 'Remote', url: 'http://example/', state: 'accessible' },
     ]);

--- a/packages/ui/src/routes/admin/addons/server.vitest.ts
+++ b/packages/ui/src/routes/admin/addons/server.vitest.ts
@@ -79,7 +79,7 @@ describe('GET /admin/addons', () => {
     const res = await GET(makeGetEvent());
     expect(res.status).toBe(200);
     const body = await res.json() as { addons: unknown[] };
-    expect(body.addons).toHaveLength(5);
+    expect(body.addons).toHaveLength(8);
   });
 
   test('lists available addons with enabled status', async () => {
@@ -90,7 +90,7 @@ describe('GET /admin/addons', () => {
     expect(res.status).toBe(200);
 
     const body = await res.json() as { addons: Array<{ name: string; enabled: boolean; available: boolean }> };
-    expect(body.addons).toHaveLength(5);
+    expect(body.addons).toHaveLength(8);
 
     const discord = body.addons.find((a) => a.name === 'discord');
     expect(discord).toEqual({ name: 'discord', enabled: true, available: true });


### PR DESCRIPTION
## Summary

- **Failures 1 & 2** (`server.vitest.ts`): Updated two `toHaveLength(5)` assertions to `toHaveLength(8)` in the GET /admin/addons tests. PR #523 expanded `BUILTIN_ADDON_IDS` from 5 (`api`, `discord`, `ollama`, `slack`, `voice`) to 8 (adding `chat`, `gateway`, `ssh`).

- **Failure 3** (`hooks.server.vitest.ts`): Added `OP_LAYOUT_VERSION=2` to the `not_installed + accessible remote` test's stack.env seed. **Root cause**: PR #523 also fixed `readLayoutVersion` case 4 — a `stack.env` that exists but has no `OP_LAYOUT_VERSION` stamp now returns layout version `1` (correct: treat as pre-stamp 0.11.0 home) rather than `CURRENT_LAYOUT_VERSION` (was skipping the 1→2 migration). The test seeds a `stack.env` with `OP_SETUP_COMPLETE=false` to simulate a `not_installed` home. With the M2 fix, the migration check now sees this as a pending 1→2 migration, `isMigrationBlocking` returns `true`, and the hook redirects to `/splash` instead of `/chat`. The fix adds `OP_LAYOUT_VERSION=2` to the seed so the home is treated as correctly stamped — matching what a real fresh 0.12.x install would have.

## Test plan

- [x] `cd packages/ui && npx vitest run src/routes/admin/addons/server.vitest.ts src/hooks.server.vitest.ts` — all 15 tests pass
- [x] `bun run ui:check` — 0 ERRORS 0 WARNINGS

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019VSa1Rx132xfKoEzBc83JG