### PR TITLE
feat(guardian): async-capable AuthStrategy seam (enables JWKS/OIDC strategies)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,14 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - The audit writer is created lazily on first write, so importing the guardian
   library has no filesystem side effects.
 
+### Changed
+
+- The `@openpalm/guardian` `AuthStrategy` seam is now async-capable: a strategy's
+  `authenticate()` may return a `Promise` (enabling JWKS/OIDC bearer-token
+  strategies that verify against a remote JWKS), and the exported `authenticate()`
+  is now async. The built-in `basicTokenAuthStrategy` and its behavior are
+  unchanged (it still resolves synchronously).
+
 ### Fixed
 
 - **`packages/skeleton/tools.json` now installs the real `opencode-ai` npm

--- a/packages/guardian/src/auth.ts
+++ b/packages/guardian/src/auth.ts
@@ -60,7 +60,10 @@ function parseBasicAuth(header: string): { id: string; secret: string } | null {
  * the exported {@link authenticate} delegates to whichever strategy is active.
  */
 export interface AuthStrategy {
-  authenticate(req: Request, expectedKind?: PrincipalKind): AuthenticatedPrincipal | null;
+  authenticate(
+    req: Request,
+    expectedKind?: PrincipalKind,
+  ): AuthenticatedPrincipal | null | Promise<AuthenticatedPrincipal | null>;
 }
 
 /** The built-in HTTP Basic / principal-token authenticator. */
@@ -106,6 +109,9 @@ export function resetAuthStrategy(): void {
 }
 
 /** Authenticate a request via the active {@link AuthStrategy}. */
-export function authenticate(req: Request, expectedKind?: PrincipalKind): AuthenticatedPrincipal | null {
+export async function authenticate(
+  req: Request,
+  expectedKind?: PrincipalKind,
+): Promise<AuthenticatedPrincipal | null> {
   return activeStrategy.authenticate(req, expectedKind);
 }

--- a/packages/guardian/src/index.test.ts
+++ b/packages/guardian/src/index.test.ts
@@ -91,6 +91,28 @@ describe('auth strategy seam', () => {
     resetAuthStrategy();
     expect(await authenticate(new Request('http://x'))).toBeNull();
   });
+
+  test('awaits an asynchronous strategy (JWKS/OIDC use case)', async () => {
+    // A strategy that resolves on a later tick — the seam must await it.
+    const asyncStrategy: AuthStrategy = {
+      authenticate: async () => {
+        await new Promise((r) => setTimeout(r, 5));
+        return { id: 'async-svc', kind: 'direct', label: 'Async', userId: 'async-svc' };
+      },
+    };
+    setAuthStrategy(asyncStrategy);
+    expect((await authenticate(new Request('http://x')))?.id).toBe('async-svc');
+  });
+
+  test('authenticate() returns a thenable — callers MUST await (no auth-bypass via truthy Promise)', async () => {
+    // Regression guard: the exported authenticate() is async, so its raw
+    // (unawaited) return value is a Promise. A caller that forgets to await and
+    // checks truthiness would treat every request as authenticated. This test
+    // documents the contract; the sole production caller (proxy.ts) awaits.
+    const result = authenticate(new Request('http://x'));
+    expect(typeof (result as Promise<unknown>).then).toBe('function');
+    await result; // settle so it isn't left dangling
+  });
 });
 
 describe('policy provider seam', () => {

--- a/packages/guardian/src/index.test.ts
+++ b/packages/guardian/src/index.test.ts
@@ -76,20 +76,20 @@ describe('transport registry seam', () => {
 describe('auth strategy seam', () => {
   beforeEach(() => resetAuthStrategy());
 
-  test('defaults to the built-in basic-token strategy', () => {
+  test('defaults to the built-in basic-token strategy', async () => {
     expect(getAuthStrategy()).toBe(basicTokenAuthStrategy);
     // No credentials -> the built-in strategy returns null.
-    expect(authenticate(new Request('http://x'))).toBeNull();
+    expect(await authenticate(new Request('http://x'))).toBeNull();
   });
 
-  test('authenticate() delegates to the active strategy', () => {
+  test('authenticate() delegates to the active strategy', async () => {
     const fake: AuthStrategy = {
       authenticate: () => ({ id: 'svc', kind: 'direct', label: 'Service', userId: 'svc' }),
     };
     setAuthStrategy(fake);
-    expect(authenticate(new Request('http://x'))?.id).toBe('svc');
+    expect((await authenticate(new Request('http://x')))?.id).toBe('svc');
     resetAuthStrategy();
-    expect(authenticate(new Request('http://x'))).toBeNull();
+    expect(await authenticate(new Request('http://x'))).toBeNull();
   });
 });
 

--- a/packages/guardian/src/proxy.ts
+++ b/packages/guardian/src/proxy.ts
@@ -164,7 +164,7 @@ export async function handleProxy(
     }
   }
 
-  const authenticated = authenticate(req, expectedKind);
+  const authenticated = await authenticate(req, expectedKind);
   if (!authenticated) {
     return deny(rid, 401, 'unauthorized', {});
   }


### PR DESCRIPTION
## Why

Downstream OIDC/SSO strategies must validate JWTs against a **remote JWKS**, which is inherently asynchronous. The guardian `AuthStrategy` seam was synchronous, so it could not host such strategies. This widens the seam to be async-capable without changing the built-in synchronous Basic/token path.

## Interface change

`packages/guardian/src/auth.ts`:

```diff
 export interface AuthStrategy {
-  authenticate(req: Request, expectedKind?: PrincipalKind): AuthenticatedPrincipal | null;
+  authenticate(
+    req: Request,
+    expectedKind?: PrincipalKind,
+  ): AuthenticatedPrincipal | null | Promise<AuthenticatedPrincipal | null>;
 }
```

The exported top-level `authenticate()` is now async and awaits the active strategy:

```diff
-export function authenticate(req: Request, expectedKind?: PrincipalKind): AuthenticatedPrincipal | null {
-  return activeStrategy.authenticate(req, expectedKind);
-}
+export async function authenticate(
+  req: Request,
+  expectedKind?: PrincipalKind,
+): Promise<AuthenticatedPrincipal | null> {
+  return activeStrategy.authenticate(req, expectedKind);
+}
```

## Built-in Basic strategy unchanged

`basicTokenAuthStrategy` is untouched — it still resolves **synchronously**. A sync return value satisfies the widened union, so its behavior is byte-for-byte identical. The only difference for callers is they now `await`, which is a no-op for sync values.

`setAuthStrategy` / `getAuthStrategy` / `resetAuthStrategy` semantics are unchanged. No version bump.

## Call sites awaited (security-critical)

Exhaustive grep of `packages/guardian/src` for `authenticate(`:

| Site | Status |
|---|---|
| `proxy.ts:167` — `handleProxy` | `const authenticated = await authenticate(req, expectedKind);` — caller already `async`. **The sole production delegating call.** |
| `index.test.ts` (2 calls in the seam tests) | now `await authenticate(...)`; the two tests made `async`. |
| `proxy-policy.test.ts:32` | an `AuthStrategy` *implementation* returning a sync value — still satisfies the union, no change needed. |
| `auth.ts` | the interface decl, the built-in strategy impl, the exported async fn, and its single delegation `activeStrategy.authenticate(...)` (inside the async fn). |

No call site treats the now-Promise return as truthy without awaiting (verified — the only delegating production call is `proxy.ts`, which awaits before the `if (!authenticated)` gate).

## Verification

- `grep -rn "authenticate(" packages/guardian/src` — every production delegating call is awaited.
- `cd packages/guardian && bun test` — **177 pass, 0 fail** (includes spawned `server.ts` integration tests exercising the real auth path over HTTP, plus auth/proxy/mcp/server suites).
- `bunx tsc --noEmit --skipLibCheck ... src/auth.ts src/proxy.ts` — clean (exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)