### PR TITLE
fix(cli): bare-tag install ref (v-prefix retirement) + stop mock.module leaking across the bun test process

### DIFF
--- a/packages/cli/src/commands/install.ts
+++ b/packages/cli/src/commands/install.ts
@@ -30,10 +30,12 @@ const logger = createLogger('cli:install');
 async function resolveDefaultInstallRef(): Promise<string> {
   try {
     const res = await fetch('https://github.com/itlackey/openpalm/releases/latest', { redirect: 'manual', signal: AbortSignal.timeout(10000) });
-    const match = (res.headers.get('location') ?? '').match(/\/tag\/(v[0-9]+\.[0-9]+\.[0-9]+[^\s]*)$/);
+    // Release tags are bare semver since the 0.12.41 v-prefix retirement (e.g.
+    // /tag/0.12.43); the optional `v?` still matches a legacy v-tagged release.
+    const match = (res.headers.get('location') ?? '').match(/\/tag\/(v?[0-9]+\.[0-9]+\.[0-9]+[^\s]*)$/);
     if (match?.[1]) return match[1];
   } catch { /* fall through */ }
-  return cliPkg.version ? `v${cliPkg.version}` : 'main';
+  return cliPkg.version ?? 'main';
 }
 
 export default defineCommand({

--- a/packages/cli/src/commands/install.ts
+++ b/packages/cli/src/commands/install.ts
@@ -27,7 +27,7 @@ import { ensureValidState } from '../lib/cli-state.ts';
 
 const logger = createLogger('cli:install');
 
-async function resolveDefaultInstallRef(): Promise<string> {
+export async function resolveDefaultInstallRef(): Promise<string> {
   try {
     const res = await fetch('https://github.com/itlackey/openpalm/releases/latest', { redirect: 'manual', signal: AbortSignal.timeout(10000) });
     // Release tags are bare semver since the 0.12.41 v-prefix retirement (e.g.

--- a/packages/cli/src/commands/status.test.ts
+++ b/packages/cli/src/commands/status.test.ts
@@ -6,11 +6,17 @@
  * the common `running` and `not_installed` scenarios.
  */
 import { describe, expect, test, mock, afterEach } from 'bun:test';
+import * as realLib from '@openpalm/lib';
 
 const libUrl = '@openpalm/lib';
 
 afterEach(() => {
   mock.restore();
+  // mock.restore() does NOT undo mock.module(), so the @openpalm/lib mock below
+  // would otherwise leak into every other test file in the shared `bun test`
+  // process (other CLI tests get a partial lib → undefined fns → flaky rejection).
+  // Re-point it back to the real package.
+  mock.module(libUrl, () => ({ ...realLib }));
 });
 
 // Helper that captures what was logged to stdout/stderr during the command run.

--- a/packages/cli/src/commands/update.test.ts
+++ b/packages/cli/src/commands/update.test.ts
@@ -1,4 +1,6 @@
 import { afterEach, describe, expect, mock, test } from 'bun:test';
+import * as realLib from '@openpalm/lib';
+import * as realCliState from '../lib/cli-state.ts';
 
 const moduleUrls = {
   cliState: new URL('../lib/cli-state.ts', import.meta.url).href,
@@ -7,6 +9,11 @@ const updateModuleUrl = new URL('./update.ts', import.meta.url).href;
 
 afterEach(() => {
   mock.restore();
+  // mock.restore() does NOT undo mock.module(), so these mocks would otherwise leak
+  // into every other test file in the shared `bun test` process (other CLI tests get a
+  // partial @openpalm/lib → undefined fns → flaky rejection). Re-point to the real modules.
+  mock.module('@openpalm/lib', () => ({ ...realLib }));
+  mock.module(moduleUrls.cliState, () => ({ ...realCliState }));
 });
 
 describe('runUpgradeAction', () => {

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -57,7 +57,7 @@ async function autoRun(opts: BareRunOpts = {}): Promise<void> {
     const { bootstrapInstall, resolveDefaultInstallRef } = await import('./commands/install.ts') as any;
     const version: string = typeof resolveDefaultInstallRef === 'function'
       ? await resolveDefaultInstallRef()
-      : (cliPkg.version ? `v${cliPkg.version}` : 'main');
+      : (cliPkg.version ?? 'main');
     await bootstrapInstall({
       force: false,
       version,

--- a/packages/lib/src/control-plane/akm-stats.test.ts
+++ b/packages/lib/src/control-plane/akm-stats.test.ts
@@ -1,6 +1,15 @@
-import { describe, expect, mock, test } from 'bun:test';
+import { afterEach, describe, expect, mock, test } from 'bun:test';
 import { getAkmStats, parseAkmStats } from './akm-stats.js';
 import type { ControlPlaneState } from './types.js';
+import * as realAssistantAkm from './assistant-akm.js';
+
+// bun's mock.restore() does NOT undo mock.module(), so the module mocked below would
+// otherwise leak into every other test file in the shared `bun test` process. Re-point
+// it back to the real implementation after each test.
+afterEach(() => {
+  mock.restore();
+  mock.module('./assistant-akm.js', () => ({ ...realAssistantAkm }));
+});
 
 const state: ControlPlaneState = {
   homeDir: '/tmp/openpalm',


### PR DESCRIPTION
Two CLI/test fixes surfaced while cutting the `0.12.44-beta.1` release.

## 1. `fix(cli)` — default install ref must match bare release tags

`resolveDefaultInstallRef` parsed the GitHub `/releases/latest` redirect with a regex that **required** a `v` prefix (`/tag/(v[0-9]…)`), but release tags are bare semver since the 0.12.41 v-prefix retirement — the redirect now points at `/tag/0.12.43`. The regex therefore never matched and the function always fell back to `v${cliPkg.version}`, a v-prefixed ref inconsistent with the bare-tag world.

Aligned with `self-update.ts` (already correct): made the `v` optional (`v?`, so a legacy v-tag still matches) and dropped the `v` from the fallback. Latent today (this ref isn't used for a GitHub asset download — images track `latest`, UI/skeleton seed by npm channel, the skeleton stamps `PLATFORM_VERSION`), but a real inconsistency and a bug-in-waiting if it ever feeds a download the way self-update's does.

## 2. `test` — stop `mock.module` leaking `@openpalm/lib` across the shared bun process

Root cause of the intermittent CI **preflight flake** (an anonymous `(unnamed)` post-run unhandled rejection): **in bun 1.3.14, `mock.restore()` does not undo `mock.module()`** (verified empirically). Three test files leaked module mocks process-wide:

- `status.test.ts` → `mock.module('@openpalm/lib', <partial>)` ("restored" via the ineffective `mock.restore()`)
- `update.test.ts` → `mock.module('@openpalm/lib', <partial>)` + `cliState`
- `akm-stats.test.ts` → `mock.module('./assistant-akm.js', …)` (no restore)

When bun's non-deterministic file ordering puts a leaking file before a test that imports the real module, the victim gets a partial mock (missing fn → `undefined` call → flaky rejection). Order-dependent ⇒ intermittent ⇒ CI-only. Fix: re-point each module back to the real implementation in teardown (`import * as real…`), the documented workaround for bun's `mock.module` non-restoration. `deploy`/`lifecycle.rollback`/`apply-stack-service` already isolate via a subprocess harness and are unaffected.

**Transparency:** the exact `(unnamed)` CI symptom was **not reproducible locally** (145+ runs across full suite / cli suite / isolation). This fixes the *confirmed* leak mechanism in the flake's exact class, not a locally-reproduced symptom. Considered (and rejected) `bun test --isolate` (breaks 30 unrelated tests) and a global unhandled-rejection logger (would *mask* the failure).

## Verification
`bun run test` **1099/0** (×5), `cli typecheck` **0**, cli suite **80× green**, forced-order leak check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)