### PR TITLE
fix(ui): Versions tab update-check is v-tolerant (don't re-pin equal versions)

### DIFF
--- a/packages/ui/src/lib/components/admin/updates/UpdatesTab.svelte
+++ b/packages/ui/src/lib/components/admin/updates/UpdatesTab.svelte
@@ -62,12 +62,19 @@
   // Auto mode pins npm packages to exact versions, so any diff (even range vs
   // concrete) is a meaningful change. If the operator wants range semantics they
   // use manual mode.
+  // Treat a legacy `v`-prefixed pin and its bare equivalent as the SAME version
+  // (stack.env "v0.11.0" vs the bare "0.11.0" the latest-resolver returns as of
+  // the 0.12.41 cutover). Without this, an up-to-date component reads as an
+  // "update" and gets re-pinned to a bare tag whose image may not exist yet
+  // (e.g. voice, still published only as v0.11.0-cpu).
+  const sameVersion = (a: string, b: string) => a.replace(/^v/, '') === b.replace(/^v/, '');
+
   const autoChanges = $derived(
     ALL_FIELDS
       .map((f) => f.key)
       .filter((k) => {
         const lat = latest[k];
-        return lat !== null && lat !== undefined && lat !== (loaded[k] ?? '');
+        return lat !== null && lat !== undefined && !sameVersion(lat, loaded[k] ?? '');
       })
   );
   const hasLatestFetch = $derived(latestFetchedAt !== '');
@@ -363,7 +370,7 @@
                 {#each ALL_FIELDS as field (field.key)}
                   {@const cur = loaded[field.key] ?? ''}
                   {@const lat = latest[field.key]}
-                  {@const changed = lat !== null && lat !== undefined && lat !== cur}
+                  {@const changed = lat !== null && lat !== undefined && !sameVersion(lat, cur)}
                   {@const unavailable = lat === null || lat === undefined}
                   <tr class:row-changed={changed}>
                     <td class="col-component">{field.label}</td>

--- a/packages/ui/src/lib/components/admin/updates/UpdatesTab.svelte.vitest.ts
+++ b/packages/ui/src/lib/components/admin/updates/UpdatesTab.svelte.vitest.ts
@@ -172,6 +172,79 @@ describe('UpdatesTab — automatic mode', () => {
     });
   });
 
