### PR TITLE
fix(update): updates were frozen — advance the version + stop misreading legacy stack.env as a pin

### DIFF
--- a/packages/lib/src/control-plane/versions.test.ts
+++ b/packages/lib/src/control-plane/versions.test.ts
@@ -139,13 +139,18 @@ describe("readPinnedVersions", () => {
     expect(pinned.OP_VOICE_VERSION).toBe("0.12.0");
   });
 
-  it("falls back to legacy stack.env when state file is absent (dual-read §1a)", () => {
+  it("a legacy stack.env value is NOT a pin — it is the applied/current version, so pinned is null (the freeze-bug fix)", () => {
+    // The old updater auto-wrote OP_*_VERSION into the legacy stack.env as the
+    // CURRENT version. Reading it as a pin froze every existing install: the UI
+    // showed it pinned and "update" re-applied that version forever. A deliberate
+    // pin lives ONLY in state/; a legacy-only value means "tracking" (pinned null),
+    // and update is free to advance it to the channel-latest.
     writeFileSync(
       join(home.state.homeDir, "knowledge", "env", "stack.env"),
       "OP_GUARDIAN_VERSION=0.12.33\n"
     );
     const pinned = readPinnedVersions(home.state);
-    expect(pinned.OP_GUARDIAN_VERSION).toBe("0.12.33");
+    expect(pinned.OP_GUARDIAN_VERSION).toBe(null);
   });
 
   it("state file wins over legacy when both present", () => {

--- a/packages/lib/src/control-plane/versions.ts
+++ b/packages/lib/src/control-plane/versions.ts
@@ -176,11 +176,18 @@ export function readVersions(state: ControlPlaneState): Record<string, string> {
  * UI could have written one).
  */
 export function readPinnedVersions(state: ControlPlaneState): Record<VersionKey, string | null> {
+  // A PIN is a DELIBERATE lock, and deliberate version records live in state/
+  // (constitution §1). A value in the legacy knowledge/env/stack.env is the
+  // auto-written APPLIED/current version (the old updater wrote it; a fresh
+  // install seeds it to "latest") — NOT a user pin. Reading legacy here was the
+  // bug that froze every existing install at whatever version it carried when it
+  // crossed onto this model: the UI showed it "pinned" and "update" re-applied
+  // that version forever. The effective/running version (what compose uses) is
+  // readVersions(), which DOES fall back to legacy; only the PIN is state-only.
   const fromState = existsSync(stateEnvFile(state.homeDir)) ? parseEnvFile(stateEnvFile(state.homeDir)) : {};
-  const fromLegacy = existsSync(legacyStackEnvFile(state.homeDir)) ? parseEnvFile(legacyStackEnvFile(state.homeDir)) : {};
   const out = {} as Record<VersionKey, string | null>;
   for (const key of SERVICE_VERSION_KEYS) {
-    const raw = fromState[key] ?? fromLegacy[key] ?? null;
+    const raw = fromState[key] ?? null;
     if (raw === null) { out[key] = null; continue; }
     // Normalize: strip legacy v-prefix and any voice variant suffix (tolerant read)
     let normalized = normalizePinValue(raw);

--- a/packages/ui/src/lib/api.ts
+++ b/packages/ui/src/lib/api.ts
@@ -122,11 +122,13 @@ export type ApplyChangesResult = {
   error?: string;
 };
 
-export async function applyChanges(): Promise<ApplyChangesResult> {
+export async function applyChanges(versions: Record<string, string> = {}): Promise<ApplyChangesResult> {
   // The route returns 502 when individual services fail (e.g. an addon
   // image isn't available). The body still carries the structured result,
   // so parse it before requireOk would throw.
-  const res = await request('POST', '/admin/update', {});
+  // `versions` carries the target each component should advance to (the resolved
+  // channel-latest or a pin) so the update actually moves forward (see UpdatesTab).
+  const res = await request('POST', '/admin/update', { versions });
   if (res.status === 401) {
     throw Object.assign(new Error('Sign-in required.'), { status: 401 });
   }
@@ -141,8 +143,8 @@ export async function applyChanges(): Promise<ApplyChangesResult> {
 
 /** Scoped single-service update (§4, §7 "Update <container>"):
  *  pull + recreate ONLY the named compose service. Pull failure is FATAL (§6). */
-export async function applyServiceUpdate(service: string): Promise<ApplyChangesResult> {
-  const res = await request('POST', '/admin/update', { service });
+export async function applyServiceUpdate(service: string, versions: Record<string, string> = {}): Promise<ApplyChangesResult> {
+  const res = await request('POST', '/admin/update', { service, versions });
   if (res.status === 401) {
     throw Object.assign(new Error('Sign-in required.'), { status: 401 });
   }

--- a/packages/ui/src/lib/components/admin/updates/UpdatesTab.svelte
+++ b/packages/ui/src/lib/components/admin/updates/UpdatesTab.svelte
@@ -127,6 +127,28 @@
     return v.replace(/^v/, '');
   }
 
+  // Resolve the version each component should ADVANCE to for an update: a deliberate
+  // pin if set, else the channel-latest `available`. A component on a moving tag
+  // (latest/next) with no pin is left alone — applyStack just re-pulls it; only a
+  // component stuck on a specific stale version needs an explicit target. This is the
+  // crux of the fix: a channel of specific tags (next/beta) has no moving tag to
+  // "track", so without writing the resolved target, update can never move forward.
+  function targetVersionsFor(keys: string[]): Record<string, string> {
+    const out: Record<string, string> = {};
+    for (const key of keys) {
+      const info = components[key];
+      if (!info) continue;
+      const target = info.pinned ?? info.available;
+      if (!target) continue;
+      const running = info.running?.plainVersion ?? null;
+      const moving = running === 'latest' || running === 'next' || running === null;
+      if (!info.pinned && moving) continue;
+      if (running && bare(target) === bare(running)) continue;
+      out[key] = target;
+    }
+    return out;
+  }
+
   // ── Row pin actions ───────────────────────────────────────────────────────
 
   function startEditPin(key: string): void {
@@ -173,7 +195,7 @@
     rowUpdateError[key] = '';
     rowUpdateSuccess[key] = '';
     try {
-      const result = await applyServiceUpdate(service);
+      const result = await applyServiceUpdate(service, targetVersionsFor([key]));
       if (!result.overallSuccess) {
         rowUpdateError[key] = result.failed.length > 0
           ? result.failed.map((f) => `${f.service}: ${f.reason}`).join('; ')
@@ -200,7 +222,7 @@
     allError = '';
     allSuccess = '';
     try {
-      const result = await applyChanges();
+      const result = await applyChanges(targetVersionsFor(Object.keys(components)));
       if (!result.overallSuccess) {
         allError = result.failed.length > 0
           ? `Failed: ${result.failed.map((f) => `${f.service}: ${f.reason}`).join('; ')}`

--- a/packages/ui/src/routes/admin/update/+server.ts
+++ b/packages/ui/src/routes/admin/update/+server.ts
@@ -12,6 +12,8 @@ import {
   buildComposeOptions,
   checkDocker,
   applyStack,
+  patchSecretsEnvFile,
+  isVersionKey,
 } from "@openpalm/lib";
 import type { RequestHandler } from "./$types";
 
@@ -23,19 +25,34 @@ export const POST: RequestHandler = async (event) => {
   const authError = requireAdmin(event, requestId);
   if (authError) return authError;
 
-  // Optional body: { service?: string } for scoped single-service updates (§4, §7).
-  // When service is present, skip the managed-file apply (no file changes) and only
-  // pull + recreate that one container — updating one container MUST NOT touch others.
+  // Optional body:
+  //   { service?: string } — scoped single-service update (§4, §7); pull + recreate
+  //     ONLY that container, never touching others.
+  //   { versions?: { OP_<X>_VERSION: "<target>" } } — the version each component
+  //     should ADVANCE to before recreate (the channel-latest the UI resolved, or a
+  //     deliberate pin). Without this, "update" just re-applies the current tag and
+  //     can never move forward on a channel whose releases are specific tags (next/
+  //     beta have no moving tag). Targets are written to the legacy stack.env — the
+  //     APPLIED/current tracker — NOT state/ (state is for deliberate pins; writing
+  //     an applied version there would make it read back as a pin and re-freeze).
   let service: string | undefined;
+  const targetVersions: Record<string, string> = {};
   try {
     const body = event.request.headers.get("content-type")?.includes("application/json")
-      ? await event.request.json() as { service?: unknown }
+      ? await event.request.json() as { service?: unknown; versions?: unknown }
       : {};
     if (typeof body?.service === "string" && body.service.trim()) {
       service = body.service.trim();
     }
+    if (body?.versions && typeof body.versions === "object") {
+      for (const [k, v] of Object.entries(body.versions as Record<string, unknown>)) {
+        if (isVersionKey(k) && typeof v === "string" && v.trim()) {
+          targetVersions[k] = v.trim();
+        }
+      }
+    }
   } catch {
-    // No body or unparseable — treat as "all" (backward compat)
+    // No body or unparseable — treat as "all" with no explicit targets (backward compat).
   }
 
   return withSerialQueue("admin:update", async () => {
@@ -56,6 +73,17 @@ export const POST: RequestHandler = async (event) => {
           dockerAvailable: false,
           overallSuccess: false,
         }, requestId);
+      }
+
+      // Advance the APPLIED version before recreate: write each component's target
+      // (the channel-latest the UI resolved, or a deliberate pin) into the legacy
+      // stack.env that `docker compose --env-file` reads, so applyStack pulls the
+      // NEW tag instead of re-applying the current one. Written to legacy (the
+      // applied/current tracker) — never state/, which is reserved for deliberate
+      // pins (an applied version in state would read back as a pin and re-freeze).
+      if (Object.keys(targetVersions).length > 0) {
+        patchSecretsEnvFile(state.homeDir, targetVersions);
+        logger.info("advanced versions before update", { requestId, targetVersions });
       }
 
       if (service) {

--- a/packages/ui/src/routes/admin/update/server.vitest.ts
+++ b/packages/ui/src/routes/admin/update/server.vitest.ts
@@ -18,6 +18,7 @@ type ApplyStackFn = (scope: unknown, opts: unknown) => Promise<{
 const applyStackMock = vi.fn<ApplyStackFn>();
 const checkDockerMock = vi.fn<() => Promise<{ ok: boolean; stdout: string; stderr: string; code: number }>>();
 const applyUpdateMock = vi.fn<() => Promise<{ restarted: string[] }>>();
+const patchSecretsEnvFileMock = vi.fn<(homeDir: string, patches: Record<string, string>) => void>();
 
 vi.mock('@openpalm/lib', async () => {
   const actual = await vi.importActual<typeof import('@openpalm/lib')>('@openpalm/lib');
@@ -25,6 +26,7 @@ vi.mock('@openpalm/lib', async () => {
     ...actual,
     applyUpdate: (...args: unknown[]) => applyUpdateMock(...(args as [])),
     applyStack: (...args: unknown[]) => applyStackMock(...(args as [unknown, unknown])),
+    patchSecretsEnvFile: (...args: unknown[]) => patchSecretsEnvFileMock(...(args as [string, Record<string, string>])),
     checkDocker: (...args: unknown[]) => checkDockerMock(...(args as [])),
     ensureHomeDirs: () => undefined,
     ensureOpenCodeConfig: () => undefined,
@@ -55,6 +57,7 @@ beforeEach(() => {
   applyStackMock.mockReset();
   checkDockerMock.mockReset();
   applyUpdateMock.mockReset();
+  patchSecretsEnvFileMock.mockReset();
 
   applyUpdateMock.mockResolvedValue({ restarted: [] });
   checkDockerMock.mockResolvedValue({ ok: true, stdout: '24.0.0', stderr: '', code: 0 });
@@ -70,6 +73,28 @@ describe('POST /admin/update', () => {
   test('requires admin auth', async () => {
     const res = await POST(makePostEvent('bad-token'));
     expect(res.status).toBe(401);
+  });
+
+  test('advances versions: writes the target versions (the resolved channel-latest) before applyStack', async () => {
+    // The freeze-bug fix: "Update everything" must write the target each component
+    // should advance to, else applyStack just re-applies the current tag. Targets go
+    // to the legacy stack.env (the applied/current tracker), never state/ (pins).
+    const res = await POST(makePostEvent('admin-token', {
+      versions: { OP_ASSISTANT_VERSION: '0.12.44-beta.2', OP_GUARDIAN_VERSION: '0.12.44-beta.2' },
+    }));
+    expect(res.status).toBe(200);
+    expect(patchSecretsEnvFileMock).toHaveBeenCalledTimes(1);
+    const [, patches] = patchSecretsEnvFileMock.mock.calls[0];
+    expect(patches).toEqual({ OP_ASSISTANT_VERSION: '0.12.44-beta.2', OP_GUARDIAN_VERSION: '0.12.44-beta.2' });
+    // written BEFORE the stack is recreated
+    expect(patchSecretsEnvFileMock.mock.invocationCallOrder[0])
+      .toBeLessThan(applyStackMock.mock.invocationCallOrder[0]);
+  });
+
+  test('does not write versions when no targets are supplied (re-apply only — backward compat)', async () => {
+    const res = await POST(makePostEvent());
+    expect(res.status).toBe(200);
+    expect(patchSecretsEnvFileMock).not.toHaveBeenCalled();
   });
 
   test('returns 200 with all services when applyStack succeeds', async () => {


### PR DESCRIPTION
**Updating never advanced an existing install.** Confirmed live against a real install (running 0.12.42, `available` 0.12.44-beta.2) — "Update everything" reported success and changed nothing.

## Two compounding bugs

1. **`readPinnedVersions` read the legacy `stack.env` as a pin.** The old updater auto-wrote `OP_*_VERSION` there as the *current* version; the new model read any value there as a *deliberate pin*. So every install that crossed onto this model showed "pinned to <old version>" and was frozen — `update` re-applied that "pin" forever. Deliberate pins live in `state/` (§1); a legacy value is the applied/current. Now **state-only**.

2. **`POST /admin/update` never resolved or wrote a target version.** It re-applied whatever tag was already in the env and recreated the same containers. On a channel whose releases are *specific* tags (`next`/`beta` have **no moving Docker tag**), update could never move forward. The endpoint now accepts `{ versions }` (the channel-latest the UI resolved, or a pin) and writes them to the **legacy** `stack.env` — the applied/current tracker, **not** `state/` (an applied version in state would read back as a pin and re-freeze) — before `applyStack` pulls the new tag. `UpdatesTab` computes the target per component (`pin ?? available`; components already on a moving tag are left to re-pull).

## ⚠️ Known, NOT fixed here (flagged for a follow-up)
`@openpalm/ui` npm **dist-tags are mismatched with the channel model**: releases publish betas to **`beta`** (`0.12.44-beta.2`), but `distTagForVersion` maps every prerelease to **`next`**, which is stale at **`0.12.0-rc.8`**. So a `next`-channel UI-build hot-swap can't see new betas. **This release must ship the Electron installer** to deliver the fix; the dist-tag/channel model needs its own fix.

## Tests
- `readPinnedVersions` returns `null` for a legacy-only value (the freeze fix)
- `/admin/update` writes the targets to legacy **before** `applyStack`, and writes nothing when none are supplied (backward compat)

Gates: lib **612/0**, root **1099/0**, UI unit **866/0**, `ui:check` **0/0**, cli typecheck **0**, eslint **0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)