### PR TITLE
fix(update): resolve prerelease channel by newest dist-tag (the stale `next` tag froze UI hot-swap)

### DIFF
--- a/packages/lib/src/control-plane/ui-assets.test.ts
+++ b/packages/lib/src/control-plane/ui-assets.test.ts
@@ -539,22 +539,27 @@ describe("checkAndUpdateUiBuild", () => {
   // channel excludes prereleases, so a prerelease app would incorrectly see
   // "no update available" if it queried `latest`.
 
-  it('checkAndUpdateUiBuild uses `next` channel for prerelease app versions', async () => {
+  it('checkAndUpdateUiBuild (prerelease app) resolves the newest version across dist-tags, not the stale `next` tag', async () => {
     makeBuild(dataUi, '0.11.0');
 
-    let requestedChannel: string | null = null;
+    let requestedRef: string | null = null;
     globalThis.fetch = async (_url: string | URL | Request) => {
       const url = String(typeof _url === 'string' ? _url : (_url as Request).url ?? _url);
+      if (url.includes('/dist-tags')) {
+        // `next` deliberately stale — the fix must pick max(dist-tags) = beta 0.12.5-beta.2
+        return new Response(JSON.stringify({ next: '0.12.0-rc.1', beta: '0.12.5-beta.2', latest: '0.12.4' }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
       if (url.includes('registry.npmjs.org/@openpalm/ui/')) {
-        requestedChannel = url.split('/@openpalm/ui/')[1];
-        return manifestResponse('0.12.0-rc.1');
+        requestedRef = url.split('/@openpalm/ui/')[1];
+        return manifestResponse('0.12.5-beta.2');
       }
       return new Response('', { status: 200 });
     };
 
-    // Call with a prerelease version — should query the `next` channel
+    // Prerelease app → `next` channel → newest across dist-tags (not the stale `next` dist-tag)
     await checkAndUpdateUiBuild('0.12.0-rc.1', join(opHome, 'data'));
-    expect(requestedChannel).toBe('next');
+    expect(requestedRef).toBe('0.12.5-beta.2');
   });
 
   it('checkAndUpdateUiBuild uses `latest` channel for stable app versions', async () => {
@@ -759,21 +764,31 @@ describe("checkAndUpdateSkeleton", () => {
     expect(readSkeletonVersion(skelOpHome)).toBe("0.12.0");
   });
 
-  it("uses the `latest` channel for stable versions and `next` for prerelease", async () => {
+  it("stable → @latest dist-tag; prerelease → NEWEST version across all dist-tags (not the stale `next` tag)", async () => {
+    // The fix: the `next` npm dist-tag goes stale because prereleases publish to a
+    // suffix tag (beta/rc), so the prerelease channel must resolve max(dist-tags),
+    // NOT @next. Here `next` is deliberately the OLDEST — the fix must ignore it.
     writeFileSync(join(skelOpHome, SKELETON_VERSION_STAMP), "0.11.0\n");
-    const channels: string[] = [];
+    const refs: string[] = [];
     globalThis.fetch = async (url: string | URL | Request) => {
       const u = String(typeof url === "string" ? url : (url as Request).url ?? String(url));
+      if (u.includes("/dist-tags")) {
+        return new Response(
+          JSON.stringify({ next: "0.12.0-rc.1", beta: "0.12.5-beta.2", latest: "0.12.4" }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
       if (u.includes("@openpalm/skeleton/")) {
-        channels.push(u.split("@openpalm/skeleton/")[1]);
+        refs.push(u.split("@openpalm/skeleton/")[1]);
         return manifestResponse("0.11.0"); // up to date, no download
       }
       return new Response("", { status: 200 });
     };
-    await checkAndUpdateSkeleton("0.12.0", skelOpHome, skelDataDir);
-    await checkAndUpdateSkeleton("0.12.0-rc.1", skelOpHome, skelDataDir);
-    expect(channels[0]).toBe("latest");
-    expect(channels[1]).toBe("next");
+    await checkAndUpdateSkeleton("0.12.0", skelOpHome, skelDataDir);       // stable → latest
+    await checkAndUpdateSkeleton("0.12.0-rc.1", skelOpHome, skelDataDir);  // prerelease → next
+    expect(refs[0]).toBe("latest");
+    // next resolves to the newest across dist-tags (beta 0.12.5-beta.2), NOT stale `next` (0.12.0-rc.1)
+    expect(refs[1]).toBe("0.12.5-beta.2");
   });
 
   it("happy-path: stages, verifies integrity, atomically swaps system/, stamps version", async () => {

--- a/packages/lib/src/control-plane/ui-assets.ts
+++ b/packages/lib/src/control-plane/ui-assets.ts
@@ -363,6 +363,29 @@ async function fetchNpmUiManifest(versionOrTag: string): Promise<NpmUiManifest> 
 }
 
 /**
+ * Resolve a channel to the npm version ref to install.
+ *
+ *   `latest` → the @latest dist-tag (newest STABLE) — unchanged.
+ *   `next`   → the NEWEST published version across ALL dist-tags.
+ *
+ * Why not just `@next`: prereleases publish to a SUFFIX dist-tag (X.Y.Z-beta.N →
+ * `beta`, -rc.N → `rc`), NOT a single moving `next` tag — so the `next` tag goes
+ * stale (it sat at 0.12.0-rc.8 while betas shipped to `beta`). Resolving `@next`
+ * therefore froze (or downgraded) the prerelease channel. Mirroring the Docker
+ * resolver (which lists tags and picks the newest on-channel), take max(dist-tags)
+ * = the true bleeding edge (latest beta/rc/stable, whichever is newest).
+ */
+async function resolveChannelRef(pkg: string, channel: UiUpdateChannel): Promise<string> {
+  if (channel === 'latest') return 'latest';
+  const res = await fetchWithRetry(`${NPM_REGISTRY}/-/package/${encodeURIComponent(pkg)}/dist-tags`);
+  if (!res.ok) throw new Error(`npm registry returned HTTP ${res.status} for ${pkg} dist-tags`);
+  const tags = await res.json() as Record<string, unknown>;
+  const versions = Object.values(tags).filter((v): v is string => typeof v === 'string' && v.length > 0);
+  if (versions.length === 0) return 'next';
+  return versions.reduce((newest, v) => (compareComparableVersions(v, newest) > 0 ? v : newest));
+}
+
+/**
  * Verify a Subresource-Integrity string against the bytes. FAIL-CLOSED: a
  * present-but-wrong hash throws (the corruption / tamper case). A registry that
  * omits the hash entirely (legacy metadata) is logged and allowed — modern npm
@@ -522,7 +545,7 @@ export async function checkAndUpdateUiBuild(
   let uiBuildBackupDir: string | undefined;
   try {
     const channel  = uiUpdateChannel(appVersion, channelOverride);
-    const manifest = await fetchNpmUiManifest(channel);
+    const manifest = await fetchNpmUiManifest(await resolveChannelRef(UI_PACKAGE, channel));
     const latestVersion = manifest.version;
 
     // §5.3 self-update-vs-redownload gate. Only meaningful when a native harness
@@ -716,7 +739,7 @@ export async function checkAndUpdateSkeleton(
   let skelBackupDir: string | undefined;
   try {
     const channel = uiUpdateChannel(appVersion, channelOverride);
-    const manifest = await fetchNpmSkeletonManifest(channel);
+    const manifest = await fetchNpmSkeletonManifest(await resolveChannelRef(SKELETON_PACKAGE, channel));
     const latestVersion = manifest.version;
 
     const currentVersion = readSkeletonVersion(homeDir);


### PR DESCRIPTION
Follow-up to #537. The container-update fix landed there; this fixes the **npm hot-swap** side of the same channel problem.

## Problem
UI-build + skeleton hot-swap resolved the channel by fetching the **`@next` dist-tag** directly. But prereleases publish to a **suffix** dist-tag (`X.Y.Z-beta.N` → `beta`, `-rc.N` → `rc`), **not** a single moving `next` tag — so `next` goes stale:

```
@openpalm/ui dist-tags: next: 0.12.0-rc.8  rc: 0.12.14-rc.9  latest: 0.12.43  beta: 0.12.44-beta.3
```

An Electron app on the `next` channel resolved `0.12.0-rc.8` — a massive downgrade (guarded against, so the hot-swap was simply inert and beta users never got UI updates).

## Fix
`resolveChannelRef(pkg, channel)`:
- `latest` → the `@latest` dist-tag (newest stable) — unchanged
- `next` → the **newest version across all dist-tags** (max of latest/next/beta/rc)

This mirrors the **Docker `available` resolver**, which already lists tags and picks the newest on-channel — and is exactly why the *container* update worked while the npm hot-swap didn't. Wired into `checkAndUpdateUiBuild` + `checkAndUpdateSkeleton`.

Verified live: `next` channel now resolves **`0.12.44-beta.3`**. Tests assert the resolver ignores a deliberately-stale `next` tag and picks the newest beta.

Gates: lib **612/0**, `ui:check` **0/0**, electron **73/0**, cli typecheck **0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)