+  test('treats a legacy v-prefixed current as up-to-date against a bare latest (0.12.41 cutover)', async () => {
+    // stack.env still carries v-prefixed pins (v0.11.0); the latest-resolver now
+    // returns bare (0.11.0). Same version must NOT register as an update.
+    vi.mocked(fetchVersions).mockResolvedValue({
+      versions: {
+        OP_ASSISTANT_VERSION: 'v0.12.22',
+        OP_GUARDIAN_VERSION: 'v0.12.22',
+        OP_PORTAL_VERSION: 'v0.12.22',
+        OP_VOICE_VERSION: 'v0.11.0',
+      },
+      platformVersion: '0.12.22',
+      autoUpdate: true,
+    });
+    vi.mocked(fetchLatestVersions).mockResolvedValue({
+      versions: {
+        OP_ASSISTANT_VERSION: '0.12.22',
+        OP_GUARDIAN_VERSION: '0.12.22',
+        OP_PORTAL_VERSION: '0.12.22',
+        OP_VOICE_VERSION: '0.11.0',
+        OP_UI_VERSION: '0.12.22',
+      },
+      errors: [],
+      fetchedAt: '2026-06-21T00:00:00Z',
+    });
+    render(UpdatesTab, { props: {} });
+    await page.getByRole('button', { name: /check for updates/i }).click();
+
+    await vi.waitFor(async () => {
+      await expect.element(page.getByText(/everything is up to date/i)).toBeVisible();
+    });
+  });
+
+  test('excludes a v-vs-bare equal component from "update all" so it is never re-pinned to a missing bare image', async () => {
+    // The reported failure: voice (v0.11.0, image only published as v0.11.0-cpu)
+    // got swept into "update all", re-pinned to bare 0.11.0, and the stack pull
+    // aborted on the nonexistent openpalm/voice:0.11.0-cpu. Voice must stay out
+    // of the patch; the genuinely-behind images still update.
+    vi.mocked(fetchVersions).mockResolvedValue({
+      versions: {
+        OP_ASSISTANT_VERSION: 'v0.12.18',
+        OP_GUARDIAN_VERSION: 'v0.12.18',
+        OP_PORTAL_VERSION: 'v0.12.18',
+        OP_VOICE_VERSION: 'v0.11.0',
+      },
+      platformVersion: '0.12.22',
+      autoUpdate: true,
+    });
+    vi.mocked(fetchLatestVersions).mockResolvedValue({
+      versions: {
+        OP_ASSISTANT_VERSION: '0.12.22',
+        OP_GUARDIAN_VERSION: '0.12.22',
+        OP_PORTAL_VERSION: '0.12.22',
+        OP_VOICE_VERSION: '0.11.0',
+        OP_UI_VERSION: '0.12.22',
+      },
+      errors: [],
+      fetchedAt: '2026-06-21T00:00:00Z',
+    });
+    render(UpdatesTab, { props: {} });
+    await page.getByRole('button', { name: /check for updates/i }).click();
+
+    const updateBtn = page.getByRole('button', { name: /update \d+ component/i });
+    await expect.element(updateBtn).toBeVisible();
+    await updateBtn.click();
+
+    await vi.waitFor(() => {
+      expect(patchVersions).toHaveBeenCalledTimes(1);
+    });
+    const patchArg = vi.mocked(patchVersions).mock.calls[0][0];
+    expect(patchArg['OP_VOICE_VERSION']).toBeUndefined();
+    expect(patchArg['OP_ASSISTANT_VERSION']).toBe('0.12.22');
+  });
+
   test('shows registry error messages when some checks fail', async () => {
     vi.mocked(fetchLatestVersions).mockResolvedValue({
       versions: { ...ALL_VERSIONS, OP_ASSISTANT_VERSION: null },


### PR DESCRIPTION
## Symptom
On the Versions tab after upgrading to control-plane 0.12.41, **Voice showed "update"** even though current `v0.11.0` and latest `0.11.0` are the same version. Clicking **Update N components** then failed:

> Saved, but applying failed: stack: Image openpalm/assistant:0.12.41 Pulling

## Root cause
The tab compared current-vs-latest as **raw strings** (`lat !== cur`). After the 0.12.41 bare-tag cutover, stack.env still carries legacy `v`-prefixed pins (`v0.11.0`) while the latest-resolver returns bare (`0.11.0`), so an up-to-date component reads as an update.

Voice is the one image **not yet republished bare** — only `openpalm/voice:v0.11.0-cpu` exists (verified: bare `0.11.0-cpu` → `manifest unknown`). So "update all" re-pinned voice to bare `0.11.0`, and `compose pull` aborted on the missing `openpalm/voice:0.11.0-cpu`. The "assistant Pulling" line is just what was mid-flight when the pull aborted — `assistant:0.12.41` is fine (amd64+arm64 present).

This is a **pre-existing latent bug the cutover exposed** — before, both sides were `v`-prefixed, so the raw compare happened to work.

## Fix
Compare with a leading `v` stripped from both sides (`sameVersion`), in both the per-row badge and the `autoChanges` set behind "update all". `v0.11.0` ≡ `0.11.0`, so an unchanged component is neither shown as an update nor re-pinned. Moving tags (`latest`/`next`) still register as a change when pinned to a concrete version. +2 regression tests (all-equal → "up to date"; mixed → voice excluded from the patch). `ui:check` 0/0, UpdatesTab tests 17/17.

## Operator recovery (separate from this code fix)
The failed apply already **saved** the bad pins, so the affected machine's `stack.env` now has `OP_VOICE_VERSION=0.11.0` (unpullable). Recover by setting **Voice → `latest`** (or `v0.11.0`) in the Manual tab and applying — `openpalm/voice:latest-cpu` exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)