### PR TITLE
Make `all` the unambiguous complete release; flag partial units

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,26 +2,40 @@ name: Release
 
 # Single manually-dispatched orchestrator for releasing OpenPalm by deployment UNIT.
 #
-# Units:
+# Units. NOTE: every unit EXCEPT `all` is PARTIAL by design — it publishes only
+# its own slice. A partial unit will silently leave the other units behind (e.g.
+# `platform` does NOT touch the portal image or the discord/slack npm adapters).
+# For a complete, coordinated release of the whole platform, use `all`.
 #   platform  — @openpalm/lib + openpalm (CLI) + @openpalm/ui (npm) + admin-tools +
 #               CLI native binaries + optional Electron + git tag + GitHub release
-#               (add include_images=true to also rebuild Docker images)
+#               (add include_images=true to also rebuild guardian + assistant images).
+#               PARTIAL: no portal image, no portal npm, no voice.
 #   portals   — @openpalm/discord-portal + @openpalm/slack-portal npm packages
 #               (the portal image bun-installs these at runtime, so they update via
 #               `bun update` without an image rebuild) + optional portal image
-#               (include_images=true) + git tag + GitHub release
-#   assistant — openpalm/assistant image + git tag + GitHub release
+#               (include_images=true) + git tag + GitHub release. PARTIAL.
+#   assistant — openpalm/assistant image + git tag + GitHub release. PARTIAL.
 #   guardian  — @openpalm/guardian + @openpalm/skeleton npm packages only
-#               (add include_images=true to also rebuild the guardian Docker image)
+#               (add include_images=true to also rebuild the guardian Docker image). PARTIAL.
 #   images    — Docker-only: rebuilds guardian + assistant + portal images at the
 #               current (or explicitly overridden) platform version. No npm publish.
 #               Use to roll out container-level changes (system deps, OpenCode version)
-#               without touching npm packages.
+#               without touching npm packages. PARTIAL.
 #   electron  — Electron installers only (mac/linux/win). No npm publish. Use when
 #               only the desktop harness has changed and other units are already published.
-#               Always pass version explicitly (the version the existing npm packages are at).
-#   all       — every unit simultaneously at a specific or bumped version + summary tag.
+#               Always pass version explicitly (the version the existing npm packages are at). PARTIAL.
+#   all       — COMPLETE coordinated release. Publishes EVERY unit at one version,
+#               flag-free (no include_images / include_electron needed):
+#                 npm: @openpalm/{lib,ui,guardian,skeleton} + openpalm (CLI)
+#                      + @openpalm/{discord,slack}-portal
+#                 images: openpalm/{assistant,guardian,portal}  (+ :latest when stable)
+#                 electron installers (mac/linux/win) + CLI native binaries
+#                 per-unit tags + bare X.Y.Z summary tag + GitHub release.
 #               Accepts any bump type (patch/minor/major) or an explicit version override.
+#               THE ONLY thing `all` does NOT build is the voice image — voice ships
+#               from publish-voice.yml on its own cadence (GPU cpu/cu121 variants).
+#               Prefer `all` for a real release; reach for a partial unit only for a
+#               deliberate, isolated hotfix to one slice.
 #
 # Thin-host decoupling: guardian and platform npm packages can be released independently
 # of Docker images. npm patches deploy instantly to thin-host deployments without a

--- a/docs/technical/release-architecture.md
+++ b/docs/technical/release-architecture.md
@@ -19,12 +19,14 @@ Each unit has a single canonical version anchor. All packages/images within a un
 | Unit | Artifacts | Canonical version anchor |
 |---|---|---|
 | `platform` | @openpalm/lib (npm), openpalm CLI (npm + binaries), @openpalm/ui (npm), @openpalm/skeleton (npm), @openpalm/guardian (npm) | root `package.json` (max with npm-published) |
-| `portals` | `openpalm/portal` Docker image | `portals/discord/package.json` |
+| `portals` | @openpalm/discord-portal + @openpalm/slack-portal (npm), optional `openpalm/portal` Docker image (`include_images=true`) | `portals/discord/package.json` |
 | `assistant` | `openpalm/assistant` Docker image | `containers/assistant/VERSION` |
 | `guardian` | @openpalm/guardian (npm), @openpalm/skeleton (npm), optional guardian Docker image | `packages/guardian/package.json` (max with npm-published) |
 | `images` | Guardian + assistant + portal Docker images (no npm) | root `package.json` (no bump — use `version` override to tag images at a new version) |
 | `electron` | Electron installers (mac/linux/win). No npm. | `packages/electron/package.json` |
-| `all` | Every unit simultaneously at any version | root `package.json` (max with npm-published) |
+| `all` | **Every unit** — all platform npm + both portal npm adapters + all three Docker images (assistant/guardian/portal) + electron installers + CLI binaries, flag-free | root `package.json` (max with npm-published) |
+
+> **Every unit except `all` is partial by design** — it publishes only its own slice and silently leaves the others behind. In particular, `platform` does **not** touch the portal image or the discord/slack npm adapters (that's a `portals` release). For a complete, coordinated release of the whole platform, use **`all`** — it builds every unit at one version with no `include_images`/`include_electron` flags required. The **only** artifact `all` does not build is the **voice** image, which ships from `publish-voice.yml` on its own cadence (GPU cpu/cu121 variants).
 
 ### Dual-owned packages
 
@@ -146,7 +148,14 @@ Preflight: `bun run electron:test`.
 
 ### `all`
 
-Stamps every unit's files simultaneously to the same version (any bump type or explicit override). Publishes all npm packages and Docker images. Creates per-unit tags + bare `X.Y.Z` summary tag.
+The **complete** release. Stamps every unit's files simultaneously to the same version (any bump type or explicit override) and publishes everything, flag-free:
+
+- **npm**: `@openpalm/{lib,ui,guardian,skeleton}` + `openpalm` (CLI) + `@openpalm/{discord,slack}-portal`
+- **Docker**: `openpalm/{assistant,guardian,portal}` (+ `:latest` for stable)
+- **Electron** installers (mac/linux/win) + CLI native binaries
+- Per-unit tags + bare `X.Y.Z` summary tag + GitHub release
+
+No `include_images` / `include_electron` needed — `all` always builds them. The only thing it does **not** build is the voice image (`publish-voice.yml`, separate cadence). Prefer `all` for a real release; reach for a partial unit only for a deliberate, isolated hotfix.
 
 ---
 


### PR DESCRIPTION
## Why
A 0.12.41 release went out as `unit=platform` and silently excluded the portal image + discord/slack npm adapters. `platform` is partial **by design**, but the workflow header didn't make that clear, so it's easy to reach for a partial unit thinking it's "the release."

## What
**No behavior change** — `unit=all`'s job conditions were already comprehensive (verified: it builds all platform npm, both portal npm adapters, all three Docker images, electron, and CLI binaries with no `include_*` flags). This just makes that explicit and flags the partials:

- **release.yml header**: every unit except `all` is now labelled **PARTIAL**; `all` enumerates exactly what it publishes flag-free. Calls out that the **only** thing `all` omits is the voice image (`publish-voice.yml`, separate GPU cpu/cu121 cadence).
- **release-architecture.md**: matching enumeration + a callout; also fixed the `portals` table row, which had omitted the discord/slack npm adapters it publishes.

## Follow-up decision (not in this PR)
Should `all` also build the **voice** image (the one remaining exclusion), or stay separate? And do you want a hard **completeness-assertion job** on `unit=all` (post-publish check that every expected image tag + npm version exists, failing loudly if a unit was skipped)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)