### PR TITLE
cleanup: move app-owned records to state/ (§1) + dev-tooling fixes

### DIFF
--- a/packages/cli/src/main.test.ts
+++ b/packages/cli/src/main.test.ts
@@ -326,12 +326,14 @@ describe('cli main', () => {
     console.warn = mock((message?: unknown) => { logs.push(String(message ?? '')); }) as typeof console.warn;
 
     try {
+      // OP_ENABLED_ADDONS is app-written addon state → state/ (constitution §1).
+      const stateEnv = () => readFileSync(join(base, 'state', 'stack.state.env'), 'utf-8');
       await main(['addon', 'enable', 'discord']);
-      expect(readFileSync(join(base, 'knowledge', 'env', 'stack.env'), 'utf-8')).toContain('OP_ENABLED_ADDONS=discord');
+      expect(stateEnv()).toContain('OP_ENABLED_ADDONS=discord');
       expect(readSecret(base, 'portal_discord_secret')).toBeTruthy();
 
       await main(['addon', 'disable', 'discord']);
-      expect(readFileSync(join(base, 'knowledge', 'env', 'stack.env'), 'utf-8')).not.toContain('discord');
+      expect(stateEnv()).not.toContain('discord');
     } finally {
       delete process.env.OP_SKIP_COMPOSE_PREFLIGHT;
       rmSync(base, { recursive: true, force: true });

--- a/packages/lib/src/control-plane/addons.test.ts
+++ b/packages/lib/src/control-plane/addons.test.ts
@@ -118,9 +118,10 @@ describe('addon runtime state', () => {
     ]);
   });
 
-  it('round-trips addon profile selection through stack.env', () => {
+  it('round-trips addon profile selection, written to state/ not stack.env (constitution §1)', () => {
     const stackDir = join(process.env.OP_HOME!, 'system', 'stack');
     const stackEnv = join(process.env.OP_HOME!, 'knowledge', 'env', 'stack.env');
+    const stateEnv = join(process.env.OP_HOME!, 'state', 'stack.state.env');
     mkdirSync(stackDir, { recursive: true });
     mkdirSync(join(process.env.OP_HOME!, 'knowledge', 'env'), { recursive: true });
     writeFileSync(stackEnv, '');
@@ -128,7 +129,9 @@ describe('addon runtime state', () => {
     expect(getAddonProfileSelection(process.env.OP_HOME!, 'voice')).toBeNull();
     setAddonProfileSelection(process.env.OP_HOME!, 'voice', 'addon.voice.cuda');
     expect(getAddonProfileSelection(process.env.OP_HOME!, 'voice')).toBe('addon.voice.cuda');
-    expect(readFileSync(stackEnv, 'utf-8')).toContain('OP_VOICE_PROFILE=addon.voice.cuda');
+    // App-written addon state lands in state/, and never in the operator-facing stack.env.
+    expect(readFileSync(stateEnv, 'utf-8')).toContain('OP_VOICE_PROFILE=addon.voice.cuda');
+    expect(readFileSync(stackEnv, 'utf-8')).not.toContain('OP_VOICE_PROFILE');
   });
 });
 

--- a/packages/lib/src/control-plane/addons.ts
+++ b/packages/lib/src/control-plane/addons.ts
@@ -12,7 +12,7 @@ import { parse as parseYaml } from 'yaml';
 import { createLogger } from '../logger.js';
 import { resolveLocalOpenpalmDir } from './ui-assets.js';
 import { ensurePortalSecret, ensureComposeVolumeTargets } from './config-persistence.js';
-import { patchSecretsEnvFile, readStackEnv } from './secrets.js';
+import { patchStateEnvFile, readStackEnv } from './secrets.js';
 import { readBundledStackAsset, readBundledCustomCompose } from './core-assets.js';
 import { canonicalAddonProfileSelection, resolveHardwareProfileVariant } from './profile-ids.js';
 import { parseEnabledAddons } from './env.js';
@@ -484,22 +484,22 @@ export function getAddonProfileSelection(homeDir: string, name: string): string 
 export function setAddonProfileSelection(homeDir: string, name: string, profile: string): void {
   const trimmed = canonicalAddonProfileSelection(name, profile);
   if (!trimmed) throw new Error(`Invalid canonical profile id for addon ${name}: ${profile}`);
-  patchSecretsEnvFile(homeDir, { [profileEnvKey(name)]: trimmed });
+  patchStateEnvFile(homeDir, { [profileEnvKey(name)]: trimmed });
 }
 
-/** Add/remove an addon id in the OP_ENABLED_ADDONS list in stack.env. */
+/** Add/remove an addon id in the OP_ENABLED_ADDONS list (app-written → state/). */
 function setEnabledAddonState(homeDir: string, name: string, enabled: boolean): void {
   const current = new Set(parseEnabledAddons(readStackEnv(homeDir).OP_ENABLED_ADDONS));
   if (enabled) current.add(name);
   else current.delete(name);
-  patchSecretsEnvFile(homeDir, { OP_ENABLED_ADDONS: [...current].sort().join(',') });
+  patchStateEnvFile(homeDir, { OP_ENABLED_ADDONS: [...current].sort().join(',') });
 }
 
 function enableAddon(homeDir: string, name: string): MutationResult {
   try {
     if (!VALID_NAME_RE.test(name)) throw new Error(`Invalid addon name: ${name}`);
     setEnabledAddonState(homeDir, name, true);
-    if (name === 'ssh') patchSecretsEnvFile(homeDir, { OPENCODE_ENABLE_SSH: '1' });
+    if (name === 'ssh') patchStateEnvFile(homeDir, { OPENCODE_ENABLE_SSH: '1' });
     return { ok: true };
   } catch (error) {
     return { ok: false, error: error instanceof Error ? error.message : String(error) };
@@ -510,7 +510,7 @@ function disableAddonByName(homeDir: string, name: string): MutationResult {
   try {
     if (!VALID_NAME_RE.test(name)) throw new Error(`Invalid addon name: ${name}`);
     setEnabledAddonState(homeDir, name, false);
-    if (name === 'ssh') patchSecretsEnvFile(homeDir, { OPENCODE_ENABLE_SSH: '0' });
+    if (name === 'ssh') patchStateEnvFile(homeDir, { OPENCODE_ENABLE_SSH: '0' });
     return { ok: true };
   } catch (error) {
     return { ok: false, error: error instanceof Error ? error.message : String(error) };

--- a/packages/lib/src/control-plane/deploy.ts
+++ b/packages/lib/src/control-plane/deploy.ts
@@ -8,7 +8,8 @@ import { applyInstall } from './lifecycle.js';
 import { buildManagedServices } from './lifecycle.js';
 import { composeDown, composePs, composePull, composeUp, detectExistingProject, resolveComposeProjectName } from './docker.js';
 import { mapDockerError } from './compose-errors.js';
-import { mergeEnvContent, parseEnvFile } from './env.js';
+import { parseEnvFile } from './env.js';
+import { patchStateEnvFile } from './secrets.js';
 import { acquireInstallLock, releaseInstallLock, type InstallLockHandle } from './install-lock.js';
 import { resolveBackupsDir } from './home.js';
 
@@ -235,9 +236,10 @@ async function pollContainerHealth(state: ControlPlaneState, progress: DeployPro
 }
 
 export function markSetupComplete(state: ControlPlaneState): void {
-  const path = `${state.stashDir}/env/stack.env`;
-  const existing = existsSync(path) ? readFileSync(path, 'utf-8') : '';
-  writeFileAtomic(path, mergeEnvContent(existing, { OP_SETUP_COMPLETE: 'true' }), 0o600);
+  // OP_SETUP_COMPLETE is an app-written record → state/ (constitution §1), not the
+  // operator-facing knowledge/env/stack.env. isSetupComplete/classifyLocalInstall
+  // merge state over legacy, so installs that recorded it in stack.env still read complete.
+  patchStateEnvFile(state.homeDir, { OP_SETUP_COMPLETE: 'true' });
 }
 
 export function backupSetupInputs(state: ControlPlaneState): string | null {

--- a/packages/lib/src/control-plane/install-edge-cases.test.ts
+++ b/packages/lib/src/control-plane/install-edge-cases.test.ts
@@ -24,6 +24,7 @@ import {
   buildOwnerEnvFromSetup,
   buildAuthJsonFromSetup,
 } from "./setup.js";
+import { markSetupComplete } from "./deploy.js";
 import type { SetupSpec, SetupConnection } from "./setup.js";
 import type { ControlPlaneState } from "./types.js";
 import { readSecret } from './secrets-files.js';
@@ -219,6 +220,23 @@ describe("Fresh Install", () => {
     const parsed = parseEnvContent(stackEnv);
     // Either entirely absent, or still the seeded "false" — never "true".
     expect(parsed.OP_SETUP_COMPLETE === undefined || parsed.OP_SETUP_COMPLETE === "false").toBe(true);
+  });
+
+  // Scenario 5: markSetupComplete writes the flag to state/ (constitution §1),
+  // never into the operator-facing knowledge/env/stack.env, and isSetupComplete
+  // reads it back via the state-over-legacy merge.
+  it("markSetupComplete writes OP_SETUP_COMPLETE to state/, not stack.env", () => {
+    mkdirSync(dataDir, { recursive: true });
+    writeFileSync(join(homeDir, "knowledge", "env", "stack.env"), "OP_SETUP_COMPLETE=false\n");
+    expect(isSetupComplete(homeDir)).toBe(false);
+
+    markSetupComplete({ homeDir } as unknown as ControlPlaneState);
+
+    expect(isSetupComplete(homeDir)).toBe(true);
+    const stateEnv = readFileSync(join(homeDir, "state", "stack.state.env"), "utf-8");
+    expect(stateEnv).toContain("OP_SETUP_COMPLETE=true");
+    // The operator-facing stack.env keeps its seeded "false" — state wins on read.
+    expect(readFileSync(join(homeDir, "knowledge", "env", "stack.env"), "utf-8")).toContain("OP_SETUP_COMPLETE=false");
   });
 });
 

--- a/packages/lib/src/control-plane/launch-status.ts
+++ b/packages/lib/src/control-plane/launch-status.ts
@@ -21,7 +21,7 @@ import { existsSync } from "node:fs";
 import { join } from "node:path";
 import { execFile } from "node:child_process";
 import { parseEnvFile } from "./env.js";
-import { legacyStackEnvFile } from "./home.js";
+import { legacyStackEnvFile, stateEnvFile } from "./home.js";
 import { checkDocker, checkDockerCompose } from "./docker.js";
 
 export type LocalStackState =
@@ -164,7 +164,11 @@ export function deriveLaunchStatus(input: { local: LocalStatus; remotes?: Remote
  */
 export function classifyLocalInstall(stackDir: string, homeDir: string): "not_installed" | "setup_incomplete" | "installed" {
   const hasCompose = existsSync(join(stackDir, "core.compose.yml"));
-  const env = parseEnvFile(legacyStackEnvFile(homeDir));
+  // OP_SETUP_COMPLETE lives in state/ (constitution §1); merge state OVER legacy so
+  // installs that recorded it in the legacy stack.env still classify as installed.
+  const legacy = parseEnvFile(legacyStackEnvFile(homeDir));
+  const state = existsSync(stateEnvFile(homeDir)) ? parseEnvFile(stateEnvFile(homeDir)) : {};
+  const env = { ...legacy, ...state };
   if (!hasCompose && env.OP_SETUP_COMPLETE !== "true") return "not_installed";
   if (env.OP_SETUP_COMPLETE === "true") return "installed";
   return "setup_incomplete";

--- a/packages/lib/src/control-plane/secrets.ts
+++ b/packages/lib/src/control-plane/secrets.ts
@@ -327,6 +327,36 @@ export function patchSecretsEnvFile(
   writeVaultFile(stackEnvPath, result);
 }
 
+/**
+ * Patch app-written records into OP_HOME/state/stack.state.env.
+ *
+ * Constitution §1: state/ is the app-written tree (setup record, enabled add-ons,
+ * version pins, channel). readStackEnv / buildEnvFiles merge this OVER the legacy
+ * knowledge/env/stack.env, so values written here win. This is the symmetric
+ * counterpart to patchSecretsEnvFile: use it for records the app owns, so the app
+ * never writes into the operator-facing stack.env. Non-secret keys only.
+ */
+export function patchStateEnvFile(homeDir: string, patches: Record<string, string>): void {
+  if (Object.keys(patches).length === 0) return;
+  assertNoSecretLikeStackEnvKeys(patches);
+
+  const path = stateEnvFile(homeDir);
+  mkdirSync(dirname(path), { recursive: true, mode: 0o700 });
+
+  let existing = "";
+  try {
+    if (existsSync(path)) existing = readFileSync(path, "utf-8");
+  } catch {
+    // start fresh
+  }
+
+  let result = mergeEnvContent(existing, patches);
+  if (!result.endsWith("\n")) result += "\n";
+  const tmp = `${path}.tmp`;
+  writeFileSync(tmp, result, { mode: 0o600 });
+  renameSync(tmp, path);
+}
+
 
 export function maskSecretValue(key: string, value: string): string {
   if (!value) return "";

--- a/packages/lib/src/control-plane/secrets.ts
+++ b/packages/lib/src/control-plane/secrets.ts
@@ -357,7 +357,6 @@ export function patchStateEnvFile(homeDir: string, patches: Record<string, strin
   renameSync(tmp, path);
 }
 
-
 export function maskSecretValue(key: string, value: string): string {
   if (!value) return "";
   if (PLAIN_CONFIG_KEYS.has(key)) return value;

--- a/packages/lib/src/control-plane/setup-status.ts
+++ b/packages/lib/src/control-plane/setup-status.ts
@@ -1,13 +1,17 @@
+import { existsSync } from 'node:fs';
 import { parseEnvFile } from './env.js';
-import { legacyStackEnvFile } from './home.js';
+import { legacyStackEnvFile, stateEnvFile } from './home.js';
 
 /**
- * Check if setup is complete by reading knowledge/env/stack.env.
+ * Check if setup is complete.
  *
- * Only OP_SETUP_COMPLETE=true is authoritative. Secrets live in
- * knowledge/secrets and are not completion sentinels.
+ * OP_SETUP_COMPLETE is an app-written record stored in state/stack.state.env
+ * (constitution §1). Merge state OVER the legacy knowledge/env/stack.env so that
+ * installs which recorded completion in the legacy file still read as complete.
+ * Only OP_SETUP_COMPLETE=true is authoritative.
  */
 export function isSetupComplete(homeDir: string): boolean {
-  const parsed = parseEnvFile(legacyStackEnvFile(homeDir));
-  return parsed.OP_SETUP_COMPLETE === "true";
+  const legacy = parseEnvFile(legacyStackEnvFile(homeDir));
+  const state = existsSync(stateEnvFile(homeDir)) ? parseEnvFile(stateEnvFile(homeDir)) : {};
+  return { ...legacy, ...state }.OP_SETUP_COMPLETE === "true";
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -18,10 +18,10 @@
     "build"
   ],
   "scripts": {
-    "dev": "PORT=5173 vite dev",
+    "dev": "PORT=${PORT:-5173} vite dev",
     "ux:audit": "NODE_PATH=\"$PWD/node_modules\" bun \"${AKM_HOME:-$HOME/akm}/skills/web-ux/ux-dom-audit/scripts/audit.ts\" e2e/ux-audit.config.json",
     "ux:audit:wizard": "NODE_PATH=\"$PWD/node_modules\" bun \"${AKM_HOME:-$HOME/akm}/skills/web-ux/ux-dom-audit/scripts/audit.ts\" e2e/ux-audit.wizard.config.json",
-    "dev:local": "PORT=5173 OP_OPENCODE_URL=${OP_OPENCODE_URL:-http://localhost:3800} vite dev",
+    "dev:local": "PORT=${PORT:-5173} OP_OPENCODE_URL=${OP_OPENCODE_URL:-http://localhost:3800} vite dev",
     "build": "svelte-kit sync && vite build && node scripts/stamp-version.mjs",
     "clean:build": "rm -rf .svelte-kit build",
     "preview": "vite preview",

--- a/packages/ui/src/routes/admin/addons/[name]/server.vitest.ts
+++ b/packages/ui/src/routes/admin/addons/[name]/server.vitest.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from 'vitest';
-import { mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { randomBytes } from 'node:crypto';
 import { tmpdir } from 'node:os';
@@ -53,7 +53,9 @@ function seedEnabledAddons(homeDir: string, csv: string): void {
 }
 
 function readStackEnvFile(homeDir: string): string {
-  return readFileSync(join(homeDir, 'knowledge', 'env', 'stack.env'), 'utf-8');
+  // OP_ENABLED_ADDONS is app-written addon state → state/ (constitution §1).
+  const p = join(homeDir, 'state', 'stack.state.env');
+  return existsSync(p) ? readFileSync(p, 'utf-8') : '';
 }
 
 let originalHome: string | undefined;

--- a/packages/ui/src/routes/admin/addons/server.vitest.ts
+++ b/packages/ui/src/routes/admin/addons/server.vitest.ts
@@ -51,7 +51,8 @@ function enableAddon(homeDir: string, name: string): void {
 }
 
 function readEnabledAddonsEnv(homeDir: string): string {
-  const p = join(homeDir, 'knowledge', 'env', 'stack.env');
+  // OP_ENABLED_ADDONS is app-written addon state → state/ (constitution §1).
+  const p = join(homeDir, 'state', 'stack.state.env');
   return existsSync(p) ? readFileSync(p, 'utf-8') : '';
 }
 

--- a/scripts/dev-setup.sh
+++ b/scripts/dev-setup.sh
@@ -263,13 +263,35 @@ if grep -q '^OP_ADMIN_PORT=' "$STASH_DIR/env/stack.env" \
 	_old_port="$(grep '^OP_ADMIN_PORT=' "$STASH_DIR/env/stack.env" | head -1 | cut -d= -f2-)"
 	printf 'OP_HOST_UI_PORT=%s\n' "$_old_port" >>"$STASH_DIR/env/stack.env"
 fi
-# Enable requested addons via OP_ENABLED_ADDONS (comma-separated) in stack.env.
+# Enable requested addons via OP_ENABLED_ADDONS (comma-separated) in stack.env,
+# and seed the matching COMPOSE_PROFILES. The production `up` path computes
+# active profiles via the control plane (resolveActiveProfiles), but the dev
+# shortcuts (dev:stack / dev:build) call docker compose directly and bypass it —
+# so without COMPOSE_PROFILES the enabled addon's containers (e.g. guardian +
+# discord portal) silently never start. docker compose reads COMPOSE_PROFILES
+# from --env-file. Mirror resolveActiveProfiles' defaults: voice/ollama use their
+# .cpu variant, everything else is addon.<name>.
 if [[ ${#enabled_addons[@]} -gt 0 ]]; then
 	_csv="$(IFS=,; echo "${enabled_addons[*]}")"
 	if grep -q '^OP_ENABLED_ADDONS=' "$STASH_DIR/env/stack.env"; then
 		sed -i "s/^OP_ENABLED_ADDONS=.*/OP_ENABLED_ADDONS=${_csv}/" "$STASH_DIR/env/stack.env"
 	else
 		printf 'OP_ENABLED_ADDONS=%s\n' "$_csv" >>"$STASH_DIR/env/stack.env"
+	fi
+
+	_profiles=()
+	for _a in "${enabled_addons[@]}"; do
+		case "$_a" in
+		voice) _profiles+=("addon.voice.cpu") ;;
+		ollama) _profiles+=("addon.ollama.cpu") ;;
+		*) _profiles+=("addon.${_a}") ;;
+		esac
+	done
+	_pcsv="$(IFS=,; echo "${_profiles[*]}")"
+	if grep -q '^COMPOSE_PROFILES=' "$STASH_DIR/env/stack.env"; then
+		sed -i "s/^COMPOSE_PROFILES=.*/COMPOSE_PROFILES=${_pcsv}/" "$STASH_DIR/env/stack.env"
+	else
+		printf 'COMPOSE_PROFILES=%s\n' "$_pcsv" >>"$STASH_DIR/env/stack.env"
 	fi
 fi
 


### PR DESCRIPTION
Follow-up cleanup after the install/update four-tree rebuild (#534). Two independent commits.

## 1. `refactor(state)` — write app-owned records to `state/`, not the operator `stack.env`

Constitution §1 makes `state/` the app-written tree. The rebuild's Phase 5 moved version pins + channel there, but two app-written records were still being written into the **operator-facing** `knowledge/env/stack.env`:

- `OP_SETUP_COMPLETE` (`markSetupComplete`)
- `OP_ENABLED_ADDONS` / `OP_<addon>_PROFILE` / `OPENCODE_ENABLE_SSH` (addon enable/disable)

This adds a symmetric `patchStateEnvFile()` next to `patchSecretsEnvFile()` and routes those writers to `state/stack.state.env`. Because `readStackEnv`/`buildEnvFiles` already merge **state over legacy**, the two legacy-only readers of `OP_SETUP_COMPLETE` (`isSetupComplete`, `classifyLocalInstall`) are updated to merge too.

**No migration needed** — the state-over-legacy merge *is* the transition: existing installs that recorded these in `stack.env` still read correctly, and the values move to `state/` naturally on the next write. This matches the rebuild's no-migrations philosophy. Backward-compat stays covered by the existing deployment-scenario fixtures (which seed the legacy value); new tests assert the write now lands in `state/` and **never** in the operator `stack.env`.

## 2. `chore(dev)` — dev-tooling fixes (surfaced during #534 stack-testing)

- **`dev-setup.sh --enable-addon`** wrote `OP_ENABLED_ADDONS` but not `COMPOSE_PROFILES`. The production `up` path computes profiles via the control plane (`resolveActiveProfiles`), but `dev:stack`/`dev:build` call `docker compose` directly and bypass it, so an enabled addon's containers (guardian + portal) silently never started. Now seeds `COMPOSE_PROFILES` alongside (compose reads it from `--env-file`, verified), mirroring `resolveActiveProfiles`' defaults. **Not** a re-implementation of control-plane logic — it completes the dev seeder's existing addon handling.
- **`packages/ui` `dev`** hardcoded `PORT=5173`, clobbering an outer `PORT` override (`ui:dev:isolated --port 3880`) and tripping the host-header guard. Changed to `PORT=${PORT:-5173}`.

(Deliberately left out: the dead-ish `OP_IMAGE_TAG` dev seed — it's still consumed by the CLI install path, and `dev:stack`=`:latest` vs `dev:build`=`:dev` is partly by design, so ripping it out isn't safe without a deeper version-var pass.)

## Verification
lib **622 pass**, root **1099 pass**, UI unit **864 pass**, `ui:check` **0/0**, CLI typecheck **0**, electron **73 pass**, UI ESLint **0**. dev-setup `bash -n` + package.json parse + `${PORT}` expansion + profile mapping verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)