### PR TITLE
Lint cleanup: Biome warnings 1448 → 0 + follow-up tech debt

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -21,6 +21,8 @@
       "!**/*.min.js",
       // SVGs are checked-in diagram assets, not source; skip them (avoids a11y/noSvgWithoutTitle on docs).
       "!**/*.svg",
+      // Large checked-in data blob (4.3 MiB provider catalog) — not lintable source.
+      "!docs/providers.json",
       // Biome's Svelte support is incomplete: it parses the <script> block but not the
       // template, so template-referenced vars/imports are mis-flagged as unused
       // (noUnusedVariables/noUnusedImports) — ~1000 false positives. Svelte files are

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -8,19 +8,25 @@
   "files": {
     "includes": [
       "**",
-      "!**/node_modules/**",
-      "!**/.svelte-kit/**",
-      "!**/build/**",
-      "!**/dist/**",
-      "!**/.dev/**",
-      "!**/.openpalm/**",
-      "!**/coverage/**",
-      "!**/test-results/**",
+      "!**/node_modules",
+      "!**/.svelte-kit",
+      "!**/build",
+      "!**/dist",
+      "!**/.dev",
+      "!**/.openpalm",
+      "!**/coverage",
+      "!**/test-results",
       "!**/bun.lock",
       "!**/bun.lockb",
       "!**/*.min.js",
       // SVGs are checked-in diagram assets, not source; skip them (avoids a11y/noSvgWithoutTitle on docs).
-      "!**/*.svg"
+      "!**/*.svg",
+      // Biome's Svelte support is incomplete: it parses the <script> block but not the
+      // template, so template-referenced vars/imports are mis-flagged as unused
+      // (noUnusedVariables/noUnusedImports) — ~1000 false positives. Svelte files are
+      // linted properly by svelte-check + eslint-plugin-svelte in packages/ui; Biome
+      // owns the .ts/.js/.json surface only.
+      "!**/*.svelte"
     ]
   },
   "json": {
@@ -41,7 +47,19 @@
         // warnings (documented cleanup follow-up); new code should still avoid them.
         "noImplicitAnyLet": "warn",
         "noAssignInExpressions": "warn",
-        "noDuplicateProperties": "warn"
+        "noDuplicateProperties": "warn",
+        // Off: every hit is a test/fixture asserting on a LITERAL `${VAR}` string — the
+        // Docker-Compose / env-var substitution syntax the whole stack is built on
+        // (skeleton-guardrail, *-rootless-entrypoint, AkmTab roundtrip, …). These are
+        // intentional literal strings, not mis-typed template literals.
+        "noTemplateCurlyInString": "off"
+      },
+      "style": {
+        // Off: non-null assertions (`x!`) are idiomatic, deliberate TypeScript used
+        // throughout this codebase (~234 sites) where the author has already narrowed
+        // the value. Mechanically rewriting each to a runtime guard would add noise and
+        // risk with no correctness benefit; TS's strict null checks remain the real gate.
+        "noNonNullAssertion": "off"
       }
     }
   },

--- a/containers/portal/start.test.ts
+++ b/containers/portal/start.test.ts
@@ -24,22 +24,27 @@ describe('portal image bake contract', () => {
     expect(startScript).not.toMatch(/^set -e\s*$/m);
     // Under `-u`, the optional PORTAL_PACKAGE check must not trip on an unset var —
     // it must fall back to empty so the friendly error path still runs.
+    // biome-ignore lint/suspicious/noTemplateCurlyInString: this is a literal bash snippet we assert is present in start.sh, not a JS template placeholder
     expect(startScript).toContain('[ -z "${PORTAL_PACKAGE:-}" ]');
     expect(startScript).not.toContain('[ -z "$PORTAL_PACKAGE" ]');
   });
 
-  test('docker image bakes the first-party adapters from the workspace', () => {
+  test('docker image bakes the first-party adapters from npm via tools/package.json', () => {
     const dockerfile = readRelative('containers/portal/Dockerfile');
+    const tools = readRelative('containers/portal/tools/package.json');
 
-    expect(dockerfile).toContain('COPY portals/discord /app/portals/discord');
-    expect(dockerfile).toContain('COPY portals/slack /app/portals/slack');
+    // Adapters are published npm packages installed at build time under
+    // /opt/openpalm/tools — no workspace source is copied into the image.
+    expect(dockerfile).toContain('COPY containers/portal/tools/package.json /opt/openpalm/tools/package.json');
+    expect(dockerfile).toContain('bun install --cwd /opt/openpalm/tools --production');
     expect(dockerfile).toContain('COPY containers/portal/portal-entrypoint.ts /app/portal-entrypoint.ts');
-    // Each adapter installs its OWN deps in place — no workspace root, no symlinked
-    // package, no generated manifest (those left @openpalm/* unresolvable at runtime).
-    expect(dockerfile).toContain('cd /app/portals/discord && bun install --production');
-    expect(dockerfile).toContain('cd /app/portals/slack && bun install --production');
-    expect(dockerfile).not.toContain('printf');
+    expect(dockerfile).not.toContain('COPY portals/discord');
+    expect(dockerfile).not.toContain('COPY portals/slack');
     expect(dockerfile).not.toContain('workspaces');
+
+    // The baked tools manifest declares the first-party adapter packages.
+    expect(tools).toContain('@openpalm/discord-portal');
+    expect(tools).toContain('@openpalm/slack-portal');
   });
 
   test('managed portal compose uses baked package names, not dist-tags', () => {

--- a/containers/portal/start.test.ts
+++ b/containers/portal/start.test.ts
@@ -24,7 +24,6 @@ describe('portal image bake contract', () => {
     expect(startScript).not.toMatch(/^set -e\s*$/m);
     // Under `-u`, the optional PORTAL_PACKAGE check must not trip on an unset var —
     // it must fall back to empty so the friendly error path still runs.
-    // biome-ignore lint/suspicious/noTemplateCurlyInString: this is a literal bash snippet we assert is present in start.sh, not a JS template placeholder
     expect(startScript).toContain('[ -z "${PORTAL_PACKAGE:-}" ]');
     expect(startScript).not.toContain('[ -z "$PORTAL_PACKAGE" ]');
   });

--- a/docs/code-quality-review.md
+++ b/docs/code-quality-review.md
@@ -245,3 +245,28 @@ Each was implemented characterization-tests-first, then put through an independe
 All landed changes preserve behavior, add tests, and keep the lint gate green. Pre-existing test
 failures unrelated to this work: 12 root-uid ownership tests (sandbox runs as uid 0), 1 guardian IPv6
 sandbox bind, 1 stale portal Dockerfile-bake test.
+
+---
+
+## Follow-up: lint-warning cleanup (post-merge)
+
+After the first PR merged, a cleanup pass drove the Biome warning count from **1,448 → 0**:
+
+- **~1,062 were `.svelte` false positives** — Biome parses the `<script>` block but not
+  the template, so template-referenced vars/imports were mis-flagged as unused. Fixed by
+  **excluding `.svelte` from Biome** (Svelte quality is owned by `svelte-check` +
+  `eslint-plugin-svelte`), not by deleting live code.
+- **Rule policy (documented in `biome.jsonc`):** `noNonNullAssertion` off (idiomatic TS,
+  ~234 deliberate sites) and `noTemplateCurlyInString` off (every hit is a test/fixture
+  asserting on a literal `${VAR}` compose-substitution string).
+- **Safe auto-fixes** applied (`useOptionalChain`, `useImportType`, `useArrowFunction`, …).
+- **The remaining ~88 real warnings** (unused `.ts` code, `any`-types, `useOptionalChain`,
+  `isNaN`→`Number.isNaN`, misc) were fixed per-package via a fan-out workflow, plus a few
+  edge cases (a 4.3 MiB data blob excluded; an intentional `100vh/100dvh` CSS fallback
+  suppressed; one `matchMedia` optional-chain).
+- Tech debt done alongside: hardened the setup-state reset test to a full-store snapshot,
+  deduped default-port constants in CLI/Electron, and refreshed the stale portal
+  Dockerfile-bake test to the current npm-install reality.
+
+**Result:** `bun run lint` reports **0 warnings** (1 informational Biome self-deprecation
+notice remains). All per-package suites green; svelte-check 0 errors; zero behavior change.

--- a/packages/cli/src/commands/audit-secrets.ts
+++ b/packages/cli/src/commands/audit-secrets.ts
@@ -1,6 +1,5 @@
 import { defineCommand } from 'citty';
 import { existsSync, readFileSync } from 'node:fs';
-import { join } from 'node:path';
 import {
   auditComposeSecrets,
   auditFileBasedSecrets,

--- a/packages/cli/src/commands/install.ts
+++ b/packages/cli/src/commands/install.ts
@@ -5,6 +5,7 @@ import { defaultWorkDir } from '../lib/paths.ts';
 import { defineAction } from '../lib/action.ts';
 import { promptYesNo } from '../lib/prompt.ts';
 import { resolveLatestReleaseTag } from '../lib/github.ts';
+import { DEFAULT_UI_PORT } from '../lib/ports.ts';
 import { resolveOpenPalmHome, resolveConfigDir } from '@openpalm/lib';
 import { ensureDirectoryTree, applyHomeSeed, seedUiBuild, uiUpdateChannel } from '../lib/io.ts';
 import {
@@ -233,7 +234,7 @@ async function prepareInstallFiles(
   console.log('Preparing directories...');
   await ensureDirectoryTree(homeDir, workDir);
 
-  try { await Bun.write(join(dataDir, 'host.json'), JSON.stringify(await detectHostInfo(), null, 2) + '\n'); }
+  try { await Bun.write(join(dataDir, 'host.json'), `${JSON.stringify(await detectHostInfo(), null, 2)}\n`); }
   catch (err) { logger.debug('failed to write host.json', { error: String(err) }); }
 
   // Seed OP_HOME from the bundled .openpalm/ source (skeleton data/ + managed
@@ -290,7 +291,7 @@ async function prepareInstallFiles(
  */
 async function runWizardInstall(noOpen: boolean): Promise<void> {
   await requireDocker();
-  const port = Number(process.env.OP_HOST_UI_PORT) || 3880;
+  const port = Number(process.env.OP_HOST_UI_PORT) || DEFAULT_UI_PORT;
   console.log(`Setup wizard: http://localhost:${port}/setup`);
   const { startUIServer } = await import('../lib/ui-server.ts');
   await startUIServer({ open: !noOpen, port });

--- a/packages/cli/src/commands/self-update.ts
+++ b/packages/cli/src/commands/self-update.ts
@@ -75,7 +75,7 @@ async function downloadVerifiedBinary(version: string, artifact: string): Promis
 async function schedulePosixReplacement(sourcePath: string, targetPath: string): Promise<void> {
   const scriptDir = await mkdtemp(join(tmpdir(), 'openpalm-self-update-script-'));
   const scriptPath = join(scriptDir, 'replace.sh');
-  const script = [
+  const script = `${[
     '#!/usr/bin/env sh',
     'set -eu',
     'sleep 1',
@@ -84,7 +84,7 @@ async function schedulePosixReplacement(sourcePath: string, targetPath: string):
     'chmod +x "$tmp"',
     'mv "$tmp" "$dest"',
     `rm -rf ${posixShellQuote(scriptDir)}`,
-  ].join('\n') + '\n';
+  ].join('\n')}\n`;
 
   await Bun.write(scriptPath, script);
   await chmod(scriptPath, 0o755);

--- a/packages/cli/src/commands/start.test.ts
+++ b/packages/cli/src/commands/start.test.ts
@@ -34,7 +34,7 @@ describe('runStartAction', () => {
     mock.module(moduleUrls.cliState, () => ({ ensureValidState: () => ({ homeDir: '/tmp/op-home', workspaceDir: '/tmp/op-home/workspace' }) }));
     mock.module(moduleUrls.cliCompose, () => ({ runComposeWithPreflight: async () => {} }));
 
-    const { runStartAction } = await import(startModuleUrl + `?t=${Math.random()}`);
+    const { runStartAction } = await import(`${startModuleUrl}?t=${Math.random()}`);
     await expect(runStartAction([])).rejects.toThrow(/Host swap detected/);
   });
 
@@ -51,7 +51,7 @@ describe('runStartAction', () => {
     mock.module(moduleUrls.cliState, () => ({ ensureValidState: () => ({ homeDir: '/tmp/op-home', workspaceDir: '/tmp/op-home/workspace' }) }));
     mock.module(moduleUrls.cliCompose, () => ({ runComposeWithPreflight: async (_state: unknown, args: string[]) => { composedArgs.push(args); } }));
 
-    const { runStartAction } = await import(startModuleUrl + `?t=${Math.random()}`);
+    const { runStartAction } = await import(`${startModuleUrl}?t=${Math.random()}`);
     await runStartAction([]);
 
     expect(reconcileArgs).toEqual({ adoptHost: false, services: ['assistant', 'guardian'] });
@@ -71,7 +71,7 @@ describe('runStartAction', () => {
     mock.module(moduleUrls.cliState, () => ({ ensureValidState: () => ({ homeDir: '/tmp/op-home', workspaceDir: '/tmp/op-home/workspace' }) }));
     mock.module(moduleUrls.cliCompose, () => ({ runComposeWithPreflight: async (_state: unknown, args: string[]) => { composedArgs.push(args); } }));
 
-    const { runStartAction } = await import(startModuleUrl + `?t=${Math.random()}`);
+    const { runStartAction } = await import(`${startModuleUrl}?t=${Math.random()}`);
     await runStartAction(['guardian'], { adoptHost: true });
 
     // Explicit services are passed straight through (no buildManagedServices).

--- a/packages/cli/src/commands/status.test.ts
+++ b/packages/cli/src/commands/status.test.ts
@@ -32,7 +32,7 @@ async function runStatusCommand(): Promise<{ stdout: string; stderr: string }> {
     err.push(args.map(String).join(' '));
   };
   try {
-    const mod = await import('./status.ts?t=' + Math.random());
+    const mod = await import(`./status.ts?t=${Math.random()}`);
     await mod.default.run?.({} as never);
   } finally {
     console.log = origLog;

--- a/packages/cli/src/commands/update.test.ts
+++ b/packages/cli/src/commands/update.test.ts
@@ -37,7 +37,7 @@ describe('runUpgradeAction', () => {
       ensureValidState: () => ({ dataDir: '/tmp/openpalm-data' }),
     }));
 
-    const { runUpgradeAction } = await import(updateModuleUrl + `?t=${Math.random()}`);
+    const { runUpgradeAction } = await import(`${updateModuleUrl}?t=${Math.random()}`);
     await runUpgradeAction();
 
     expect(currentVersionArg).toBe('v0.12.0-rc.1');
@@ -58,7 +58,7 @@ describe('runUpgradeAction', () => {
       ensureValidState: () => ({ dataDir: '/tmp/openpalm-data' }),
     }));
 
-    const { runUpgradeAction } = await import(updateModuleUrl + `?t=${Math.random()}`);
+    const { runUpgradeAction } = await import(`${updateModuleUrl}?t=${Math.random()}`);
 
     await runUpgradeAction();                       // default: stable only
     await runUpgradeAction({ allowPrerelease: true }); // --pre

--- a/packages/cli/src/install-flow.test.ts
+++ b/packages/cli/src/install-flow.test.ts
@@ -20,7 +20,7 @@ import {
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { parse as yamlParse } from 'yaml';
-import { parseEnvFile, expandEnvVars } from '@openpalm/lib';
+import { parseEnvFile, expandEnvVars, type SetupSpec } from '@openpalm/lib';
 
 // ── Helpers ───────────────────────────────────────────────────────────────
 
@@ -103,7 +103,7 @@ function seedFromLocal(homeDir: string, enabledAddons: string[] = []): void {
   }
 }
 
-function makeSetupSpec(): Record<string, unknown> {
+function makeSetupSpec(): SetupSpec {
   return {
     version: 2,
     llm: { provider: 'ollama', model: 'qwen2.5-coder:3b', baseUrl: 'http://host.docker.internal:11434' },
@@ -120,6 +120,11 @@ function makeSetupSpec(): Record<string, unknown> {
   };
 }
 
+/** Minimal shape of a compose document needed to walk volume mounts. */
+type ComposeVolume = string | { source?: string };
+type ComposeService = { volumes?: ComposeVolume[] } | null | undefined;
+type ComposeDoc = { services?: Record<string, ComposeService> };
+
 /** Extract all host-side volume mount paths from compose files. */
 function extractVolumeMountPaths(
   composeFiles: string[],
@@ -128,12 +133,13 @@ function extractVolumeMountPaths(
   const results: { path: string; isFile: boolean }[] = [];
   for (const file of composeFiles) {
     if (!existsSync(file)) continue;
-    let doc: any;
-    try { doc = yamlParse(readFileSync(file, 'utf-8')); } catch { continue; }
+    let doc: ComposeDoc | undefined;
+    try { doc = yamlParse(readFileSync(file, 'utf-8')) as ComposeDoc; } catch { continue; }
     if (!doc?.services) continue;
-    for (const svc of Object.values(doc.services) as any[]) {
-      if (!Array.isArray(svc?.volumes)) continue;
-      for (const vol of svc.volumes) {
+    for (const svc of Object.values(doc.services)) {
+      const volumes = svc?.volumes;
+      if (!Array.isArray(volumes)) continue;
+      for (const vol of volumes) {
         const raw = typeof vol === 'string' ? vol.split(':')[0] : (vol?.source ?? '');
         if (!raw || typeof raw !== 'string') continue;
         const resolved = expandEnvVars(raw, vars);
@@ -172,7 +178,7 @@ describe('install flow — tier 1 (file validation)', () => {
     // Step 2: Run performSetup
     const { performSetup } = await import('@openpalm/lib');
     const spec = makeSetupSpec();
-    const result = await performSetup(spec as any);
+    const result = await performSetup(spec);
     expect(result.ok).toBe(true);
 
     // ── Validate enabled addons via stack.env ─────────────────────────
@@ -242,7 +248,7 @@ describe('install flow — tier 1 (file validation)', () => {
         expect(stat.isDirectory()).toBe(true);
       }
       // Must be owned by current user, not root
-      expect(stat.uid).toBe(process.getuid!());
+      expect(stat.uid).toBe((process.getuid as () => number)());
     }
 
     // ── Validate no root-owned files ─────────────────────────────────
@@ -272,7 +278,7 @@ describe('install flow — tier 1 (file validation)', () => {
     // ── Re-run setup: user edits to akm-improve.yml must survive ─────
     const userEdited = 'schedule: "0 9 * * *"\nenabled: false\ncommand: ["akm","improve","--auto-accept","safe"]\n';
     writeFileSync(akmImprovePath, userEdited);
-    const reSetup = await performSetup(spec as any);
+    const reSetup = await performSetup(spec);
     expect(reSetup.ok).toBe(true);
     expect(readFileSync(akmImprovePath, 'utf-8')).toBe(userEdited);
   }, 30_000);
@@ -286,7 +292,7 @@ describe('install flow — tier 1 (file validation)', () => {
     seedFromLocal(homeDir, ['chat']);
 
     const { performSetup } = await import('@openpalm/lib');
-    const result = await performSetup(makeSetupSpec() as any);
+    const result = await performSetup(makeSetupSpec());
     expect(result.ok).toBe(true);
 
     // Ensure all volume mount targets exist so compose doesn't complain
@@ -367,7 +373,7 @@ describe('install flow — tier 1 (file validation)', () => {
     seedFromLocal(homeDir);
 
     const { performSetup } = await import('@openpalm/lib');
-    const result = await performSetup(makeSetupSpec() as any);
+    const result = await performSetup(makeSetupSpec());
     expect(result.ok).toBe(true);
 
     expect(existsSync(join(homeDir, 'knowledge', 'env', 'stack.env'))).toBe(true);

--- a/packages/cli/src/lib/ports.ts
+++ b/packages/cli/src/lib/ports.ts
@@ -1,0 +1,11 @@
+/**
+ * Default host ports for OpenPalm services, defined once so the CLI does not
+ * scatter magic numbers across install/run sites. Each is overridable via the
+ * matching environment variable at the call site.
+ */
+
+/** Default host port for the UI server (override via OP_HOST_UI_PORT). */
+export const DEFAULT_UI_PORT = 3880;
+
+/** Default published host port for the assistant (override via OP_ASSISTANT_PORT). */
+export const DEFAULT_ASSISTANT_PORT = 3800;

--- a/packages/cli/src/lib/ui-server.ts
+++ b/packages/cli/src/lib/ui-server.ts
@@ -15,9 +15,10 @@ import {
 } from '@openpalm/lib';
 import { ensureValidState } from './cli-state.ts';
 import { openBrowser } from './browser.ts';
+import { DEFAULT_UI_PORT } from './ports.ts';
 
 const logger = createLogger('cli:ui');
-const DEFAULT_PORT = Number(process.env.OP_HOST_UI_PORT) || 3880;
+const DEFAULT_PORT = Number(process.env.OP_HOST_UI_PORT) || DEFAULT_UI_PORT;
 const STOP_TIMEOUT_MS  = 5_000;
 
 export interface UIServerOptions {
@@ -249,7 +250,7 @@ export function createCliUiSupervisor(deps: CliUiSupervisorDeps): {
  */
 export async function startUIServer(opts: UIServerOptions = {}): Promise<void> {
   const port = opts.port ?? DEFAULT_PORT;
-  if (isNaN(port) || port < 1 || port > 65535) {
+  if (Number.isNaN(port) || port < 1 || port > 65535) {
     console.error(`Invalid port: ${port}`);
     process.exit(1);
   }

--- a/packages/cli/src/main.test.ts
+++ b/packages/cli/src/main.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, mock } from 'bun:test';
-import { existsSync, mkdirSync, writeFileSync, mkdtempSync, readFileSync, readdirSync, rmSync, statSync } from 'node:fs';
+import { existsSync, mkdirSync, writeFileSync, mkdtempSync, readFileSync, readdirSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -638,7 +638,7 @@ describe('cli entrypoint (subprocess)', () => {
       });
       const stdout = await new Response(proc.stdout).text();
       const stderr = await new Response(proc.stderr).text();
-      const code = await proc.exited;
+      await proc.exited;
       // The process must produce output — silent exit 0 was the bug
       expect(stdout.length + stderr.length).toBeGreaterThan(0);
     } finally {

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -2,6 +2,7 @@
 import { defineCommand, runCommand, runMain } from 'citty';
 import cliPkg from '../package.json' with { type: 'json' };
 import { classifyLocalInstall, resolveStackDir, resolveOpenPalmHome } from '@openpalm/lib';
+import { DEFAULT_ASSISTANT_PORT } from './lib/ports.ts';
 
 // Re-export public API used by tests and external consumers
 export { detectHostInfo } from './lib/host-info.ts';
@@ -20,7 +21,7 @@ interface BareRunOpts {
  * active.
  */
 async function isAssistantHealthy(): Promise<boolean> {
-  const port = process.env.OP_ASSISTANT_PORT ?? '3800';
+  const port = process.env.OP_ASSISTANT_PORT ?? String(DEFAULT_ASSISTANT_PORT);
   try {
     const res = await fetch(`http://127.0.0.1:${port}/health`, {
       signal: AbortSignal.timeout(1500),
@@ -47,7 +48,7 @@ async function autoRun(opts: BareRunOpts = {}): Promise<void> {
   const isInstalled = classifyLocalInstall(resolveStackDir(), resolveOpenPalmHome()) !== 'not_installed';
 
   if (!isInstalled) {
-    const { bootstrapInstall, resolveDefaultInstallRef } = await import('./commands/install.ts') as any;
+    const { bootstrapInstall, resolveDefaultInstallRef } = await import('./commands/install.ts');
     const version: string = typeof resolveDefaultInstallRef === 'function'
       ? await resolveDefaultInstallRef()
       : (cliPkg.version ?? 'main');
@@ -56,6 +57,7 @@ async function autoRun(opts: BareRunOpts = {}): Promise<void> {
       version,
       noStart: false,
       noOpen: opts.open === false,
+      assumeYes: false,
     });
     return;
   }
@@ -136,7 +138,8 @@ function isVersionFlag(argv: string[]): boolean {
 
 /** True when the first arg names a registered subcommand (or help alias). */
 function hasSubcommand(argv: string[]): boolean {
-  return argv.length > 0 && SUBCOMMAND_NAMES.has(argv[0]!);
+  const first = argv[0];
+  return first !== undefined && SUBCOMMAND_NAMES.has(first);
 }
 
 /** Parse `--port`/`--no-open` from a bare-command argv. */
@@ -146,7 +149,7 @@ function parseBareArgs(argv: string[]): BareRunOpts {
     if (argv[i] === '--port' && argv[i + 1]) {
       opts.port = Number(argv[++i]);
     } else if (argv[i]?.startsWith('--port=')) {
-      opts.port = Number(argv[i]!.split('=')[1]);
+      opts.port = Number(argv[i]?.split('=')[1]);
     } else if (argv[i] === '--no-open') {
       opts.open = false;
     }

--- a/packages/electron/admin-tools/src/index.ts
+++ b/packages/electron/admin-tools/src/index.ts
@@ -15,7 +15,7 @@
  * - No shell interpolation: every external command uses execFile with
  *   an argument array (repo rule).
  */
-import { type Plugin } from "@opencode-ai/plugin";
+import type { Plugin } from "@opencode-ai/plugin";
 
 import composeUp from "./tools/compose-up.js";
 import composeDown from "./tools/compose-down.js";

--- a/packages/electron/admin-tools/test/endpoints-list.test.ts
+++ b/packages/electron/admin-tools/test/endpoints-list.test.ts
@@ -15,7 +15,6 @@ afterEach(() => {
 });
 
 describe("endpointsPath", () => {
-  // biome-ignore lint/suspicious/noTemplateCurlyInString: literal ${OP_HOME} documents the path template in the test name, not an interpolation.
   it("resolves to ${OP_HOME}/config/endpoints.json", () => {
     expect(endpointsPath("/some/home")).toBe("/some/home/config/endpoints.json");
   });

--- a/packages/electron/admin-tools/test/endpoints-list.test.ts
+++ b/packages/electron/admin-tools/test/endpoints-list.test.ts
@@ -15,6 +15,7 @@ afterEach(() => {
 });
 
 describe("endpointsPath", () => {
+  // biome-ignore lint/suspicious/noTemplateCurlyInString: literal ${OP_HOME} documents the path template in the test name, not an interpolation.
   it("resolves to ${OP_HOME}/config/endpoints.json", () => {
     expect(endpointsPath("/some/home")).toBe("/some/home/config/endpoints.json");
   });

--- a/packages/electron/admin-tools/test/plugin.test.ts
+++ b/packages/electron/admin-tools/test/plugin.test.ts
@@ -8,7 +8,7 @@ describe("admin-tools-plugin", () => {
       {} as Parameters<typeof plugin>[1],
     );
     expect(hooks.tool).toBeDefined();
-    const names = Object.keys(hooks.tool!);
+    const names = Object.keys(hooks.tool as NonNullable<typeof hooks.tool>);
     expect(names).toContain("compose.up");
     expect(names).toContain("compose.down");
     expect(names).toContain("compose.ps");
@@ -22,7 +22,7 @@ describe("admin-tools-plugin", () => {
       {} as Parameters<typeof plugin>[0],
       {} as Parameters<typeof plugin>[1],
     );
-    for (const [name, def] of Object.entries(hooks.tool!)) {
+    for (const [name, def] of Object.entries(hooks.tool as NonNullable<typeof hooks.tool>)) {
       expect(typeof def.description).toBe("string");
       expect(def.description.length).toBeGreaterThan(20);
       expect(def.args).toBeDefined();

--- a/packages/electron/assets/docker-error.html
+++ b/packages/electron/assets/docker-error.html
@@ -17,10 +17,10 @@
     </div>
     <script>
       const op = window.openpalm;
-      document.getElementById('install').addEventListener('click', ()=> { op && op.openDockerInstall(); });
-      document.getElementById('retry').addEventListener('click', ()=> {
+      document.getElementById('install').addEventListener('click', () => { op?.openDockerInstall(); });
+      document.getElementById('retry').addEventListener('click', () => {
         var b=document.getElementById('retry'); b.textContent='Checking…'; b.disabled=true;
-        op && op.retryDockerPreflight();
+        op?.retryDockerPreflight();
       });
     </script>
   </body></html>

--- a/packages/electron/assets/docker-error.html
+++ b/packages/electron/assets/docker-error.html
@@ -17,8 +17,8 @@
     </div>
     <script>
       const op = window.openpalm;
-      document.getElementById('install').addEventListener('click', function(){ op && op.openDockerInstall(); });
-      document.getElementById('retry').addEventListener('click', function(){
+      document.getElementById('install').addEventListener('click', ()=> { op && op.openDockerInstall(); });
+      document.getElementById('retry').addEventListener('click', ()=> {
         var b=document.getElementById('retry'); b.textContent='Checking…'; b.disabled=true;
         op && op.retryDockerPreflight();
       });

--- a/packages/electron/assets/splash.html
+++ b/packages/electron/assets/splash.html
@@ -10,7 +10,7 @@
     <div class="spinner"></div>
     <div class="hint" id="hint">Starting…</div>
     <script>
-      setTimeout(function(){var h=document.getElementById('hint');if(h)h.textContent='Still starting (first launch may take a minute)…';},15000);
-      setTimeout(function(){var h=document.getElementById('hint');if(h)h.textContent='Almost there…';},40000);
+      setTimeout(()=> {var h=document.getElementById('hint');if(h)h.textContent='Still starting (first launch may take a minute)…';},15000);
+      setTimeout(()=> {var h=document.getElementById('hint');if(h)h.textContent='Almost there…';},40000);
     </script>
   </body></html>

--- a/packages/electron/assets/splash.html
+++ b/packages/electron/assets/splash.html
@@ -10,7 +10,7 @@
     <div class="spinner"></div>
     <div class="hint" id="hint">Starting…</div>
     <script>
-      setTimeout(()=> {var h=document.getElementById('hint');if(h)h.textContent='Still starting (first launch may take a minute)…';},15000);
-      setTimeout(()=> {var h=document.getElementById('hint');if(h)h.textContent='Almost there…';},40000);
+      setTimeout(() => {var h=document.getElementById('hint');if(h)h.textContent='Still starting (first launch may take a minute)…';},15000);
+      setTimeout(() => {var h=document.getElementById('hint');if(h)h.textContent='Almost there…';},40000);
     </script>
   </body></html>

--- a/packages/electron/src/main.ts
+++ b/packages/electron/src/main.ts
@@ -123,7 +123,13 @@ function resolveAdminToolsPluginPath(): string {
   return '@openpalm/admin-tools-plugin';
 }
 
-const UI_PORT = Number(process.env.OP_HOST_UI_PORT) || 3880;
+// Default host ports used when the corresponding env override is unset. Named
+// here so the magic numbers live in one place (mirrors the CLI port-constant
+// dedup). DEFAULT_ASSISTANT_PORT is a string because it flows straight into a
+// URL and OP_ASSISTANT_PORT is read as an env string.
+const DEFAULT_UI_PORT = 3880;
+const DEFAULT_ASSISTANT_PORT = '3800';
+const UI_PORT = Number(process.env.OP_HOST_UI_PORT) || DEFAULT_UI_PORT;
 const READY_TIMEOUT_MS = 60_000;
 const MIC_SHORTCUT = 'CommandOrControl+Shift+M';
 const APP_USER_MODEL_ID = 'com.openpalm.app';
@@ -174,7 +180,7 @@ export function resolveAssistantUrl(homeDir: string): string {
   if (userOverride) return userOverride;
   const stackEnv = parseEnvFile(join(homeDir, 'knowledge', 'env', 'stack.env'));
   const bind = stackEnv.OP_ASSISTANT_BIND_ADDRESS || '127.0.0.1';
-  const port = stackEnv.OP_ASSISTANT_PORT || '3800';
+  const port = stackEnv.OP_ASSISTANT_PORT || DEFAULT_ASSISTANT_PORT;
   return `http://${bind}:${port}`;
 }
 
@@ -368,7 +374,7 @@ async function startUIServer(): Promise<void> {
   const uiPidFile = join(dataDir, '.ui-server.pid');
   await killStaleUIServer(uiPidFile);
 
-  spawnUIServer(uiBuildDir, homeDir, dataDir, uiPidFile, appUpdate);
+  spawnUIServer(uiBuildDir, homeDir, uiPidFile, appUpdate);
   // Hand the bespoke initial child to the shared supervisor so a later
   // SIGUSR2/IPC restart knows which handle to stop (§6.2).
   if (uiProcess) uiSupervisor.adopt(uiProcess);
@@ -400,7 +406,6 @@ async function startUIServer(): Promise<void> {
 function spawnUIServer(
   uiBuildDir: string,
   homeDir: string,
-  dataDir: string,
   uiPidFile: string,
   appUpdate?: UpdateInfo | null,
 ): void {
@@ -537,7 +542,7 @@ const uiSupervisor = new UiSupervisor<ChildProcess>({
         console.error('UI restart aborted: build not found at', uiBuildDir);
         throw new UiRestartAbortError();
       }
-      spawnUIServer(uiBuildDir, homeDir, dataDir, uiPidFile, getCachedUpdateInfo());
+      spawnUIServer(uiBuildDir, homeDir, uiPidFile, getCachedUpdateInfo());
       if (!uiProcess) throw new Error('UI server failed to spawn');
       return uiProcess;
     },

--- a/packages/electron/src/settings.ts
+++ b/packages/electron/src/settings.ts
@@ -63,7 +63,7 @@ export function saveSettings(dataDir: string, patch: Partial<DesktopSettings>): 
   try {
     const file = settingsPath(dataDir);
     mkdirSync(dirname(file), { recursive: true });
-    writeFileSync(file, JSON.stringify(next, null, 2) + '\n', 'utf-8');
+    writeFileSync(file, `${JSON.stringify(next, null, 2)}\n`, 'utf-8');
   } catch (err) {
     console.warn(
       'Failed to persist desktop settings (non-fatal):',

--- a/packages/electron/test/local-opencode.test.ts
+++ b/packages/electron/test/local-opencode.test.ts
@@ -212,8 +212,8 @@ describe('startLocalOpenCode (SDK stubbed)', () => {
 
     const handle = await startLocalOpenCode({ dataDir, pluginPath: '/test/admin-tools-plugin/index.js' });
     expect(handle).not.toBeNull();
-    expect(handle!.url).toBe('http://127.0.0.1:54321');
-    expect(handle!.username).toBe('openpalm');
+    expect(handle?.url).toBe('http://127.0.0.1:54321');
+    expect(handle?.username).toBe('openpalm');
     // No Basic auth — admin OpenCode mirrors the no-auth assistant so the
     // cross-origin Advanced iframe can load it.
     expect(spawnEnv?.OPENCODE_AUTH).toBe('false');
@@ -234,7 +234,7 @@ describe('startLocalOpenCode (SDK stubbed)', () => {
     expect(rt.url).toBe('http://127.0.0.1:54321');
     expect('password' in rt).toBe(false);
 
-    await handle!.stop();
+    await handle?.stop();
     expect(existsSync(runtimePath(dataDir))).toBe(false);
     expect(existsSync(pidfilePath(dataDir))).toBe(false);
   }, 10_000);
@@ -266,6 +266,6 @@ describe('startLocalOpenCode (SDK stubbed)', () => {
     expect(rt.url).toBe('http://127.0.0.1:9999');
     expect(existsSync(unavailableSentinelPath(dataDir))).toBe(false);
 
-    await handle!.stop();
+    await handle?.stop();
   }, 10_000);
 });

--- a/packages/electron/test/main.test.ts
+++ b/packages/electron/test/main.test.ts
@@ -346,6 +346,7 @@ describe('resolveAssistantUrl', () => {
     expect(resolveAssistantUrl('/home/user/.openpalm')).toBe('http://example.test:1234');
   });
 
+  // biome-ignore lint/suspicious/noTemplateCurlyInString: literal ${homeDir} documents the path template in the test name, not an interpolation.
   it('reads stack.env from ${homeDir}/knowledge/env/stack.env', () => {
     vi.mocked(lib.parseEnvFile).mockReturnValue({});
     delete process.env.OP_OPENCODE_URL;
@@ -413,7 +414,7 @@ describe('restart-ui-server reloads the renderer', () => {
     const handler = ipcMainHandleHandlers.get('restart-ui-server');
     expect(handler).toBeTypeOf('function');
 
-    const ok = await handler!();
+    const ok = await handler?.();
 
     expect(ok).toBe(true);
     expect(mockBrowserWindow.loadURL).toHaveBeenCalledWith('http://127.0.0.1:3880/');
@@ -429,7 +430,7 @@ describe('restart-ui-server reloads the renderer', () => {
     vi.mocked(app.quit).mockClear();
 
     const handler = ipcMainHandleHandlers.get('restart-ui-server');
-    const ok = await handler!();
+    const ok = await handler?.();
 
     expect(ok).toBe(false);
     expect(lib.restoreUiBackup).toHaveBeenCalled();            // §4.4 backup restored
@@ -446,9 +447,9 @@ describe('restart-ui-server reloads the renderer', () => {
     const { spawn } = await import('node:child_process');
     vi.mocked(spawn).mockClear();
 
-    const handler = ipcMainHandleHandlers.get('restart-ui-server')!;
-    const inFlight = handler();       // sets uiServerRestarting = true before its first await
-    const second = await handler();   // guarded out immediately
+    const handler = ipcMainHandleHandlers.get('restart-ui-server');
+    const inFlight = handler?.();       // sets uiServerRestarting = true before its first await
+    const second = await handler?.();   // guarded out immediately
     const first = await inFlight;
 
     expect(second).toBe(false);
@@ -616,7 +617,7 @@ describe('Docker preflight', () => {
     // Simulate the renderer's "I've installed it — retry" click.
     const retry = ipcMainOnHandlers.get('retry-docker-preflight');
     expect(retry, 'retry-docker-preflight handler must be registered').toBeDefined();
-    retry!();
+    retry?.();
 
     await pending;
     expect(resolved).toBe(true);
@@ -628,7 +629,7 @@ describe('Docker preflight', () => {
     const open = ipcMainOnHandlers.get('open-docker-install');
     expect(open, 'open-docker-install handler must be registered').toBeDefined();
     vi.mocked(shell.openExternal).mockClear();
-    open!();
+    open?.();
     expect(shell.openExternal).toHaveBeenCalledWith('https://docs.docker.com/get-docker/');
   });
 });
@@ -643,13 +644,13 @@ describe('before-quit handler', () => {
   it('handler is synchronous', () => {
     const entry = vi.mocked(app.on).mock.calls.find(([e]) => e === 'before-quit');
     expect(entry, 'before-quit handler must be registered').toBeDefined();
-    const handler = entry![1] as (...args: unknown[]) => unknown;
+    const handler = entry?.[1] as (...args: unknown[]) => unknown;
     expect(handler.constructor.name, 'handler must not be AsyncFunction').not.toBe('AsyncFunction');
   });
 
   it('first call: prevents default and calls app.exit(0); second call: passes through', () => {
     const entry = vi.mocked(app.on).mock.calls.find(([e]) => e === 'before-quit');
-    const handler = entry![1] as (event: { preventDefault: () => void }) => void;
+    const handler = entry?.[1] as (event: { preventDefault: () => void }) => void;
 
     vi.mocked(app.exit).mockClear();
     vi.mocked(app.quit).mockClear();

--- a/packages/electron/test/main.test.ts
+++ b/packages/electron/test/main.test.ts
@@ -346,7 +346,6 @@ describe('resolveAssistantUrl', () => {
     expect(resolveAssistantUrl('/home/user/.openpalm')).toBe('http://example.test:1234');
   });
 
-  // biome-ignore lint/suspicious/noTemplateCurlyInString: literal ${homeDir} documents the path template in the test name, not an interpolation.
   it('reads stack.env from ${homeDir}/knowledge/env/stack.env', () => {
     vi.mocked(lib.parseEnvFile).mockReturnValue({});
     delete process.env.OP_OPENCODE_URL;

--- a/packages/guardian/src/audit.ts
+++ b/packages/guardian/src/audit.ts
@@ -64,7 +64,7 @@ process.on("beforeExit", onShutdown);
 
 export function audit(event: Record<string, unknown>): void {
   try {
-    getAuditWriter().write(JSON.stringify({ ts: new Date().toISOString(), ...event }) + "\n");
+    getAuditWriter().write(`${JSON.stringify({ ts: new Date().toISOString(), ...event })}\n`);
     dirty = true;
   } catch (err) {
     logger.error("Audit write failed", { error: err instanceof Error ? err.message : String(err) });

--- a/packages/guardian/src/auth.ts
+++ b/packages/guardian/src/auth.ts
@@ -64,7 +64,7 @@ export const basicTokenAuthStrategy: AuthStrategy = {
     if (!basic) return null;
 
     const record = readCachedPrincipal(basic.id);
-    if (!record || !record.enabled) return null;
+    if (!record?.enabled) return null;
 
     const tokenHash = createHash('sha256').update(basic.secret).digest('hex');
     if (!constantTimeEqual(record.tokenHash, tokenHash)) return null;

--- a/packages/guardian/src/drift.test.ts
+++ b/packages/guardian/src/drift.test.ts
@@ -102,7 +102,6 @@ describe("assertDocCompatible (pure, §5)", () => {
 
 describe("runDriftCheck — reconnect re-assertion is not boot-only (D2a item 5)", () => {
   let mockServer: ReturnType<typeof Bun.serve> | null = null;
-  const mockDocPath = "/doc";
   const serveGoodDoc = true;
 
   const getPort = (): Promise<number> =>

--- a/packages/guardian/src/drift.test.ts
+++ b/packages/guardian/src/drift.test.ts
@@ -102,8 +102,8 @@ describe("assertDocCompatible (pure, §5)", () => {
 
 describe("runDriftCheck — reconnect re-assertion is not boot-only (D2a item 5)", () => {
   let mockServer: ReturnType<typeof Bun.serve> | null = null;
-  let mockDocPath = "/doc";
-  let serveGoodDoc = true;
+  const mockDocPath = "/doc";
+  const serveGoodDoc = true;
 
   const getPort = (): Promise<number> =>
     new Promise((resolve, reject) => {

--- a/packages/guardian/src/event-fanout.test.ts
+++ b/packages/guardian/src/event-fanout.test.ts
@@ -244,7 +244,7 @@ describe("consumeSseBuffer — SSE frame parsing", () => {
     expect(tail).toBe(partialStart);
     // Second chunk: the rest of frame 2 + its boundary → routes f2.
     const rest = `data: ${f2}`.slice(15);
-    const tail2 = consumeSseBuffer(tail + rest + "\n\n");
+    const tail2 = consumeSseBuffer(`${tail}${rest}\n\n`);
     expect(tail2).toBe("");
     expect(payloads(a.frames)).toEqual([f1, f2]);
     a.drop();

--- a/packages/guardian/src/event-fanout.ts
+++ b/packages/guardian/src/event-fanout.ts
@@ -252,13 +252,14 @@ export function broadcastUpstreamReset(error: { name: string; message: string })
  */
 export function consumeSseBuffer(buffer: string): string {
   let working = buffer;
-  let boundary: number;
   // Frames are separated by a blank line: "\n\n" (tolerate "\r\n\r\n").
-  while ((boundary = nextFrameBoundary(working)) !== -1) {
+  let boundary = nextFrameBoundary(working);
+  while (boundary !== -1) {
     const rawFrame = working.slice(0, boundary);
     working = working.slice(advancePastBoundary(working, boundary));
     const dataPayload = extractData(rawFrame);
     if (dataPayload !== null) routeFrame(dataPayload);
+    boundary = nextFrameBoundary(working);
   }
   return working;
 }

--- a/packages/guardian/src/index.ts
+++ b/packages/guardian/src/index.ts
@@ -18,7 +18,7 @@
 import { startGuardian, type GuardianServers, type StartGuardianOptions } from './server.ts';
 import { setAuthStrategy, type AuthStrategy } from './auth.ts';
 import { setPolicyProvider, type PolicyProvider } from './policy.ts';
-import { type Transport } from './transport.ts';
+import type { Transport } from './transport.ts';
 
 // --- composition root ---
 export { startGuardian };

--- a/packages/guardian/src/oc-allowlist.ts
+++ b/packages/guardian/src/oc-allowlist.ts
@@ -45,7 +45,7 @@ function canonicalize(path: string): string {
     }
     out.push(seg);
   }
-  return '/' + out.join('/');
+  return `/${out.join('/')}`;
 }
 
 function matchTemplate(template: string, path: string): Record<string, string> | null {

--- a/packages/guardian/src/openai-api-stream.test.ts
+++ b/packages/guardian/src/openai-api-stream.test.ts
@@ -40,6 +40,7 @@ function stubGuardian(opts: StubOpts): void {
 }
 
 async function readAll(resp: Response): Promise<string> {
+  // biome-ignore lint/style/noNonNullAssertion: streaming test responses always have a body.
   const reader = resp.body!.getReader();
   const decoder = new TextDecoder();
   let out = '';
@@ -176,6 +177,7 @@ describe('streamTurn — non-interactive permission policy', () => {
     await readAll(resp);
     const reply = calls.find((call) => call.path === '/permission/per_42/reply');
     expect(reply).toBeDefined();
+    // biome-ignore lint/style/noNonNullAssertion: reply is asserted defined immediately above.
     expect(JSON.parse(reply!.body).reply).toBe('reject');
   });
 
@@ -193,6 +195,7 @@ describe('streamTurn — non-interactive permission policy', () => {
     const resp = streamTurn({ client, policy: loadPermissionPolicy({ OP_API_PERMISSION_MODE: 'auto', OP_API_PERMISSION_ALLOWLIST: 'bash' }), userId: 'api:u1', sessionKey: 'api:u1', text: 'run bash', framer: openAiChatFramer('chatcmpl-test', 'gpt-4') });
     await readAll(resp);
     const reply = calls.find((call) => call.path === '/permission/per_99/reply');
+    // biome-ignore lint/style/noNonNullAssertion: the matching permission reply is guaranteed to have been recorded.
     expect(JSON.parse(reply!.body).reply).toBe('once');
   });
 });

--- a/packages/guardian/src/openai-api-stream.test.ts
+++ b/packages/guardian/src/openai-api-stream.test.ts
@@ -40,7 +40,6 @@ function stubGuardian(opts: StubOpts): void {
 }
 
 async function readAll(resp: Response): Promise<string> {
-  // biome-ignore lint/style/noNonNullAssertion: streaming test responses always have a body.
   const reader = resp.body!.getReader();
   const decoder = new TextDecoder();
   let out = '';
@@ -177,7 +176,6 @@ describe('streamTurn — non-interactive permission policy', () => {
     await readAll(resp);
     const reply = calls.find((call) => call.path === '/permission/per_42/reply');
     expect(reply).toBeDefined();
-    // biome-ignore lint/style/noNonNullAssertion: reply is asserted defined immediately above.
     expect(JSON.parse(reply!.body).reply).toBe('reject');
   });
 
@@ -195,7 +193,6 @@ describe('streamTurn — non-interactive permission policy', () => {
     const resp = streamTurn({ client, policy: loadPermissionPolicy({ OP_API_PERMISSION_MODE: 'auto', OP_API_PERMISSION_ALLOWLIST: 'bash' }), userId: 'api:u1', sessionKey: 'api:u1', text: 'run bash', framer: openAiChatFramer('chatcmpl-test', 'gpt-4') });
     await readAll(resp);
     const reply = calls.find((call) => call.path === '/permission/per_99/reply');
-    // biome-ignore lint/style/noNonNullAssertion: the matching permission reply is guaranteed to have been recorded.
     expect(JSON.parse(reply!.body).reply).toBe('once');
   });
 });

--- a/packages/guardian/src/openai-api-stream.ts
+++ b/packages/guardian/src/openai-api-stream.ts
@@ -60,7 +60,7 @@ export function openAiChatFramer(id: string, model: string): SseFramer {
 }
 
 export function openAiLegacyFramer(id: string, model: string): SseFramer {
-  return { contentType: 'text/event-stream', open: () => '', delta: (text) => openAiLegacyChunk(id, model, text, null), close: () => openAiLegacyChunk(id, model, '', 'stop') + 'data: [DONE]\n\n' };
+  return { contentType: 'text/event-stream', open: () => '', delta: (text) => openAiLegacyChunk(id, model, text, null), close: () => `${openAiLegacyChunk(id, model, '', 'stop')}data: [DONE]\n\n` };
 }
 
 export function anthropicFramer(id: string, model: string): SseFramer {

--- a/packages/guardian/src/openai-api-stream.ts
+++ b/packages/guardian/src/openai-api-stream.ts
@@ -1,5 +1,5 @@
 import { createLogger } from './logger.ts';
-import { OcClient } from './openai-api-oc-client.ts';
+import type { OcClient } from './openai-api-oc-client.ts';
 import {
   extractPermissionAsk,
   extractQuestionAsk,

--- a/packages/guardian/src/openai-api-utils.ts
+++ b/packages/guardian/src/openai-api-utils.ts
@@ -7,7 +7,7 @@ export function extractChatText(messages: unknown): string | null {
   if (!Array.isArray(messages)) return null;
   for (let index = messages.length - 1; index >= 0; index--) {
     const record = asRecord(messages[index]);
-    if (!record || record.role !== 'user') continue;
+    if (record?.role !== 'user') continue;
     if (typeof record.content === 'string' && record.content.trim()) return record.content;
     if (Array.isArray(record.content)) {
       const parts: string[] = [];

--- a/packages/guardian/src/proxy-direct.test.ts
+++ b/packages/guardian/src/proxy-direct.test.ts
@@ -235,6 +235,7 @@ describe("/oc proxy — direct tier: moderation block → prompt-rewrite (not 40
     expect(messageHits).toBe(before + 1);
     // The rewritten body sent to upstream contains the refusal instruction.
     expect(lastMessageBody).not.toBeNull();
+    // biome-ignore lint/style/noNonNullAssertion: asserted non-null on the line above.
     const parsed = JSON.parse(lastMessageBody!);
     const firstText = parsed?.parts?.[0]?.text as string | undefined;
     expect(typeof firstText).toBe("string");
@@ -256,6 +257,7 @@ describe("/oc proxy — direct tier: moderation block → prompt-rewrite (not 40
     expect(resp.status).not.toBe(403);
     expect(messageHits).toBe(before + 1);
     expect(lastMessageBody).not.toBeNull();
+    // biome-ignore lint/style/noNonNullAssertion: asserted non-null on the line above.
     const parsed = JSON.parse(lastMessageBody!);
     const firstText = parsed?.parts?.[0]?.text as string | undefined;
     expect(typeof firstText).toBe("string");
@@ -279,6 +281,7 @@ describe("/oc proxy — direct tier: moderation block → prompt-rewrite (not 40
     // Upstream IS contacted with the rewritten body.
     expect(messageHits).toBe(before + 1);
     expect(lastMessageBody).not.toBeNull();
+    // biome-ignore lint/style/noNonNullAssertion: asserted non-null on the line above.
     const parsed = JSON.parse(lastMessageBody!);
     const firstText = parsed?.parts?.[0]?.text as string | undefined;
     expect(typeof firstText).toBe("string");

--- a/packages/guardian/src/proxy-direct.test.ts
+++ b/packages/guardian/src/proxy-direct.test.ts
@@ -235,7 +235,6 @@ describe("/oc proxy — direct tier: moderation block → prompt-rewrite (not 40
     expect(messageHits).toBe(before + 1);
     // The rewritten body sent to upstream contains the refusal instruction.
     expect(lastMessageBody).not.toBeNull();
-    // biome-ignore lint/style/noNonNullAssertion: asserted non-null on the line above.
     const parsed = JSON.parse(lastMessageBody!);
     const firstText = parsed?.parts?.[0]?.text as string | undefined;
     expect(typeof firstText).toBe("string");
@@ -257,7 +256,6 @@ describe("/oc proxy — direct tier: moderation block → prompt-rewrite (not 40
     expect(resp.status).not.toBe(403);
     expect(messageHits).toBe(before + 1);
     expect(lastMessageBody).not.toBeNull();
-    // biome-ignore lint/style/noNonNullAssertion: asserted non-null on the line above.
     const parsed = JSON.parse(lastMessageBody!);
     const firstText = parsed?.parts?.[0]?.text as string | undefined;
     expect(typeof firstText).toBe("string");
@@ -281,7 +279,6 @@ describe("/oc proxy — direct tier: moderation block → prompt-rewrite (not 40
     // Upstream IS contacted with the rewritten body.
     expect(messageHits).toBe(before + 1);
     expect(lastMessageBody).not.toBeNull();
-    // biome-ignore lint/style/noNonNullAssertion: asserted non-null on the line above.
     const parsed = JSON.parse(lastMessageBody!);
     const firstText = parsed?.parts?.[0]?.text as string | undefined;
     expect(typeof firstText).toBe("string");

--- a/packages/guardian/src/proxy-policy.test.ts
+++ b/packages/guardian/src/proxy-policy.test.ts
@@ -148,15 +148,15 @@ describe("Gate 2b: PolicyProvider seam", () => {
     await handleProxy(makeRequest("/session/abc-123"), "rid-capture");
 
     expect(captured).not.toBeNull();
-    expect(captured!.principalId).toBe("stub-portal");
-    expect(captured!.kind).toBe("portal");
-    expect(captured!.action).toBe("oc:GET");
+    expect(captured?.principalId).toBe("stub-portal");
+    expect(captured?.kind).toBe("portal");
+    expect(captured?.action).toBe("oc:GET");
     // resource is the route template or raw path
-    expect(typeof captured!.resource).toBe("string");
-    expect(captured!.resource!.length).toBeGreaterThan(0);
+    expect(typeof captured?.resource).toBe("string");
+    expect(captured?.resource?.length).toBeGreaterThan(0);
     // attributes carry userId and path
-    expect(captured!.attributes?.userId).toBe("stub-user");
-    expect(String(captured!.attributes?.path)).toContain("/session/abc-123");
+    expect(captured?.attributes?.userId).toBe("stub-user");
+    expect(String(captured?.attributes?.path)).toContain("/session/abc-123");
   });
 
   it("resetPolicyProvider restores default-allow behavior", async () => {

--- a/packages/guardian/src/proxy.test.ts
+++ b/packages/guardian/src/proxy.test.ts
@@ -147,7 +147,6 @@ beforeAll(async () => {
   tmpDir = mkdtempSync(join(tmpdir(), "guardian-proxy-test-"));
   secretPath = join(tmpDir, "test-secret");
   writeFileSync(secretPath, `${TEST_SECRET}\n`);
-  const auditPath = join(tmpDir, "audit.log");
 
   mockAssistant = Bun.serve({
     port: assistantPort,
@@ -579,6 +578,7 @@ describe("/oc proxy — /event filtered stream (§3.2)", () => {
  * instead of hanging the suite.
  */
 async function readStreamUntil(resp: Response, needle: string, maxMs = 2000): Promise<string> {
+  // biome-ignore lint/style/noNonNullAssertion: streaming test responses always have a body.
   const reader = resp.body!.getReader();
   const decoder = new TextDecoder();
   let out = "";

--- a/packages/guardian/src/proxy.test.ts
+++ b/packages/guardian/src/proxy.test.ts
@@ -578,7 +578,6 @@ describe("/oc proxy — /event filtered stream (§3.2)", () => {
  * instead of hanging the suite.
  */
 async function readStreamUntil(resp: Response, needle: string, maxMs = 2000): Promise<string> {
-  // biome-ignore lint/style/noNonNullAssertion: streaming test responses always have a body.
   const reader = resp.body!.getReader();
   const decoder = new TextDecoder();
   let out = "";

--- a/packages/guardian/src/proxy.ts
+++ b/packages/guardian/src/proxy.ts
@@ -31,7 +31,7 @@
 import { matchAllowlist, type AllowlistMatch } from './oc-allowlist.ts';
 import { createLogger } from './logger.ts';
 
-import { authenticate, type AuthenticatedPrincipal } from "./auth";
+import { authenticate } from "./auth";
 import {
   type Principal,
   ownsSession,
@@ -280,6 +280,7 @@ async function routeAllowed(
   search: string,
   body: string,
 ): Promise<Response> {
+  // biome-ignore lint/style/noNonNullAssertion: routeAllowed is only invoked after a successful allowlist match, so route is always present.
   const template = match.route!.template;
   const params = match.params ?? {};
   const sessionId = params.id;
@@ -753,7 +754,7 @@ function rawOcPath(rawUrl: string): string | null {
   const noScheme = rawUrl.replace(/^[a-zA-Z][a-zA-Z0-9+.-]*:\/\/[^/]*/, "");
   const pathOnly = noScheme.split("?")[0].split("#")[0];
   if (pathOnly === OC_PREFIX) return "/"; // "/oc" alone → "/"
-  if (!pathOnly.startsWith(OC_PREFIX + "/")) return null;
+  if (!pathOnly.startsWith(`${OC_PREFIX}/`)) return null;
   return pathOnly.slice(OC_PREFIX.length); // keep the leading "/"
 }
 

--- a/packages/guardian/src/proxy.ts
+++ b/packages/guardian/src/proxy.ts
@@ -280,7 +280,6 @@ async function routeAllowed(
   search: string,
   body: string,
 ): Promise<Response> {
-  // biome-ignore lint/style/noNonNullAssertion: routeAllowed is only invoked after a successful allowlist match, so route is always present.
   const template = match.route!.template;
   const params = match.params ?? {};
   const sessionId = params.id;

--- a/packages/guardian/src/server.test.ts
+++ b/packages/guardian/src/server.test.ts
@@ -19,7 +19,6 @@ let guardianPort = 0;
 let directPort = 0;
 let adminPort = 0;
 let sessionCreateCount = 0;
-let messageCount = 0;
 let lastCreateBody: unknown = null;
 
 function getAvailablePort(): Promise<number> {
@@ -83,7 +82,6 @@ function startMockAssistant(): ReturnType<typeof Bun.serve> {
         return Response.json([]);
       }
       if (url.pathname.startsWith('/session/') && url.pathname.endsWith('/message') && req.method === 'POST') {
-        messageCount += 1;
         const sessionId = url.pathname.split('/')[2] ?? 'unknown-session';
         return Response.json({ parts: [{ type: 'text', text: `mock answer from ${sessionId}` }] });
       }

--- a/packages/guardian/src/server.ts
+++ b/packages/guardian/src/server.ts
@@ -16,7 +16,7 @@ import {
   reconnectBucketCount,
 } from './oc-bounds';
 import { handleProxy, OC_PREFIX } from './proxy';
-import { allow, activeRateLimiters, PORTAL_RATE_LIMIT, PORTAL_RATE_WINDOW_MS, USER_RATE_LIMIT, USER_RATE_WINDOW_MS } from './rate-limit';
+import { activeRateLimiters, PORTAL_RATE_LIMIT, PORTAL_RATE_WINDOW_MS, USER_RATE_LIMIT, USER_RATE_WINDOW_MS } from './rate-limit';
 import { runDriftCheckWithRetry, startProxyRecovery, stopProxyRecovery, isProxyEnabled } from './drift';
 import { initializePrincipalStore, listPrincipals, seedPortalPrincipalsFromEnv } from './state-db';
 import { matchTransport, registerTransport, type Transport } from './transport';

--- a/packages/guardian/src/state-db.test.ts
+++ b/packages/guardian/src/state-db.test.ts
@@ -62,7 +62,7 @@ describe('state-db — kind migration (channel → portal)', () => {
 
     expect(row).not.toBeNull();
     // Old schema should still contain 'channel' in the CHECK.
-    expect(row!.sql).toContain("'channel'");
+    expect(row?.sql).toContain("'channel'");
 
     // Run migration.
     database.exec(`
@@ -125,7 +125,7 @@ describe('state-db — kind migration (channel → portal)', () => {
     ).get();
 
     // New schema does NOT contain 'channel' in the CHECK — migration is skipped.
-    expect(row!.sql).not.toContain("'channel'");
+    expect(row?.sql).not.toContain("'channel'");
 
     type Row = { id: string; kind: string };
     const rows = database.query<Row, []>('SELECT id, kind FROM principals').all();

--- a/packages/guardian/src/state-db.ts
+++ b/packages/guardian/src/state-db.ts
@@ -133,7 +133,6 @@ export function upsertPrincipal(input: { id: string; kind: PrincipalKind; label?
       token_hash = excluded.token_hash,
       enabled = excluded.enabled
   `).run(input.id, input.kind, label, hashToken(input.token), input.enabled === false ? 0 : 1, createdAt);
-  // biome-ignore lint/style/noNonNullAssertion: the row was just upserted above, so getPrincipalRecord always returns it.
   return getPrincipalRecord(input.id)!;
 }
 

--- a/packages/guardian/src/state-db.ts
+++ b/packages/guardian/src/state-db.ts
@@ -133,6 +133,7 @@ export function upsertPrincipal(input: { id: string; kind: PrincipalKind; label?
       token_hash = excluded.token_hash,
       enabled = excluded.enabled
   `).run(input.id, input.kind, label, hashToken(input.token), input.enabled === false ? 0 : 1, createdAt);
+  // biome-ignore lint/style/noNonNullAssertion: the row was just upserted above, so getPrincipalRecord always returns it.
   return getPrincipalRecord(input.id)!;
 }
 

--- a/packages/lib/src/control-plane/addons.ts
+++ b/packages/lib/src/control-plane/addons.ts
@@ -5,7 +5,7 @@
  * resolved to Compose profiles. The fixed compose files under config/stack are
  * the runtime source of truth.
  */
-import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { errMessage } from './errors.js';
 import { join } from 'node:path';
 import { parse as parseYaml } from 'yaml';

--- a/packages/lib/src/control-plane/akm-sources.ts
+++ b/packages/lib/src/control-plane/akm-sources.ts
@@ -75,14 +75,6 @@ function upsertSource(config: AkmConfigObject, entry: FilesystemSourceEntry): Ak
   return { ...config, sources };
 }
 
-function removeSource(config: AkmConfigObject, name: string): AkmConfigObject {
-  if (!Array.isArray(config.sources)) return config;
-  const sources = (config.sources as unknown[]).filter(
-    (s) => !(s && typeof s === "object" && (s as Record<string, unknown>).name === name),
-  );
-  return { ...config, sources };
-}
-
 function assertNoPrimaryEscalation(entry: FilesystemSourceEntry): void {
   // Defense in depth: the type forbids `primary`, but assert at runtime too —
   // a secondary that became primary would change the write target.

--- a/packages/lib/src/control-plane/akm-stats.test.ts
+++ b/packages/lib/src/control-plane/akm-stats.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, mock, test } from 'bun:test';
-import { getAkmStats, parseAkmStats } from './akm-stats.js';
+import { parseAkmStats } from './akm-stats.js';
 import type { ControlPlaneState } from './types.js';
 import * as realAssistantAkm from './assistant-akm.js';
 

--- a/packages/lib/src/control-plane/apply-stack-service.test.ts
+++ b/packages/lib/src/control-plane/apply-stack-service.test.ts
@@ -13,7 +13,7 @@
  */
 import { describe, it, expect, beforeAll, afterAll } from "bun:test";
 import {
-  mkdtempSync, mkdirSync, writeFileSync, rmSync, chmodSync, readFileSync,
+  mkdtempSync, writeFileSync, rmSync, chmodSync, readFileSync,
 } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";

--- a/packages/lib/src/control-plane/backup.ts
+++ b/packages/lib/src/control-plane/backup.ts
@@ -1,4 +1,4 @@
-import { cpSync, existsSync, mkdirSync, readdirSync, rmSync, statSync, statfsSync } from "node:fs";
+import { cpSync, type Dirent, existsSync, mkdirSync, readdirSync, rmSync, statSync, statfsSync } from "node:fs";
 import { join } from "node:path";
 
 export function timestampDirName(now = new Date()): string {
@@ -17,7 +17,7 @@ export function estimateHomeBackupBytes(homeDir: string): number {
   const backupsDir = join(homeDir, "data", "backups");
   let total = 0;
   const walk = (dir: string): void => {
-    let entries;
+    let entries: Dirent[];
     try {
       entries = readdirSync(dir, { withFileTypes: true });
     } catch {
@@ -150,7 +150,7 @@ export function listBackupDirs(homeDir: string): string[] {
 
 function dirSizeBytes(dir: string): number {
   let total = 0;
-  let entries;
+  let entries: Dirent[];
   try {
     entries = readdirSync(dir, { withFileTypes: true });
   } catch {

--- a/packages/lib/src/control-plane/bind-warning.ts
+++ b/packages/lib/src/control-plane/bind-warning.ts
@@ -35,7 +35,7 @@ function isLoopback(value: string): boolean {
 export function isRemoteSetupAllowed(
   env: Record<string, string | undefined> = process.env,
 ): boolean {
-  const v = env["OP_ALLOW_REMOTE_SETUP"]?.trim().toLowerCase();
+  const v = env.OP_ALLOW_REMOTE_SETUP?.trim().toLowerCase();
   return v === "1" || v === "true" || v === "yes";
 }
 
@@ -51,7 +51,7 @@ export function collectBindAddressWarnings(
 ): string[] {
   const warnings: string[] = [];
 
-  const globalBind = env["OP_BIND_ADDRESS"];
+  const globalBind = env.OP_BIND_ADDRESS;
   if (globalBind && !isLoopback(globalBind)) {
     warnings.push(
       `OP_BIND_ADDRESS is set to "${globalBind}" — services will be exposed on the host network interface, not just loopback. ` +

--- a/packages/lib/src/control-plane/cleanup-guardrails.test.ts
+++ b/packages/lib/src/control-plane/cleanup-guardrails.test.ts
@@ -286,7 +286,7 @@ describe("guardrail: component/instance system removed", () => {
 
   test("no source file references data/components or data/catalog", () => {
     const sources = readSourceFiles();
-    for (const { path, content } of sources) {
+    for (const { content } of sources) {
       expect(content).not.toContain("data/components");
       expect(content).not.toContain("data/catalog");
     }

--- a/packages/lib/src/control-plane/compose-args.test.ts
+++ b/packages/lib/src/control-plane/compose-args.test.ts
@@ -46,7 +46,7 @@ function seedEnvFiles(files: { stack?: boolean } = {}): void {
 function seedAddon(name: string): void {
   const stackDir = join(tempDir, "system", "stack");
   mkdirSync(stackDir, { recursive: true });
-  writeFileSync(join(stackDir, "portals.compose.yml"), `services:\n  ${name}:\n    profiles: [\"addon.${name}\"]\n    image: test\n`);
+  writeFileSync(join(stackDir, "portals.compose.yml"), `services:\n  ${name}:\n    profiles: ["addon.${name}"]\n    image: test\n`);
   const envDir = join(tempDir, "knowledge", "env");
   mkdirSync(envDir, { recursive: true });
   writeFileSync(join(envDir, "stack.env"), `OP_ENABLED_ADDONS=${name}\n`);

--- a/packages/lib/src/control-plane/compose-errors.ts
+++ b/packages/lib/src/control-plane/compose-errors.ts
@@ -111,7 +111,6 @@ export function parseComposeStderr(stderr: string): ComposeServiceFailure[] {
         service: notFound[1],
         reason: `no such service: ${notFound[1]}`,
       });
-      continue;
     }
   }
 

--- a/packages/lib/src/control-plane/compose-errors.ts
+++ b/packages/lib/src/control-plane/compose-errors.ts
@@ -141,7 +141,7 @@ export function summarizeComposeStderr(stderr: string, maxLen = 500): string {
     .split(/\r?\n/)
     .map((l) => l.trim())
     .find((l) => l.length > 0) ?? "";
-  return first.length > maxLen ? first.slice(0, maxLen - 1) + "…" : first;
+  return first.length > maxLen ? `${first.slice(0, maxLen - 1)}…` : first;
 }
 
 export function mapDockerError(stderr: string): DockerErrorMapping {

--- a/packages/lib/src/control-plane/config-persistence.ts
+++ b/packages/lib/src/control-plane/config-persistence.ts
@@ -371,7 +371,7 @@ export function discoverHomeBindMountSources(state: ControlPlaneState): Array<{ 
         if (!rawSource) continue;
 
         const hostPath = expandEnvVars(rawSource, envVars);
-        if (!hostPath || !hostPath.startsWith('/')) continue;
+        if (!hostPath?.startsWith('/')) continue;
         const resolvedHostPath = resolvePath(hostPath);
         if (!resolvedHostPath.startsWith(`${homeRoot}/`) && resolvedHostPath !== homeRoot) continue;
 

--- a/packages/lib/src/control-plane/deploy.test.ts
+++ b/packages/lib/src/control-plane/deploy.test.ts
@@ -13,7 +13,7 @@
  * exported), verifying the concurrency property without needing a full runDeploy.
  */
 import { describe, it, expect, afterEach } from 'bun:test';
-import { mkdtempSync, rmSync, mkdirSync, writeFileSync, readFileSync, existsSync } from 'node:fs';
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, existsSync } from 'node:fs';
 import { spawnSync } from 'node:child_process';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';

--- a/packages/lib/src/control-plane/deploy.ts
+++ b/packages/lib/src/control-plane/deploy.ts
@@ -134,7 +134,6 @@ function parseComposePsOutput(stdout: string): ComposeContainerState[] {
         health: String(obj.Health ?? ''),
       });
     } catch {
-      continue;
     }
   }
   return results;

--- a/packages/lib/src/control-plane/deploy.ts
+++ b/packages/lib/src/control-plane/deploy.ts
@@ -1,4 +1,4 @@
-import { copyFileSync, existsSync, mkdirSync, readFileSync, readdirSync, rmSync, statSync } from 'node:fs';
+import { copyFileSync, existsSync, mkdirSync, readFileSync, readdirSync } from 'node:fs';
 import { execFile } from 'node:child_process';
 import { dirname, join } from 'node:path';
 import type { ControlPlaneState } from './types.js';
@@ -10,7 +10,7 @@ import { composeDown, composePs, composePull, composeUp, detectExistingProject, 
 import { mapDockerError } from './compose-errors.js';
 import { parseEnvFile } from './env.js';
 import { patchStateEnvFile } from './secrets.js';
-import { acquireInstallLock, releaseInstallLock, type InstallLockHandle } from './install-lock.js';
+import { acquireInstallLock, releaseInstallLock } from './install-lock.js';
 import { resolveBackupsDir } from './home.js';
 
 export type DeployEntry = {

--- a/packages/lib/src/control-plane/deployment-scenarios.test.ts
+++ b/packages/lib/src/control-plane/deployment-scenarios.test.ts
@@ -25,7 +25,7 @@
  *                                                  ("Docker is not installed…/not running…/Compose v2 is required…")
  */
 import { describe, it, expect, beforeEach, afterEach } from "bun:test";
-import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, existsSync, rmSync } from "node:fs";
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { upsertEnvValue } from "./env.js";

--- a/packages/lib/src/control-plane/host-akm-sharing.test.ts
+++ b/packages/lib/src/control-plane/host-akm-sharing.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from "bun:test";
-import { mkdtempSync, rmSync, mkdirSync, writeFileSync, readFileSync, existsSync } from "node:fs";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {

--- a/packages/lib/src/control-plane/host-identity.ts
+++ b/packages/lib/src/control-plane/host-identity.ts
@@ -95,5 +95,5 @@ export function readHostIdentity(path: string): HostIdentity | null {
 
 export function writeHostIdentity(path: string, identity: HostIdentity): void {
   mkdirSync(dirname(path), { recursive: true });
-  writeFileAtomic(path, JSON.stringify(identity, null, 2) + '\n');
+  writeFileAtomic(path, `${JSON.stringify(identity, null, 2)}\n`);
 }

--- a/packages/lib/src/control-plane/host-opencode.ts
+++ b/packages/lib/src/control-plane/host-opencode.ts
@@ -16,7 +16,7 @@
  *   - Conflict detection compares provider IDs; existing credentials are
  *     preserved unless overwriteConflicts=true.
  */
-import { existsSync, mkdirSync, readFileSync, writeFileSync, chmodSync, copyFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, writeFileSync, chmodSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname } from "node:path";
 import type { ControlPlaneState } from "./types.js";
@@ -217,7 +217,7 @@ export function importHostOpenCode(
          }
        }
 
-       writeFileSync(destPath, JSON.stringify(merged, null, 2) + "\n");
+       writeFileSync(destPath, `${JSON.stringify(merged, null, 2)}\n`);
      }
   }
 
@@ -239,7 +239,7 @@ export function importHostOpenCode(
           importedCredentials++;
         }
       }
-      writeFileSync(destPath, JSON.stringify(merged, null, 2) + "\n");
+      writeFileSync(destPath, `${JSON.stringify(merged, null, 2)}\n`);
     } else {
       // No existing file or overwrite requested — parse, filter, then write.
       // Belt-and-suspenders: never write anthropic credentials into OP_HOME.
@@ -250,7 +250,7 @@ export function importHostOpenCode(
         filtered[id] = value;
         importedCredentials++;
       }
-      writeFileSync(destPath, JSON.stringify(filtered, null, 2) + "\n");
+      writeFileSync(destPath, `${JSON.stringify(filtered, null, 2)}\n`);
     }
 
     try {

--- a/packages/lib/src/control-plane/host-opencode.ts
+++ b/packages/lib/src/control-plane/host-opencode.ts
@@ -195,7 +195,7 @@ export function importHostOpenCode(
 
       const mergedProviders: Record<string, unknown> = { ...existingProviders };
       for (const [id, entry] of Object.entries(hostProviders)) {
-        if (Object.prototype.hasOwnProperty.call(existingProviders, id) && !overwriteConflicts) {
+        if (Object.hasOwn(existingProviders, id) && !overwriteConflicts) {
           conflicts.push(id);
         } else {
           mergedProviders[id] = entry;
@@ -234,7 +234,7 @@ export function importHostOpenCode(
       const merged: Record<string, unknown> = { ...existingAuth };
       for (const [id, value] of Object.entries(hostAuth)) {
         if (id === 'anthropic') continue;
-        if (!Object.prototype.hasOwnProperty.call(existingAuth, id)) {
+        if (!Object.hasOwn(existingAuth, id)) {
           merged[id] = value;
           importedCredentials++;
         }

--- a/packages/lib/src/control-plane/install-edge-cases.test.ts
+++ b/packages/lib/src/control-plane/install-edge-cases.test.ts
@@ -17,7 +17,7 @@ import {
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { parseEnvContent, parseEnvFile, mergeEnvContent } from "./env.js";
-import { ensureSecrets, readStackEnv } from "./secrets.js";
+import { ensureSecrets } from "./secrets.js";
 import { isSetupComplete } from "./setup-status.js";
 import {
   performSetup,

--- a/packages/lib/src/control-plane/iu-harness.ts
+++ b/packages/lib/src/control-plane/iu-harness.ts
@@ -118,8 +118,9 @@ export interface ComposeProject {
 function docker(args: string[]): { ok: boolean; out: string; err: string } {
   try {
     return { ok: true, out: execFileSync("docker", args, { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] }), err: "" };
-  } catch (e: any) {
-    return { ok: false, out: e.stdout?.toString() ?? "", err: e.stderr?.toString() ?? String(e) };
+  } catch (e) {
+    const err = e as { stdout?: { toString(): string }; stderr?: { toString(): string } };
+    return { ok: false, out: err.stdout?.toString() ?? "", err: err.stderr?.toString() ?? String(e) };
   }
 }
 

--- a/packages/lib/src/control-plane/iu-invariants.integration.test.ts
+++ b/packages/lib/src/control-plane/iu-invariants.integration.test.ts
@@ -89,7 +89,7 @@ describe.skipIf(SKIP_DOCKER)("install/update invariants (Phase 0 baseline)", () 
       }
       if (existsSync(dst) && readFileSync(dst, "utf8").includes("OP_ENABLED_ADDONS")) return "skip";
       mkdirSync(join(dst, ".."), { recursive: true });
-      writeFileSync(`${dst}.tmp`, picked.join("\n") + "\n");
+      writeFileSync(`${dst}.tmp`, `${picked.join("\n")}\n`);
       renameSync(`${dst}.tmp`, dst);
       return "written";
     };
@@ -162,7 +162,7 @@ describe.skipIf(SKIP_DOCKER)("install/update invariants (Phase 0 baseline)", () 
 
     // Now getRunningImages should show a running container with a real digest
     const after = await getRunningImages({ files: [proj.file], envFiles: [envFile], profiles: [] });
-    const svcInfo = after["svc"];
+    const svcInfo = after.svc;
     expect(svcInfo).not.toBeUndefined();
     expect(svcInfo!.state).toBe("running");
     expect(svcInfo!.digest).toMatch(/^sha256:/);

--- a/packages/lib/src/control-plane/lifecycle.rollback.test.ts
+++ b/packages/lib/src/control-plane/lifecycle.rollback.test.ts
@@ -2,7 +2,6 @@ import { describe, test, expect } from 'bun:test';
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { spawnSync } from 'node:child_process';
 import { join } from 'node:path';
-import { tmpdir } from 'node:os';
 import { fileURLToPath } from 'node:url';
 
 type RollbackScenario = {

--- a/packages/lib/src/control-plane/model-runner.ts
+++ b/packages/lib/src/control-plane/model-runner.ts
@@ -118,7 +118,7 @@ function parsePortEnv(raw: string | undefined): number | null {
  */
 function getProbeTimeoutMs(): number {
   const floor = 1000;
-  const envRaw = process.env["OP_LOCAL_PROBE_TIMEOUT_MS"];
+  const envRaw = process.env.OP_LOCAL_PROBE_TIMEOUT_MS;
   if (envRaw) {
     const n = parseInt(envRaw, 10);
     if (Number.isFinite(n) && n >= floor) return n;
@@ -149,7 +149,7 @@ function buildModelRunnerProbes(): ProviderProbe[] {
     },
   ];
 
-  const port = parsePortEnv(process.env["MODEL_RUNNER_PORT"]);
+  const port = parsePortEnv(process.env.MODEL_RUNNER_PORT);
   if (port !== null) {
     return [
       {
@@ -183,7 +183,7 @@ function buildOllamaProbes(): ProviderProbe[] {
     },
   ];
 
-  const base = parseOllamaHostEnv(process.env["OLLAMA_HOST"]);
+  const base = parseOllamaHostEnv(process.env.OLLAMA_HOST);
   if (base !== null) {
     return [
       {
@@ -210,7 +210,7 @@ function buildLmStudioProbes(): ProviderProbe[] {
     },
   ];
 
-  const port = parsePortEnv(process.env["LMSTUDIO_PORT"] ?? process.env["LM_STUDIO_PORT"]);
+  const port = parsePortEnv(process.env.LMSTUDIO_PORT ?? process.env.LM_STUDIO_PORT);
   if (port !== null) {
     return [
       {

--- a/packages/lib/src/control-plane/network-partitioning.test.ts
+++ b/packages/lib/src/control-plane/network-partitioning.test.ts
@@ -109,11 +109,11 @@ describe("network partitioning — assistant_net membership", () => {
   const PORTAL_ADAPTERS = ["discord", "slack"];
 
   test("assistant is on assistant_net", () => {
-    expect(allServices["assistant"]?.networks).toContain("assistant_net");
+    expect(allServices.assistant?.networks).toContain("assistant_net");
   });
 
   test("guardian is on assistant_net", () => {
-    expect(allServices["guardian"]?.networks).toContain("assistant_net");
+    expect(allServices.guardian?.networks).toContain("assistant_net");
   });
 
   test("no portal adapter is on assistant_net", () => {
@@ -139,13 +139,13 @@ describe("network partitioning — assistant_net membership", () => {
   });
 
   test("guardian is on portal_net (the ingress bridge)", () => {
-    expect(allServices["guardian"]?.networks).toContain("portal_net");
+    expect(allServices.guardian?.networks).toContain("portal_net");
   });
 });
 
 describe("network partitioning — assistant host port defaults", () => {
   test("assistant host port defaults to loopback (127.0.0.1)", () => {
-    const assistantPorts = allServices["assistant"]?.ports ?? [];
+    const assistantPorts = allServices.assistant?.ports ?? [];
     // The port entry must contain the loopback default.
     // Pattern: "${OP_ASSISTANT_BIND_ADDRESS:-127.0.0.1}:..."
     const hasLoopbackDefault = assistantPorts.some((p) =>

--- a/packages/lib/src/control-plane/opencode-client.test.ts
+++ b/packages/lib/src/control-plane/opencode-client.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, beforeEach, afterEach, mock } from "bun:test";
+import { describe, test, expect, afterEach } from "bun:test";
 import { createOpenCodeClient } from "./opencode-client.ts";
 
 // ── Test server helper ──────────────────────────────────────────────────
@@ -99,7 +99,7 @@ describe("createOpenCodeClient", () => {
   });
 
   test("setProviderApiKey sends PUT with correct body", async () => {
-    let receivedBody: any = null;
+    let receivedBody: unknown = null;
     let receivedMethod = "";
     let receivedPath = "";
 

--- a/packages/lib/src/control-plane/ownership-reconcile.ts
+++ b/packages/lib/src/control-plane/ownership-reconcile.ts
@@ -132,7 +132,7 @@ export function ownershipRepairMarkerMatches(homeDir: string, ids: { uid: number
 export function writeOwnershipRepairMarker(homeDir: string, ids: { uid: number; gid: number }): void {
   const file = ownershipRepairMarkerFile(homeDir);
   mkdirSync(dirname(file), { recursive: true });
-  writeFileAtomic(file, JSON.stringify({ uid: ids.uid, gid: ids.gid }) + '\n');
+  writeFileAtomic(file, `${JSON.stringify({ uid: ids.uid, gid: ids.gid })}\n`);
 }
 
 // ── Composed host-ownership reconcile (R2) ───────────────────────────────────

--- a/packages/lib/src/control-plane/ownership-reconcile.ts
+++ b/packages/lib/src/control-plane/ownership-reconcile.ts
@@ -46,7 +46,6 @@ export function readCanaryOwners(paths: string[]): Array<{ path: string; uid: nu
       const stat = statSync(path);
       owners.push({ path, uid: stat.uid, gid: stat.gid });
     } catch {
-      continue;
     }
   }
   return owners;

--- a/packages/lib/src/control-plane/portals.ts
+++ b/packages/lib/src/control-plane/portals.ts
@@ -136,7 +136,6 @@ export function isAllowedService(value: string, configDir?: string): boolean {
           }
         }
       } catch {
-        continue;
       }
     }
   }

--- a/packages/lib/src/control-plane/portals.ts
+++ b/packages/lib/src/control-plane/portals.ts
@@ -119,7 +119,7 @@ export function discoverPortals(configDir: string): PortalInfo[] {
  * content is checked, not directory naming conventions.
  */
 export function isAllowedService(value: string, configDir?: string): boolean {
-  if (!value || !value.trim() || value !== value.toLowerCase()) return false;
+  if (!value?.trim() || value !== value.toLowerCase()) return false;
   if ((CORE_SERVICES as string[]).includes(value)) return true;
 
   if (configDir) {
@@ -147,7 +147,7 @@ export function isAllowedService(value: string, configDir?: string): boolean {
  * Accepts enabled first-party portals and custom portal overlays.
  */
 export function isValidPortal(value: string, configDir?: string): boolean {
-  if (!value || !value.trim()) return false;
+  if (!value?.trim()) return false;
   if (!isValidPortalName(value)) return false;
   if (configDir) {
     return discoverPortals(configDir).some((portal) => portal.name === value);

--- a/packages/lib/src/control-plane/provider-models.ts
+++ b/packages/lib/src/control-plane/provider-models.ts
@@ -113,7 +113,7 @@ export async function fetchProviderModels(
 
     const headers: Record<string, string> = {};
     if (resolvedKey) {
-      headers["Authorization"] = `Bearer ${resolvedKey}`;
+      headers.Authorization = `Bearer ${resolvedKey}`;
     }
 
     const res = await fetch(url, { headers, signal: AbortSignal.timeout(5000) });

--- a/packages/lib/src/control-plane/rollback.ts
+++ b/packages/lib/src/control-plane/rollback.ts
@@ -55,7 +55,7 @@ export function snapshotCurrentState(state: ControlPlaneState, opts: { arm?: boo
   // Write a timestamp marker
   writeFileSync(
     join(rollbackDir, SNAPSHOT_TS_FILE),
-    new Date().toISOString() + "\n",
+    `${new Date().toISOString()}\n`,
   );
 
   if (opts.arm) {

--- a/packages/lib/src/control-plane/scheduler.ts
+++ b/packages/lib/src/control-plane/scheduler.ts
@@ -6,7 +6,7 @@
  * Execution is handled by `akm tasks run <id>`.
  */
 import { execFile } from "node:child_process";
-import { existsSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { createLogger } from "../logger.js";
 import { loadMarkdownTasks, taskToAutomationConfig } from "./markdown-task.js";

--- a/packages/lib/src/control-plane/secret-mappings.ts
+++ b/packages/lib/src/control-plane/secret-mappings.ts
@@ -126,7 +126,7 @@ export function readPlaintextSecretIndex(state: ControlPlaneState): SecretIndexF
 export function writePlaintextSecretIndex(state: ControlPlaneState, index: SecretIndexFile): void {
   const dir = `${state.dataDir}/secrets`;
   mkdirSync(dir, { recursive: true });
-  writeFileSync(secretIndexPath(state), JSON.stringify(index, null, 2) + '\n');
+  writeFileSync(secretIndexPath(state), `${JSON.stringify(index, null, 2)}\n`);
 }
 
 export function ensurePlaintextSecretEntry(

--- a/packages/lib/src/control-plane/secret-strip-notice.test.ts
+++ b/packages/lib/src/control-plane/secret-strip-notice.test.ts
@@ -31,7 +31,7 @@ describe('#502 secret-strip notice', () => {
     const state = createState();
     writeFileSync(
       join(homeDir, 'knowledge', 'env', 'stack.env'),
-      'OP_HOME=' + homeDir + '\nOPENAI_API_KEY=sk-leak\nDISCORD_BOT_TOKEN=tok\nOP_LOG_LEVEL=info\n',
+      `OP_HOME=${homeDir}\nOPENAI_API_KEY=sk-leak\nDISCORD_BOT_TOKEN=tok\nOP_LOG_LEVEL=info\n`,
     );
 
     writeSystemEnv(state);
@@ -48,7 +48,7 @@ describe('#502 secret-strip notice', () => {
     const state = createState();
     writeFileSync(
       join(homeDir, 'knowledge', 'env', 'stack.env'),
-      'OP_HOME=' + homeDir + '\nOP_LOG_LEVEL=info\n',
+      `OP_HOME=${homeDir}\nOP_LOG_LEVEL=info\n`,
     );
 
     writeSystemEnv(state);

--- a/packages/lib/src/control-plane/secrets.test.ts
+++ b/packages/lib/src/control-plane/secrets.test.ts
@@ -5,7 +5,7 @@
  *   - readStackEnv excludes secret-like keys that somehow ended up in stack.env
  */
 import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
-import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, existsSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import {
@@ -19,7 +19,6 @@ import { readSecret } from './secrets-files.js';
 // Each test gets a fresh temp dir shaped like an OP_HOME config/stack directory.
 // The secrets functions take the OP_HOME root directly (knowledge/secrets is derived from it).
 let home: string;
-let stackDir: string;
 
 function makeHome(): { home: string; stackDir: string } {
   const h = mkdtempSync(join(tmpdir(), 'openpalm-secrets-'));
@@ -31,7 +30,7 @@ function makeHome(): { home: string; stackDir: string } {
 }
 
 beforeEach(() => {
-  ({ home, stackDir } = makeHome());
+  ({ home } = makeHome());
 });
 
 afterEach(() => {

--- a/packages/lib/src/control-plane/secrets.ts
+++ b/packages/lib/src/control-plane/secrets.ts
@@ -9,7 +9,7 @@ import { authJsonPath as resolveAuthJsonPath } from "./paths.js";
 import { dirname } from "node:path";
 import { ensureSecret, listSecretNames, readSecret, resolveSecretsDir, writeSecret } from './secrets-files.js';
 
-const OPENCODE_STARTER_CONFIG = JSON.stringify({ $schema: "https://opencode.ai/config.json" }, null, 2) + "\n";
+const OPENCODE_STARTER_CONFIG = `${JSON.stringify({ $schema: "https://opencode.ai/config.json" }, null, 2)}\n`;
 const logger = createLogger("secrets");
 
 
@@ -142,7 +142,7 @@ function ensureSystemSecrets(state: ControlPlaneState): void {
         "OP_SETUP_COMPLETE=false",
       "",
     ].join("\n");
-    writeVaultFile(systemEnvPath, header.endsWith("\n") ? header : header + "\n");
+    writeVaultFile(systemEnvPath, header.endsWith("\n") ? header : `${header}\n`);
     return;
   }
 }
@@ -248,7 +248,7 @@ export function writeAuthJsonProviderKeys(
     }
   }
 
-  writeVaultFile(authJsonPath, JSON.stringify(current, null, 2) + "\n");
+  writeVaultFile(authJsonPath, `${JSON.stringify(current, null, 2)}\n`);
 }
 
 /** Read and parse knowledge/env/stack.env. Returns {} if the file does not exist. */

--- a/packages/lib/src/control-plane/setup.ts
+++ b/packages/lib/src/control-plane/setup.ts
@@ -217,7 +217,7 @@ export async function performSetup(
       // to an old release kept deploying a months-old image. Each image now has
       // its own OP_*_VERSION var (no single OP_IMAGE_TAG cascade); the Advanced
       // field pins all four to the same tag.
-      const requestedTag = imageTag && imageTag.trim() ? imageTag.trim() : "latest";
+      const requestedTag = imageTag?.trim() ? imageTag.trim() : "latest";
       for (const key of SERVICE_VERSION_KEYS) {
         akmUpdates[key] = requestedTag;
       }

--- a/packages/lib/src/control-plane/task-files.test.ts
+++ b/packages/lib/src/control-plane/task-files.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, beforeEach, afterEach } from 'bun:test';
-import { mkdtempSync, rmSync, mkdirSync, writeFileSync, existsSync, statSync } from 'node:fs';
+import { mkdtempSync, rmSync, writeFileSync, statSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {

--- a/packages/lib/src/control-plane/ui-assets.test.ts
+++ b/packages/lib/src/control-plane/ui-assets.test.ts
@@ -317,12 +317,6 @@ describe("declaredUiChannel", () => {
 // missing-integrity and mismatch cases) and through checkAndUpdateUiBuild
 // returning {updated:false} early (for the up-to-date case).
 
-/** Build a correct sha512 SRI string for the given bytes. */
-function makeSri(data: Uint8Array): string {
-  const digest = createHash("sha512").update(data).digest("base64");
-  return `sha512-${digest}`;
-}
-
 describe("npm integrity verification (fail-closed)", () => {
   let savedFetch: typeof globalThis.fetch;
 

--- a/packages/lib/src/control-plane/validate.ts
+++ b/packages/lib/src/control-plane/validate.ts
@@ -58,7 +58,7 @@ export async function validateProposedState(state: ControlPlaneState): Promise<{
   // the env files so the operator sees the slot. Missing slots warn (not
   // error) since not every provider is in use on every install.
   for (const mapping of STATIC_CORE_MAPPINGS) {
-    const inRuntime = Object.prototype.hasOwnProperty.call(runtimeEnv, mapping.envKey);
+    const inRuntime = Object.hasOwn(runtimeEnv, mapping.envKey);
     if (!inRuntime) {
       warnings.push(
         `WARN: ${mapping.envKey} (akm ${mapping.secretKey}) is not declared in knowledge/secrets/${mapping.envKey.toLowerCase()}`,

--- a/packages/portal-sdk/src/runtime.ts
+++ b/packages/portal-sdk/src/runtime.ts
@@ -113,7 +113,7 @@ export function splitMessage(content: string, maxLength: number): string[] {
       chunk += '\n```';
       const match = chunk.match(/```(\w+)?/);
       const lang = match?.[1] || '';
-      remaining = '```' + lang + '\n' + remaining;
+      remaining = `\`\`\`${lang}\n${remaining}`;
     }
 
     chunks.push(chunk.trim());

--- a/packages/ui/src/app.css
+++ b/packages/ui/src/app.css
@@ -929,6 +929,7 @@ body.chat-locked {
 /* ── Setup wizard: light editorial layout ───────────────────────── */
 .setup-page {
   min-height: 100vh;
+  /* biome-ignore lint/suspicious/noDuplicateProperties: intentional progressive-enhancement fallback — 100vh for browsers without dvh support, 100dvh where available. */
   min-height: 100dvh;
   display: flex;
   flex-direction: column;

--- a/packages/ui/src/app.d.ts
+++ b/packages/ui/src/app.d.ts
@@ -35,6 +35,7 @@ declare global {
         enabled: boolean;
       }>;
       setTrayMicRecording?: (recording: boolean) => Promise<void>;
+      // biome-ignore lint/suspicious/noConfusingVoidType: registration may return an unsubscribe fn or nothing (void); switching to undefined would reject void-returning implementations.
       onGlobalMicToggle?: (callback: () => void) => (() => void) | void;
     };
   }

--- a/packages/ui/src/app.html
+++ b/packages/ui/src/app.html
@@ -15,7 +15,7 @@
           const stored = window.localStorage.getItem(storageKey);
           const preference = stored === 'light' || stored === 'dark' || stored === 'system' ? stored : 'system';
           const resolved = preference === 'system'
-            ? (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light')
+            ? (window.matchMedia?.('(prefers-color-scheme: dark)').matches ? 'dark' : 'light')
             : preference;
           const root = document.documentElement;
           root.setAttribute('data-theme', resolved);

--- a/packages/ui/src/app.html
+++ b/packages/ui/src/app.html
@@ -15,7 +15,7 @@
           const stored = window.localStorage.getItem(storageKey);
           const preference = stored === 'light' || stored === 'dark' || stored === 'system' ? stored : 'system';
           const resolved = preference === 'system'
-            ? (window.matchMedia?.('(prefers-color-scheme: dark)').matches ? 'dark' : 'light')
+            ? (window.matchMedia?.('(prefers-color-scheme: dark)')?.matches ? 'dark' : 'light')
             : preference;
           const root = document.documentElement;
           root.setAttribute('data-theme', resolved);

--- a/packages/ui/src/hooks.server.ts
+++ b/packages/ui/src/hooks.server.ts
@@ -170,7 +170,7 @@ export const handle: Handle = async ({ event, resolve }) => {
   if (path.startsWith('/admin') && !computeFeatureFlags().admin) {
     redirect(302, '/chat');
   }
-  const isSetupPath = SETUP_PATHS.some(p => path === p || path.startsWith(p + "/"));
+  const isSetupPath = SETUP_PATHS.some(p => path === p || path.startsWith(`${p}/`));
 
   // SEC-4: While setup is not yet complete the /setup routes are unauthenticated
   // by design (first-run). Restrict them to the local machine so a remote actor

--- a/packages/ui/src/hooks.server.ts
+++ b/packages/ui/src/hooks.server.ts
@@ -132,7 +132,6 @@ function parseComposePsServices(stdout: string): ComposeServiceStatus[] {
         health: String(parsed.Health ?? ''),
       });
     } catch {
-      continue;
     }
   }
   return services;

--- a/packages/ui/src/lib/components/admin/automations/task-form.ts
+++ b/packages/ui/src/lib/components/admin/automations/task-form.ts
@@ -55,21 +55,21 @@ export function cronToPresetId(cron: string): SchedulePresetId {
 export function cronToHour(cron: string): number {
   const m = cron.trim().match(/^0 (\d{1,2})/);
   const h = m ? parseInt(m[1] ?? '0', 10) : 0;
-  return isNaN(h) ? 0 : Math.min(23, Math.max(0, h));
+  return Number.isNaN(h) ? 0 : Math.min(23, Math.max(0, h));
 }
 
 /** Extract day-of-week (0-6) from a weekly cron expression. */
 export function cronToDow(cron: string): number {
   const m = cron.trim().match(/^0 \d{1,2} \* \* (\d)$/);
   const d = m ? parseInt(m[1] ?? '0', 10) : 0;
-  return isNaN(d) ? 0 : Math.min(6, Math.max(0, d));
+  return Number.isNaN(d) ? 0 : Math.min(6, Math.max(0, d));
 }
 
 /** Extract day-of-month (1-31) from a monthly cron expression. */
 export function cronToDom(cron: string): number {
   const m = cron.trim().match(/^0 \d{1,2} (\d{1,2}) \* \*$/);
   const d = m ? parseInt(m[1] ?? '1', 10) : 1;
-  return isNaN(d) ? 1 : Math.min(31, Math.max(1, d));
+  return Number.isNaN(d) ? 1 : Math.min(31, Math.max(1, d));
 }
 
 /** Build a cron string from preset parameters. */
@@ -132,7 +132,7 @@ export function validateCron(cron: string): string | null {
     const field = parts[i]!;
     if (field === '*' || /^\*\/\d+$/.test(field)) continue;
     const n = parseInt(field, 10);
-    if (isNaN(n)) return `Field ${i + 1} is not a valid number or wildcard`;
+    if (Number.isNaN(n)) return `Field ${i + 1} is not a valid number or wildcard`;
     const [min, max] = ranges[i]!;
     if (n < min || n > max) return `Field ${i + 1} must be ${min}–${max}`;
   }

--- a/packages/ui/src/lib/components/akm/improve-process-helpers.ts
+++ b/packages/ui/src/lib/components/akm/improve-process-helpers.ts
@@ -74,15 +74,15 @@ export const DEFAULT_ENABLED: Record<ProcKey, boolean> = {
 };
 
 export function optNum(s: string | number): number | undefined {
-	if (typeof s === 'number') return isNaN(s) ? undefined : s;
+	if (typeof s === 'number') return Number.isNaN(s) ? undefined : s;
 	const n = parseFloat(s);
-	return s.trim() === '' || isNaN(n) ? undefined : n;
+	return s.trim() === '' || Number.isNaN(n) ? undefined : n;
 }
 
 export function optInt(s: string | number): number | undefined {
-	if (typeof s === 'number') return isNaN(s) ? undefined : Math.trunc(s);
+	if (typeof s === 'number') return Number.isNaN(s) ? undefined : Math.trunc(s);
 	const n = parseInt(s, 10);
-	return s.trim() === '' || isNaN(n) ? undefined : n;
+	return s.trim() === '' || Number.isNaN(n) ? undefined : n;
 }
 
 export function emptyFEntry(enabled: boolean): FEntry {

--- a/packages/ui/src/lib/server/akm.ts
+++ b/packages/ui/src/lib/server/akm.ts
@@ -70,8 +70,8 @@ function isEmbeddingModel(provider: string, model: string): boolean {
 
 function compareModelPreference(provider: string, left: string, right: string): number {
   const preferred = PREFERRED_EMBEDDING_MODELS[provider] ?? [];
-  const leftIdx = preferred.findIndex((entry) => entry === left);
-  const rightIdx = preferred.findIndex((entry) => entry === right);
+  const leftIdx = preferred.indexOf(left);
+  const rightIdx = preferred.indexOf(right);
   if (leftIdx >= 0 || rightIdx >= 0) {
     if (leftIdx < 0) return 1;
     if (rightIdx < 0) return -1;

--- a/packages/ui/src/lib/server/opencode/config.ts
+++ b/packages/ui/src/lib/server/opencode/config.ts
@@ -53,7 +53,7 @@ export async function patchConfig(config: RawConfig): Promise<RawConfig> {
 		};
 	}
 
-	writeFileSync(configPath(), JSON.stringify(merged, null, 2) + '\n');
+	writeFileSync(configPath(), `${JSON.stringify(merged, null, 2)}\n`);
 
 	// Also notify OpenCode to reload (best-effort)
 	await opencodeFetch<RawConfig>('/config', {

--- a/packages/ui/src/lib/server/opencode/http.ts
+++ b/packages/ui/src/lib/server/opencode/http.ts
@@ -15,7 +15,7 @@ export async function opencodeFetch<T>(path: string, init?: RequestInit): Promis
 	};
 	if (endpoint.password) {
 		const user = endpoint.username || 'openpalm';
-		headers['authorization'] = `Basic ${btoa(`${user}:${endpoint.password}`)}`;
+		headers.authorization = `Basic ${btoa(`${user}:${endpoint.password}`)}`;
 	}
 	const response = await fetch(`${endpoint.url}${path}`, {
 		...init,

--- a/packages/ui/src/lib/server/provider-constants.vitest.ts
+++ b/packages/ui/src/lib/server/provider-constants.vitest.ts
@@ -34,9 +34,9 @@ describe("PROVIDER_LABELS", () => {
 
   test("label values are human-readable (not raw slugs)", () => {
     // Spot-check a few known labels
-    expect(PROVIDER_LABELS['openai']).toBe('OpenAI');
+    expect(PROVIDER_LABELS.openai).toBe('OpenAI');
     expect(PROVIDER_LABELS['model-runner']).toBe('Docker Model Runner');
-    expect(PROVIDER_LABELS['lmstudio']).toBe('LM Studio');
+    expect(PROVIDER_LABELS.lmstudio).toBe('LM Studio');
   });
 });
 
@@ -56,8 +56,8 @@ describe("LOCAL_PROVIDER_HELP", () => {
   test("help text contains actionable guidance", () => {
     // Each help string should mention how to add models
     expect(LOCAL_PROVIDER_HELP['model-runner']).toContain('docker model');
-    expect(LOCAL_PROVIDER_HELP['ollama']).toContain('ollama pull');
-    expect(LOCAL_PROVIDER_HELP['lmstudio']).toContain('LM Studio');
+    expect(LOCAL_PROVIDER_HELP.ollama).toContain('ollama pull');
+    expect(LOCAL_PROVIDER_HELP.lmstudio).toContain('LM Studio');
   });
 });
 
@@ -70,13 +70,13 @@ describe("PROVIDER_DEFAULT_URLS", () => {
   });
 
   test("has a base URL for lmstudio", () => {
-    expect(PROVIDER_DEFAULT_URLS['lmstudio']).toBeDefined();
-    expect(PROVIDER_DEFAULT_URLS['lmstudio']).toContain('1234');
+    expect(PROVIDER_DEFAULT_URLS.lmstudio).toBeDefined();
+    expect(PROVIDER_DEFAULT_URLS.lmstudio).toContain('1234');
   });
 
   test("has a base URL for ollama", () => {
-    expect(PROVIDER_DEFAULT_URLS['ollama']).toBeDefined();
-    expect(PROVIDER_DEFAULT_URLS['ollama']).toContain('11434');
+    expect(PROVIDER_DEFAULT_URLS.ollama).toBeDefined();
+    expect(PROVIDER_DEFAULT_URLS.ollama).toContain('11434');
   });
 
   test("cloud provider URLs use HTTPS", () => {
@@ -100,7 +100,7 @@ describe("PROVIDER_DEFAULT_URLS", () => {
 
 describe("PROVIDER_KEY_MAP", () => {
   test("maps openai to OPENAI_API_KEY", () => {
-    expect(PROVIDER_KEY_MAP['openai']).toBe('OPENAI_API_KEY');
+    expect(PROVIDER_KEY_MAP.openai).toBe('OPENAI_API_KEY');
   });
 
   test('maps additional supported providers', () => {

--- a/packages/ui/src/lib/server/release-units.ts
+++ b/packages/ui/src/lib/server/release-units.ts
@@ -105,7 +105,6 @@ export function groupReleasesByUnit(raw: RawGitHubRelease[]): GroupedReleases {
         seenPlatform.add(tag);
         releases.push({ tag, ...base });
       }
-      continue;
     }
 
     // Non-matching tag — skip.
@@ -155,7 +154,6 @@ export function selectInstallableReleases(raw: RawGitHubRelease[]): ReleaseEntry
         seen.add(tag);
         releases.push({ tag, prerelease: r.prerelease, publishedAt: r.published_at, hasElectronBuild });
       }
-      continue;
     }
     // Per-unit tags (assistant-*, guardian-*, portals-*) and non-matching tags — skip.
   }

--- a/packages/ui/src/lib/server/remote-status-cache.vitest.ts
+++ b/packages/ui/src/lib/server/remote-status-cache.vitest.ts
@@ -158,7 +158,7 @@ describe('listRemoteStatuses — probe TTL (in-memory only)', () => {
     const first = await listRemoteStatuses();
     // Mutate an element in the returned array.
     if (first.length > 0) {
-      (first[0] as unknown as Record<string, unknown>)['state'] = 'MUTATED' as never;
+      (first[0] as unknown as Record<string, unknown>).state = 'MUTATED' as never;
     }
 
     const second = await listRemoteStatuses();

--- a/packages/ui/src/lib/server/secrets.vitest.ts
+++ b/packages/ui/src/lib/server/secrets.vitest.ts
@@ -268,7 +268,7 @@ describe("maskSecretValue", () => {
 
   test("masks secret keys, showing last 4 chars", () => {
     expect(maskSecretValue("OPENAI_API_KEY", "sk-test-1234abcd")).toBe(
-      "*".repeat("sk-test-1234abcd".length - 4) + "abcd"
+      `${"*".repeat("sk-test-1234abcd".length - 4)}abcd`
     );
   });
 

--- a/packages/ui/src/lib/server/voice-errors.ts
+++ b/packages/ui/src/lib/server/voice-errors.ts
@@ -49,6 +49,6 @@ export function translateDockerError(stderr: string | undefined | null): string 
 
   // Default: include the first ~300 chars verbatim so the operator at
   // least has something searchable.
-  const slice = raw.length > 300 ? raw.slice(0, 297) + '…' : raw;
+  const slice = raw.length > 300 ? `${raw.slice(0, 297)}…` : raw;
   return slice;
 }

--- a/packages/ui/src/lib/server/voice/bring-up.ts
+++ b/packages/ui/src/lib/server/voice/bring-up.ts
@@ -20,7 +20,7 @@ import { execFile } from 'node:child_process';
 import { existsSync, writeFileSync } from 'node:fs';
 import { connect } from 'node:net';
 import { join } from 'node:path';
-import { getState } from '$lib/server/state.js';
+import type { getState } from '$lib/server/state.js';
 import {
   annotateAddonProfileAvailability,
   addonProfileId,

--- a/packages/ui/src/lib/setup/setup-state.svelte.ts
+++ b/packages/ui/src/lib/setup/setup-state.svelte.ts
@@ -169,7 +169,7 @@ export class SetupState {
 
   // ── Derived ──────────────────────────────────────────────────────────────────
   hostLocalLlmRunning = $derived(
-    this.providerState['ollama']?.ollamaMode === 'running' ||
+    this.providerState.ollama?.ollamaMode === 'running' ||
       this.detectedHostProviders.some((p) => p.provider === 'ollama' || p.provider === 'lmstudio'),
   );
 
@@ -299,7 +299,7 @@ export class SetupState {
 
   enableRecommendedOllama(variant?: 'cuda' | 'rocm' | 'cpu'): void {
     this.ollamaEnabled = true;
-    const st = this.providerState['ollama'];
+    const st = this.providerState.ollama;
     if (st) {
       st.selected = true;
       st.verified = true;
@@ -721,7 +721,7 @@ export class SetupState {
       this.showDeploy = true;
       this.startDeployPolling();
     } catch (e) {
-      this.installError = 'Network error: ' + (e instanceof Error ? e.message : 'unable to reach server.');
+      this.installError = `Network error: ${e instanceof Error ? e.message : 'unable to reach server.'}`;
       this.installing = false;
     }
   }

--- a/packages/ui/src/lib/setup/setup-state.vitest.ts
+++ b/packages/ui/src/lib/setup/setup-state.vitest.ts
@@ -89,7 +89,7 @@ describe('SetupState — canComplete', () => {
     s.allowEmptyInstall = true;
     // Simulate a background verification landing (the historical bug had an
     // $effect flip allowEmptyInstall off here, silently moving the checkbox).
-    s.providerState['openai'].verified = true;
+    s.providerState.openai.verified = true;
     expect(s.allowEmptyInstall).toBe(true);
     expect(s.canComplete).toBe(true);
   });
@@ -139,12 +139,12 @@ describe('SetupState — verified providers derivations', () => {
     expect(s.verifiedCount).toBe(0);
     expect(s.hasOpenAI).toBe(false);
 
-    s.providerState['openai'].verified = true;
+    s.providerState.openai.verified = true;
     expect(s.verifiedCount).toBe(1);
     expect(s.hasOpenAI).toBe(true);
     expect(s.verifiedProviders.map((p) => p.id)).toContain('openai');
 
-    s.providerState['groq'].verified = true;
+    s.providerState.groq.verified = true;
     expect(s.verifiedCount).toBe(2);
   });
 
@@ -152,7 +152,7 @@ describe('SetupState — verified providers derivations', () => {
     const s = new SetupState();
     s.initProviderState();
     expect(s.voiceDefaults).toEqual({ tts: 'browser-tts', stt: 'browser-stt' });
-    s.providerState['openai'].verified = true;
+    s.providerState.openai.verified = true;
     expect(s.voiceDefaults).toEqual({ tts: 'openai-tts', stt: 'openai-stt' });
   });
 });
@@ -188,7 +188,7 @@ describe('SetupState — autoSelectModels', () => {
   it('fills the unset chat role from a verified provider, preserving set roles', () => {
     const s = new SetupState();
     s.initProviderState();
-    s.providerState['openai'] = providerEntry({ verified: true, models: ['gpt-4o', 'gpt-4o-mini'] });
+    s.providerState.openai = providerEntry({ verified: true, models: ['gpt-4o', 'gpt-4o-mini'] });
 
     s.autoSelectModels();
     expect(s.modelSelection.llm?.connId).toBe('openai');
@@ -247,7 +247,7 @@ describe('SetupState — payload derivation delegates to buildSetupPayload', () 
     expect(s.payload.llm).toBeUndefined();
 
     // Verify a provider and select its chat model — the payload picks it up.
-    s.providerState['openai'] = providerEntry({ verified: true, models: ['gpt-4o'] });
+    s.providerState.openai = providerEntry({ verified: true, models: ['gpt-4o'] });
     s.modelSelection.llm = { connId: 'openai', model: 'gpt-4o', dims: 0 };
     expect(s.payload.llm).toBeDefined();
     expect(s.payload.llm?.model).toBe('gpt-4o');
@@ -285,42 +285,52 @@ describe('SetupState — module singleton is reset on a fresh (non-rerun) mount'
     setupState.recommendationApplied = true;
     setupState.savedCloudLlm = { connId: 'openai', model: 'gpt-4o', dims: 0 };
     setupState.detectedCloudConn = 'openai';
-    const discord = setupState.portalSelection['discord'];
+    const discord = setupState.portalSelection.discord;
     if (typeof discord === 'object') discord.enabled = true;
 
     // Remount (init() runs once per mount and resets first).
     setupState.init();
 
-    // Fresh wizard: System Check no longer bypassed, back on the hidden step 0.
-    expect(setupState.currentStep).toBe(0);
-    expect(setupState.maxVisitedStep).toBe(0);
-    expect(setupState.systemCheckPassed).toBe(false);
+    // Whole-store snapshot: EVERY reactive field must return to its constructor
+    // default. A pristine `new SetupState()` is the source of truth for those
+    // defaults; init() additionally re-seeds `providerState` and mints a fresh
+    // login token, so we mirror those two deterministic mutations on the
+    // reference before comparing. This guards all ~51 fields (including any
+    // added later) against a reset() that forgets one — not just a spot-check.
+    const fresh = new SetupState();
+    fresh.initProviderState(); // init() re-seeds providerState right after reset()
+    fresh.uiLoginPassword = setupState.uiLoginPassword; // random per mount — normalize
+
+    // Public reactive fields only (derived getters + private internals excluded).
+    const FIELDS = [
+      'currentStep', 'maxVisitedStep', 'showDeploy', 'systemCheckPassed',
+      'modelMode', 'voiceEnabled', 'uiLoginPassword', 'step0Error',
+      'autoModeImporting', 'gpuDetected', 'providerState', 'detectedHostProviders',
+      'detectedProviders', 'opencodeAvailable', 'opencodeProviders', 'opencodeAuth',
+      'hostProviderCount', 'allowEmptyInstall', 'recommendation', 'recommendationAlert',
+      'recommendationApplied', 'detectedGpuVramMb', 'detectedGpuVendor', 'detectedGpuName',
+      'modelSelection', 'voiceTts', 'voiceStt', 'voiceProfiles', 'selectedVoiceProfile',
+      'importedLlmModel', 'importedSmallModel', 'portalSelection', 'ollamaEnabled',
+      'ollamaProfiles', 'selectedOllamaProfile', 'imageTag', 'hostAkmEnabled',
+      'installError', 'installing', 'emptyAiAck', 'deployData', 'deployDone',
+      'deployHasWarnings', 'deployError', 'deployPollErrors', 'savedCloudLlm',
+      'detectedCloudConn', 'hostImportTriggered', 'hostImporting', 'hostImportError',
+      'isRerun',
+    ] as const;
+    // structuredClone flattens Svelte's $state proxies to plain objects so the
+    // deep-equality diff reads cleanly (and preserves undefined/null fields).
+    const snapshot = (s: SetupState): Record<string, unknown> => {
+      const rec = s as unknown as Record<string, unknown>;
+      return structuredClone(Object.fromEntries(FIELDS.map((k) => [k, rec[k]])));
+    };
+    expect(snapshot(setupState)).toEqual(snapshot(fresh));
+
+    // A fresh (non-rerun) mount does not bypass System Check, and init() always
+    // mints a login token (the one field the snapshot deliberately normalizes).
     expect(setupState.isRerun).toBe(false);
+    expect(setupState.uiLoginPassword).not.toBe('');
 
-    // Selections cleared.
-    expect(setupState.modelMode).toBe('cloud');
-    expect(setupState.voiceEnabled).toBe(false);
-    expect(setupState.voiceTts.engine).toBe('');
-    expect(setupState.voiceStt.engine).toBe('');
-    expect(setupState.selectedVoiceProfile).toBe('');
-    expect(setupState.modelSelection.llm).toBeUndefined();
-    expect(setupState.ollamaEnabled).toBe(false);
-    expect(setupState.savedCloudLlm).toBeUndefined();
-    expect(setupState.detectedCloudConn).toBe('');
-
-    // Gating / one-shot flags cleared.
-    expect(setupState.allowEmptyInstall).toBe(false);
-    expect(setupState.emptyAiAck).toBe(false);
-    expect(setupState.installError).toBe('');
-    expect(setupState.showDeploy).toBe(false);
-    expect(setupState.deployDone).toBe(false);
-    expect(setupState.hostImportTriggered).toBe(false);
-    expect(setupState.recommendationApplied).toBe(false);
-
-    // Fresh portal objects (no lingering enabled/credentials).
-    expect(setupState.portalSelection['discord']).toEqual({ enabled: false, botToken: '', applicationId: '' });
-
-    // Derived predicates recompute clean.
+    // Derived predicates (getters, not part of the field snapshot) recompute clean.
     expect(setupState.canComplete).toBe(false);
     expect(setupState.hasUsableAI).toBe(false);
     expect(setupState.verifiedCount).toBe(0);

--- a/packages/ui/src/lib/voice/audio-playback.ts
+++ b/packages/ui/src/lib/voice/audio-playback.ts
@@ -223,7 +223,7 @@ export class AudioPlaybackController {
         // Network/CORS — fall through to browser TTS if available.
       }
 
-      if (res && res.ok && res.headers.get('content-type')?.startsWith('audio/')) {
+      if (res?.ok && res.headers.get('content-type')?.startsWith('audio/')) {
         const blob = await res.blob();
         const url = URL.createObjectURL(blob);
         const audio = new Audio(url);

--- a/packages/ui/src/routes/admin/addons/[name]/+server.ts
+++ b/packages/ui/src/routes/admin/addons/[name]/+server.ts
@@ -35,7 +35,7 @@ export const GET: RequestHandler = async (event) => {
   }
 
   const enabled = listEnabledAddonIds(state.homeDir).includes(name);
-  let config;
+  let config: ReturnType<typeof getRegistryAddonConfig>;
   try {
     config = getRegistryAddonConfig(name);
   } catch (error) {

--- a/packages/ui/src/routes/admin/addons/[name]/credentials/+server.ts
+++ b/packages/ui/src/routes/admin/addons/[name]/credentials/+server.ts
@@ -109,7 +109,7 @@ export const GET: RequestHandler = async (event) => {
     return errorResponse(404, "not_found", `Addon "${name}" is not available`, { name }, requestId);
   }
 
-  let config;
+  let config: ReturnType<typeof getRegistryAddonConfig>;
   try {
     config = getRegistryAddonConfig(name);
   } catch (error) {
@@ -155,7 +155,7 @@ export const POST: RequestHandler = async (event) => {
   if ("error" in parsed) return jsonBodyError(parsed, requestId);
   const valuesRaw = (parsed.data.values as Record<string, unknown> | undefined) ?? {};
 
-  let config;
+  let config: ReturnType<typeof getRegistryAddonConfig>;
   try {
     config = getRegistryAddonConfig(name);
   } catch (error) {

--- a/packages/ui/src/routes/admin/akm/+server.ts
+++ b/packages/ui/src/routes/admin/akm/+server.ts
@@ -380,7 +380,7 @@ export const PATCH: RequestHandler = async (event) => {
         if (f in embBody) merged[f] = embBody[f];
       }
       if (isRec(embBody.ollamaOptions) && 'num_ctx' in embBody.ollamaOptions) {
-        merged.ollamaOptions = { ...(existing.embedding as Rec | undefined)?.['ollamaOptions'] as Rec ?? {}, num_ctx: (embBody.ollamaOptions as Rec).num_ctx };
+        merged.ollamaOptions = { ...(existing.embedding as Rec | undefined)?.ollamaOptions as Rec ?? {}, num_ctx: (embBody.ollamaOptions as Rec).num_ctx };
       }
       updated.embedding = merged;
     }

--- a/packages/ui/src/routes/admin/automations/[name]/log/server.vitest.ts
+++ b/packages/ui/src/routes/admin/automations/[name]/log/server.vitest.ts
@@ -36,7 +36,7 @@ function seedTaskLogs(dataDir: string, id: string, entries: Array<{ ts: string; 
   const logDir = join(dataDir, 'akm', 'cache', 'tasks', 'logs', id);
   mkdirSync(logDir, { recursive: true });
   for (const { ts, content } of entries) {
-    writeFileSync(join(logDir, `${ts}.log`), content + '\n');
+    writeFileSync(join(logDir, `${ts}.log`), `${content}\n`);
   }
 }
 

--- a/packages/ui/src/routes/admin/config/validate/server.vitest.ts
+++ b/packages/ui/src/routes/admin/config/validate/server.vitest.ts
@@ -54,7 +54,7 @@ function makeGetEvent(token = "admin-token"): Parameters<typeof GET>[0] {
   };
   // Phase 2: x-admin-token header fallback removed; auth flows via op_session cookie.
   if (token) {
-    headers["cookie"] = `op_session=${token}`;
+    headers.cookie = `op_session=${token}`;
   }
   return {
     request: new Request("http://localhost/admin/config/validate", {

--- a/packages/ui/src/routes/admin/health/+server.ts
+++ b/packages/ui/src/routes/admin/health/+server.ts
@@ -24,7 +24,7 @@ export const GET: RequestHandler = async (event) => {
 		const headers: Record<string, string> = {};
 		if (endpoint.password) {
 			const user = endpoint.username || 'openpalm';
-			headers['authorization'] = `Basic ${btoa(`${user}:${endpoint.password}`)}`;
+			headers.authorization = `Basic ${btoa(`${user}:${endpoint.password}`)}`;
 		}
 		const res = await fetch(`${endpoint.url}/health`, {
 			headers,

--- a/packages/ui/src/routes/admin/providers/[id]/+server.ts
+++ b/packages/ui/src/routes/admin/providers/[id]/+server.ts
@@ -102,7 +102,7 @@ export const PATCH: RequestHandler = async (event) => {
   if (kind === 'register-local') {
     // Register a detected local provider
     try {
-      if (!Object.prototype.hasOwnProperty.call(LOCAL_PROVIDER_LABELS, providerId)) {
+      if (!Object.hasOwn(LOCAL_PROVIDER_LABELS, providerId)) {
         return errorResponse(400, 'bad_request', 'provider must be one of: ollama, lmstudio, model-runner', {}, requestId);
       }
       const detected = await detectLocalProviders();

--- a/packages/ui/src/routes/admin/providers/[id]/+server.ts
+++ b/packages/ui/src/routes/admin/providers/[id]/+server.ts
@@ -107,12 +107,12 @@ export const PATCH: RequestHandler = async (event) => {
       }
       const detected = await detectLocalProviders();
       const match = detected.find((d) => d.provider === providerId);
-      if (!match || !match.available) {
+      if (!match?.available) {
         return jsonResponse(200, { ok: false, message: `No reachable ${LOCAL_PROVIDER_LABELS[providerId] ?? providerId} endpoint found.`, selectedProviderId: providerId } satisfies ProviderActionResult, requestId);
       }
 
       const config = await getCurrentConfig();
-      const existingEntry = (config.provider ?? {})[providerId] as Record<string, unknown> | undefined;
+      const existingEntry = config.provider?.[providerId] as Record<string, unknown> | undefined;
       const existingOptions = (existingEntry?.options as Record<string, unknown> | undefined) ?? {};
       await registerProvider(providerId, {
         npm: typeof existingEntry?.npm === 'string' ? existingEntry.npm : '@ai-sdk/openai-compatible',

--- a/packages/ui/src/routes/admin/providers/import-host/+server.ts
+++ b/packages/ui/src/routes/admin/providers/import-host/+server.ts
@@ -119,7 +119,7 @@ export const POST: RequestHandler = async (event) => {
 		}
 
 		// File-level import (durable)
-		let result;
+		let result: ReturnType<typeof importHostOpenCode>;
 		try {
 			result = importHostOpenCode(state, { overwriteConflicts });
 		} catch (err) {

--- a/packages/ui/src/routes/admin/secrets/user-env/server.vitest.ts
+++ b/packages/ui/src/routes/admin/secrets/user-env/server.vitest.ts
@@ -27,7 +27,7 @@ function makeTempDir(): string {
 function makeEvent(method: string, path: string, body?: Record<string, unknown>, token = 'admin-token') {
   const headers: Record<string, string> = { 'x-request-id': 'req-ue-1' };
   // Phase 2: x-admin-token header fallback removed; auth flows via op_session cookie.
-  if (token) headers['cookie'] = `op_session=${token}`;
+  if (token) headers.cookie = `op_session=${token}`;
   if (body) headers['content-type'] = 'application/json';
   return {
     request: new Request(`http://localhost${path}`, {

--- a/packages/ui/src/routes/admin/versions/+server.ts
+++ b/packages/ui/src/routes/admin/versions/+server.ts
@@ -268,7 +268,7 @@ export const GET: RequestHandler = async (event) => {
     // They miss the running/pinned/available distinction — acceptable during the
     // mixed-version window (Phase 6 UpdatesTab rebuild consumes the new shape).
     versions,
-    autoUpdate: env["OP_AUTO_UPDATE"] !== "false",
+    autoUpdate: env.OP_AUTO_UPDATE !== "false",
   });
 };
 

--- a/packages/ui/src/routes/admin/voice/+server.ts
+++ b/packages/ui/src/routes/admin/voice/+server.ts
@@ -40,7 +40,7 @@ const REACHABILITY_TIMEOUT_MS = 1_500;
 
 async function probeReachable(baseURL: string): Promise<boolean> {
   if (!baseURL) return false;
-  const url = baseURL.replace(/\/+$/, '') + '/v1/models';
+  const url = `${baseURL.replace(/\/+$/, '')}/v1/models`;
   try {
     // Use GET, not HEAD. FastAPI (openpalm/voice's framework) doesn't
     // auto-derive a HEAD handler from a GET route — Starlette would
@@ -67,8 +67,8 @@ export const GET: RequestHandler = async (event) => {
   const state = getState();
   const env = readStackEnv(state.homeDir);
 
-  const ttsBaseURL = env['OP_TTS_BASE_URL'] ?? '';
-  const sttBaseURL = env['OP_STT_BASE_URL'] ?? '';
+  const ttsBaseURL = env.OP_TTS_BASE_URL ?? '';
+  const sttBaseURL = env.OP_STT_BASE_URL ?? '';
 
   const rawProfiles = getAddonProfiles(state.homeDir, VOICE_ADDON);
   const profiles = await annotateAddonProfileAvailability(rawProfiles);
@@ -83,19 +83,19 @@ export const GET: RequestHandler = async (event) => {
   return jsonResponse(200, {
     tts: {
       enabled: true,
-      engine: env['OP_TTS_ENGINE'] ?? '',
-      provider: env['OP_TTS_PROVIDER'] ?? '',
+      engine: env.OP_TTS_ENGINE ?? '',
+      provider: env.OP_TTS_PROVIDER ?? '',
       baseURL: ttsBaseURL,
-      model: env['OP_TTS_MODEL'] ?? '',
-      voice: env['OP_TTS_VOICE'] ?? '',
+      model: env.OP_TTS_MODEL ?? '',
+      voice: env.OP_TTS_VOICE ?? '',
     },
     stt: {
       enabled: true,
-      engine: env['OP_STT_ENGINE'] ?? '',
-      provider: env['OP_STT_PROVIDER'] ?? '',
+      engine: env.OP_STT_ENGINE ?? '',
+      provider: env.OP_STT_PROVIDER ?? '',
       baseURL: sttBaseURL,
-      model: env['OP_STT_MODEL'] ?? '',
-      language: env['OP_STT_LANGUAGE'] ?? '',
+      model: env.OP_STT_MODEL ?? '',
+      language: env.OP_STT_LANGUAGE ?? '',
     },
     availability: {
       stt: {
@@ -152,17 +152,17 @@ const OPENPALM_VOICE_DEFAULT_VOICE = 'bf_isabella';
  */
 function applyOpenPalmVoicePreset(section: VoiceSection, kind: 'tts' | 'stt'): void {
   if (section.engine !== 'openpalm-voice') return;
-  if (!section.baseURL || !section.baseURL.trim()) section.baseURL = openpalmVoiceBaseURL();
-  if (!section.model || !section.model.trim()) {
+  if (!section.baseURL?.trim()) section.baseURL = openpalmVoiceBaseURL();
+  if (!section.model?.trim()) {
     section.model = kind === 'tts' ? OPENPALM_VOICE_TTS_MODEL : OPENPALM_VOICE_STT_MODEL;
   }
-  if (kind === 'tts' && (!section.voice || !section.voice.trim())) {
+  if (kind === 'tts' && !section.voice?.trim()) {
     section.voice = OPENPALM_VOICE_DEFAULT_VOICE;
   }
 }
 
 function validateSection(section: VoiceSection | null, kind: 'tts' | 'stt'): string | null {
-  if (!section || !section.engine) return null;
+  if (!section?.engine) return null;
   // `browser` engines store no server-side URL — fine.
   if (section.engine === 'browser' || section.engine === 'browser-stt' || section.engine === 'browser-tts') {
     return null;
@@ -172,7 +172,7 @@ function validateSection(section: VoiceSection | null, kind: 'tts' | 'stt'): str
   // before validation runs, so it always satisfies the remote check.
   // Any remote (including openpalm-voice with a user-supplied URL) must
   // end up with a non-empty baseURL.
-  if (!section.baseURL || !section.baseURL.trim()) {
+  if (!section.baseURL?.trim()) {
     return `Remote ${kind.toUpperCase()} requires an endpoint URL.`;
   }
   return null;

--- a/packages/ui/src/routes/admin/voice/server.vitest.ts
+++ b/packages/ui/src/routes/admin/voice/server.vitest.ts
@@ -127,15 +127,15 @@ describe('PUT /admin/voice', () => {
 
 		const state = getState();
 		const env = readStackEnv(state.homeDir);
-		expect(env['OP_TTS_ENGINE']).toBe('openpalm-voice');
-		expect(env['OP_STT_ENGINE']).toBe('openpalm-voice');
+		expect(env.OP_TTS_ENGINE).toBe('openpalm-voice');
+		expect(env.OP_STT_ENGINE).toBe('openpalm-voice');
 		// Preset URL points at the loopback host port the voice addon
 		// publishes (config in OP_VOICE_PORT_HOST; defaults to 8880).
-		expect(env['OP_TTS_BASE_URL']).toMatch(/^http:\/\/127\.0\.0\.1:\d+/);
-		expect(env['OP_STT_BASE_URL']).toMatch(/^http:\/\/127\.0\.0\.1:\d+/);
-		expect(env['OP_TTS_MODEL']).toBe('kokoro');
-		expect(env['OP_STT_MODEL']).toBe('whisper-1');
-		expect(env['OP_TTS_VOICE']).toBe('bf_isabella');
+		expect(env.OP_TTS_BASE_URL).toMatch(/^http:\/\/127\.0\.0\.1:\d+/);
+		expect(env.OP_STT_BASE_URL).toMatch(/^http:\/\/127\.0\.0\.1:\d+/);
+		expect(env.OP_TTS_MODEL).toBe('kokoro');
+		expect(env.OP_STT_MODEL).toBe('whisper-1');
+		expect(env.OP_TTS_VOICE).toBe('bf_isabella');
 	});
 
 	test('openpalm-voice respects user-supplied overrides', async () => {
@@ -146,10 +146,10 @@ describe('PUT /admin/voice', () => {
 
 		const state = getState();
 		const env = readStackEnv(state.homeDir);
-		expect(env['OP_TTS_BASE_URL']).toBe('http://elsewhere:9999');
-		expect(env['OP_TTS_VOICE']).toBe('af_heart');
+		expect(env.OP_TTS_BASE_URL).toBe('http://elsewhere:9999');
+		expect(env.OP_TTS_VOICE).toBe('af_heart');
 		// Model still defaults since the user didn't override.
-		expect(env['OP_TTS_MODEL']).toBe('kokoro');
+		expect(env.OP_TTS_MODEL).toBe('kokoro');
 	});
 
 	test('rejects engine "remote" without baseURL', async () => {
@@ -346,7 +346,7 @@ describe('translateDockerError', () => {
 	});
 
 	test('unknown stderr → first 300 chars verbatim', () => {
-		const raw = 'something exploded ' + 'x'.repeat(400);
+		const raw = `something exploded ${'x'.repeat(400)}`;
 		const out = translateDockerError(raw);
 		expect(out.length).toBeLessThanOrEqual(300);
 		expect(out.startsWith('something exploded')).toBe(true);

--- a/packages/ui/src/routes/advanced/page.svelte.vitest.ts
+++ b/packages/ui/src/routes/advanced/page.svelte.vitest.ts
@@ -1,3 +1,4 @@
+import type { AfterNavigate } from '@sveltejs/kit';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import { render } from 'vitest-browser-svelte';
 import { page } from 'vitest/browser';
@@ -11,9 +12,8 @@ vi.mock('$app/state', () => ({ page: mockPage }));
 vi.mock('$app/navigation', () => ({
   goto: vi.fn(),
   // Call the callback immediately to simulate the initial load navigation event.
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  afterNavigate: vi.fn((cb: (nav: any) => void) =>
-    cb({ to: mockPage, from: null, type: 'goto', complete: Promise.resolve(), delta: 0, willUnload: false })
+  afterNavigate: vi.fn((cb: (nav: AfterNavigate) => void) =>
+    cb({ to: mockPage, from: null, type: 'goto', complete: Promise.resolve(), delta: 0, willUnload: false } as unknown as AfterNavigate)
   ),
 }));
 

--- a/packages/ui/src/routes/api/setup/system-check/+server.ts
+++ b/packages/ui/src/routes/api/setup/system-check/+server.ts
@@ -26,8 +26,8 @@ async function portHeldByOurContainer(port: number): Promise<"held" | "free" | "
           const lines = stdout.toString().split("\n").map((l) => l.trim()).filter(Boolean);
           for (const line of lines) {
             const [name, ports] = line.split("\t");
-            if (!name || !name.startsWith("openpalm-")) continue;
-            if (ports && ports.includes(`:${port}->`)) {
+            if (!name?.startsWith("openpalm-")) continue;
+            if (ports?.includes(`:${port}->`)) {
               return resolve("held");
             }
           }

--- a/packages/ui/src/routes/api/speak/+server.ts
+++ b/packages/ui/src/routes/api/speak/+server.ts
@@ -92,9 +92,9 @@ export const POST: RequestHandler = async (event) => {
     }
   }
 
-  const upstreamUrl = ttsBaseURL.replace(/\/+$/, '') + '/v1/audio/speech';
+  const upstreamUrl = `${ttsBaseURL.replace(/\/+$/, '')}/v1/audio/speech`;
   const headers: Record<string, string> = { 'content-type': 'application/json' };
-  if (ttsApiKey) headers['authorization'] = `Bearer ${ttsApiKey}`;
+  if (ttsApiKey) headers.authorization = `Bearer ${ttsApiKey}`;
 
   let upstream: Response;
   try {

--- a/packages/ui/src/routes/api/speak/server.vitest.ts
+++ b/packages/ui/src/routes/api/speak/server.vitest.ts
@@ -61,7 +61,7 @@ describe('POST /api/speak speech prep', () => {
     writeFileSync(join(getState().configDir, 'assistant', 'persona.md'), 'Be warm and relaxed.\n');
     writeFileSync(
       join(getState().configDir, 'assistant', 'opencode.json'),
-      JSON.stringify({ small_model: 'openai/gpt-4.1-mini', model: 'openai/gpt-4.1' }) + '\n',
+      `${JSON.stringify({ small_model: 'openai/gpt-4.1-mini', model: 'openai/gpt-4.1' })}\n`,
     );
 
     const calls: Array<{ url: string; init?: RequestInit }> = [];
@@ -119,7 +119,7 @@ describe('POST /api/speak speech prep', () => {
     writeFileSync(join(getState().configDir, 'assistant', 'persona.md'), 'Be crisp and friendly.\n');
     writeFileSync(
       join(getState().configDir, 'assistant', 'opencode.json'),
-      JSON.stringify({ model: 'openai/gpt-4.1' }) + '\n',
+      `${JSON.stringify({ model: 'openai/gpt-4.1' })}\n`,
     );
 
     const calls: Array<{ url: string; init?: RequestInit }> = [];

--- a/packages/ui/src/routes/api/transcribe/+server.ts
+++ b/packages/ui/src/routes/api/transcribe/+server.ts
@@ -92,9 +92,9 @@ export const POST: RequestHandler = async (event) => {
     outForm.append('prompt', promptReq.trim());
   }
 
-  const upstreamUrl = sttBaseURL.replace(/\/+$/, '') + '/v1/audio/transcriptions';
+  const upstreamUrl = `${sttBaseURL.replace(/\/+$/, '')}/v1/audio/transcriptions`;
   const headers: Record<string, string> = {};
-  if (sttApiKey) headers['authorization'] = `Bearer ${sttApiKey}`;
+  if (sttApiKey) headers.authorization = `Bearer ${sttApiKey}`;
 
   let upstream: Response;
   try {

--- a/packages/ui/src/routes/api/transcribe/server.vitest.ts
+++ b/packages/ui/src/routes/api/transcribe/server.vitest.ts
@@ -141,7 +141,7 @@ describe('POST /api/transcribe', () => {
 		expect(captured).not.toBeNull();
 		const c = captured as unknown as { url: string; init: RequestInit };
 		expect(String(c.url)).toBe('http://stt.local/v1/audio/transcriptions');
-		const auth = (c.init?.headers as Record<string, string>)?.['authorization'];
+		const auth = (c.init?.headers as Record<string, string>)?.authorization;
 		expect(auth).toBeUndefined();
 
 		const sentBody = c.init?.body as FormData;
@@ -155,7 +155,7 @@ describe('POST /api/transcribe', () => {
 		process.env.OP_STT_API_KEY = 'sk-secret-12345';
 		let capturedAuth: string | undefined;
 		fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(async (_url, init) => {
-			capturedAuth = (init?.headers as Record<string, string>)?.['authorization'];
+			capturedAuth = (init?.headers as Record<string, string>)?.authorization;
 			return new Response(JSON.stringify({ text: 'ok' }), {
 				status: 200,
 				headers: { 'content-type': 'application/json' },

--- a/packages/ui/src/routes/proxy/assistant/[...path]/+server.ts
+++ b/packages/ui/src/routes/proxy/assistant/[...path]/+server.ts
@@ -36,7 +36,7 @@ function buildForwardHeaders(
     // local) with `"openpalm"`, so that's our fallback when the endpoint
     // entry doesn't specify one.
     const user = username || 'openpalm';
-    headers['authorization'] = `Basic ${btoa(`${user}:${password}`)}`;
+    headers.authorization = `Basic ${btoa(`${user}:${password}`)}`;
   }
   return headers;
 }

--- a/packages/ui/src/routes/proxy/assistant/[...path]/server.vitest.ts
+++ b/packages/ui/src/routes/proxy/assistant/[...path]/server.vitest.ts
@@ -40,7 +40,7 @@ beforeEach(async () => {
   _seedSession('test-admin-token');
 
   // Stand up an SSE emitter that writes 4 chunks with 80ms gaps between them.
-  sseServer = createServer((req, res) => {
+  sseServer = createServer((_req, res) => {
     res.writeHead(200, {
       'content-type': 'text/event-stream',
       'cache-control': 'no-cache',

--- a/packages/ui/src/test-setup-isolation.ts
+++ b/packages/ui/src/test-setup-isolation.ts
@@ -39,10 +39,10 @@ const FORBIDDEN: string[] = [
 function isForbidden(p: string): boolean {
   try {
     const real = realpathSync(p);
-    return FORBIDDEN.some((f) => real === f || real.startsWith(f + "/"));
+    return FORBIDDEN.some((f) => real === f || real.startsWith(`${f}/`));
   } catch {
     // Path doesn't exist yet — check the string form
-    return FORBIDDEN.some((f) => p === f || p.startsWith(f + "/"));
+    return FORBIDDEN.some((f) => p === f || p.startsWith(`${f}/`));
   }
 }
 

--- a/portals/discord/src/index.test.ts
+++ b/portals/discord/src/index.test.ts
@@ -454,7 +454,6 @@ describe("parseCustomCommands", () => {
     }]);
     const commands = parseCustomCommands(json);
     expect(commands.length).toBe(1);
-    // biome-ignore lint/style/noNonNullAssertion: parsed command is asserted to have options
     const opts = commands[0].options!;
     expect(opts.length).toBe(4);
     expect(opts[0].type).toBe(CommandOptionType.STRING);
@@ -1099,7 +1098,6 @@ describe("command validation edge cases", () => {
     }]);
     const commands = parseCustomCommands(json);
     expect(commands.length).toBe(1);
-    // biome-ignore lint/style/noNonNullAssertion: parsed command is asserted to have a promptTemplate
     const resolved = resolvePromptTemplate(commands[0].promptTemplate!, { text: "hello", lang: "Spanish" });
     expect(resolved).toBe("Translate 'hello' to Spanish");
   });
@@ -1124,7 +1122,6 @@ describe("full command flow", () => {
     expect(cmd).toBeDefined();
     expect(cmd?.promptTemplate).toBeDefined();
 
-    // biome-ignore lint/style/noNonNullAssertion: cmd and its promptTemplate are asserted defined above
     const prompt = resolvePromptTemplate(cmd!.promptTemplate!, { topic: "recursion" });
     expect(prompt).toBe("Explain recursion in simple terms");
   });

--- a/portals/discord/src/index.test.ts
+++ b/portals/discord/src/index.test.ts
@@ -454,6 +454,7 @@ describe("parseCustomCommands", () => {
     }]);
     const commands = parseCustomCommands(json);
     expect(commands.length).toBe(1);
+    // biome-ignore lint/style/noNonNullAssertion: parsed command is asserted to have options
     const opts = commands[0].options!;
     expect(opts.length).toBe(4);
     expect(opts[0].type).toBe(CommandOptionType.STRING);
@@ -478,8 +479,8 @@ describe("parseCustomCommands", () => {
       }],
     }]);
     const commands = parseCustomCommands(json);
-    expect(commands[0].options![0].choices?.length).toBe(2);
-    expect(commands[0].options![0].choices![0].name).toBe("Red");
+    expect(commands[0].options?.[0].choices?.length).toBe(2);
+    expect(commands[0].options?.[0].choices?.[0].name).toBe("Red");
   });
 
   it("limits choices to 25", () => {
@@ -490,7 +491,7 @@ describe("parseCustomCommands", () => {
       options: [{ name: "opt", description: "Pick", type: 3, choices }],
     }]);
     const commands = parseCustomCommands(json);
-    expect(commands[0].options![0].choices?.length).toBe(25);
+    expect(commands[0].options?.[0].choices?.length).toBe(25);
   });
 });
 
@@ -525,10 +526,10 @@ describe("buildCommandRegistry", () => {
     const { registrationPayload } = buildCommandRegistry([]);
     const ask = registrationPayload.find((c) => c.name === "ask");
     expect(ask).toBeDefined();
-    expect(ask!.options).toBeDefined();
-    expect(ask!.options!.length).toBeGreaterThan(0);
-    expect(ask!.options![0].name).toBe("message");
-    expect(ask!.options![0].required).toBe(true);
+    expect(ask?.options).toBeDefined();
+    expect(ask?.options?.length).toBeGreaterThan(0);
+    expect(ask?.options?.[0].name).toBe("message");
+    expect(ask?.options?.[0].required).toBe(true);
   });
 
   it("builtin commands: ask, health, help, clear", () => {
@@ -929,7 +930,6 @@ describe("thread TTL tracking", () => {
     // Set a very short TTL for testing
     Object.assign(channel, { threadTtlMs: 1 });
 
-    const touch = (channel as unknown as { touchThread: (id: string) => void }).touchThread;
     const isActive = (channel as unknown as { isThreadActive: (id: string) => boolean }).isThreadActive;
     const activeThreads = (channel as unknown as { activeThreads: Map<string, number> }).activeThreads;
 
@@ -1084,7 +1084,7 @@ describe("command validation edge cases", () => {
       }],
     }]);
     const commands = parseCustomCommands(json);
-    expect(commands[0].options![0].choices?.length).toBe(2);
+    expect(commands[0].options?.[0].choices?.length).toBe(2);
   });
 
   it("handles command with promptTemplate containing multiple variables", () => {
@@ -1099,6 +1099,7 @@ describe("command validation edge cases", () => {
     }]);
     const commands = parseCustomCommands(json);
     expect(commands.length).toBe(1);
+    // biome-ignore lint/style/noNonNullAssertion: parsed command is asserted to have a promptTemplate
     const resolved = resolvePromptTemplate(commands[0].promptTemplate!, { text: "hello", lang: "Spanish" });
     expect(resolved).toBe("Translate 'hello' to Spanish");
   });
@@ -1121,8 +1122,9 @@ describe("full command flow", () => {
     const { all } = buildCommandRegistry(custom);
     const cmd = findCommand(all, "explain");
     expect(cmd).toBeDefined();
-    expect(cmd!.promptTemplate).toBeDefined();
+    expect(cmd?.promptTemplate).toBeDefined();
 
+    // biome-ignore lint/style/noNonNullAssertion: cmd and its promptTemplate are asserted defined above
     const prompt = resolvePromptTemplate(cmd!.promptTemplate!, { topic: "recursion" });
     expect(prompt).toBe("Explain recursion in simple terms");
   });
@@ -1131,24 +1133,24 @@ describe("full command flow", () => {
     const { all } = buildCommandRegistry([]);
     const ask = findCommand(all, "ask");
     expect(ask).toBeDefined();
-    expect(ask!.options).toBeDefined();
-    const msgOpt = ask!.options!.find((o) => o.name === "message");
+    expect(ask?.options).toBeDefined();
+    const msgOpt = ask?.options?.find((o) => o.name === "message");
     expect(msgOpt).toBeDefined();
-    expect(msgOpt!.required).toBe(true);
-    expect(msgOpt!.type).toBe(CommandOptionType.STRING);
+    expect(msgOpt?.required).toBe(true);
+    expect(msgOpt?.type).toBe(CommandOptionType.STRING);
   });
 
   it("ephemeral builtins: health, help, clear", () => {
     for (const name of ["health", "help", "clear"]) {
       const cmd = findCommand(BUILTIN_COMMANDS, name);
       expect(cmd).toBeDefined();
-      expect(cmd!.ephemeral).toBe(true);
+      expect(cmd?.ephemeral).toBe(true);
     }
   });
 
   it("ask command is not ephemeral", () => {
     const ask = findCommand(BUILTIN_COMMANDS, "ask");
     expect(ask).toBeDefined();
-    expect(ask!.ephemeral).toBeFalsy();
+    expect(ask?.ephemeral).toBeFalsy();
   });
 });

--- a/portals/discord/src/oc-event-hub.ts
+++ b/portals/discord/src/oc-event-hub.ts
@@ -19,7 +19,7 @@
  * gaps without churning opens). If the upstream errors/closes, all subscribers
  * are ended so their turns finalize, and the next subscribe reopens.
  */
-import { OcClient } from '@openpalm/portal-sdk';
+import type { OcClient } from '@openpalm/portal-sdk';
 
 /** Grace period to keep the upstream open after the last turn unsubscribes, so
  * back-to-back turns in a thread don't churn open/close (and re-pay the 429

--- a/portals/discord/src/stream-render.test.ts
+++ b/portals/discord/src/stream-render.test.ts
@@ -71,17 +71,17 @@ describe("extractToolUpdate — colored by state.status (§4.1)", () => {
       SID,
     );
     expect(t).not.toBeNull();
-    expect(t!.callID).toBe("c1");
-    expect(t!.tool).toBe("bash");
-    expect(t!.status).toBe("running");
-    expect(t!.title).toBe("echo hi");
+    expect(t?.callID).toBe("c1");
+    expect(t?.tool).toBe("bash");
+    expect(t?.status).toBe("running");
+    expect(t?.title).toBe("echo hi");
   });
 
   test("session.next.tool.called yields a running update", () => {
     const t = extractToolUpdate(ev("session.next.tool.called", { sessionID: SID, callID: "c2", tool: "edit" }), SID);
     expect(t).not.toBeNull();
-    expect(t!.callID).toBe("c2");
-    expect(t!.status).toBe("running");
+    expect(t?.callID).toBe("c2");
+    expect(t?.status).toBe("running");
   });
 
   test("a tool update for a foreign session is ignored", () => {
@@ -104,9 +104,9 @@ describe("extractPermissionAsk — surfaces requestID for our session (§4.1)", 
       SID,
     );
     expect(ask).not.toBeNull();
-    expect(ask!.requestID).toBe("per_1");
-    expect(ask!.permission).toBe("bash");
-    expect(ask!.patterns).toEqual(["echo *"]);
+    expect(ask?.requestID).toBe("per_1");
+    expect(ask?.permission).toBe("bash");
+    expect(ask?.patterns).toEqual(["echo *"]);
   });
 
   test("permission.asked for a foreign session is ignored", () => {

--- a/portals/slack/src/index.test.ts
+++ b/portals/slack/src/index.test.ts
@@ -5,7 +5,7 @@ import { join } from "node:path";
 import SlackChannel, { DEFAULT_FORWARD_TIMEOUT_MS, parseForwardTimeoutMs } from "./index.ts";
 import { checkPermissions, loadPermissionConfig, parseIdList } from "./permissions.ts";
 import { ConversationQueue } from '@openpalm/portal-sdk';
-import type { PermissionConfig, PermissionResult, UserInfo } from "./types.ts";
+import type { PermissionConfig, UserInfo } from "./types.ts";
 
 // ── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -1418,7 +1418,7 @@ describe("runConversation", () => {
     const client = createMockClient();
     // First postMessage (thinking) fails, second (response) succeeds
     let callCount = 0;
-    client.chat.postMessage = mock(async (args: Record<string, unknown>) => {
+    client.chat.postMessage = mock(async (_args: Record<string, unknown>) => {
       callCount++;
       if (callCount === 1) throw new Error("no permission");
       return { ts: "1234567890.123456" };

--- a/portals/slack/src/index.ts
+++ b/portals/slack/src/index.ts
@@ -264,7 +264,6 @@ export default class SlackChannel extends BasePortal {
         : `slack:channel:${event.channel}:user:${event.user}`;
 
     if (inTrackedThread) {
-      // biome-ignore lint/style/noNonNullAssertion: inTrackedThread implies event.thread_ts != null
       this.touchThread(event.channel, event.thread_ts!);
     }
 

--- a/portals/slack/src/index.ts
+++ b/portals/slack/src/index.ts
@@ -264,6 +264,7 @@ export default class SlackChannel extends BasePortal {
         : `slack:channel:${event.channel}:user:${event.user}`;
 
     if (inTrackedThread) {
+      // biome-ignore lint/style/noNonNullAssertion: inTrackedThread implies event.thread_ts != null
       this.touchThread(event.channel, event.thread_ts!);
     }
 

--- a/portals/slack/src/stream-render.test.ts
+++ b/portals/slack/src/stream-render.test.ts
@@ -26,6 +26,11 @@ import {
 } from "./stream-render.ts";
 import type { OcClient } from '@openpalm/portal-sdk';
 
+// Structural shape of the Block Kit JSON the builders emit — enough to assert on
+// in these tests (the builders themselves are typed `unknown[]`).
+type KitEl = { action_id?: string; value?: string; text?: string };
+type KitBlock = { type?: string; text?: { text?: string }; elements?: KitEl[] };
+
 // A hand-written OcClient stub recording the calls the registry makes.
 function stubClient(): { client: OcClient; replies: Array<{ userId: string; requestID: string; reply: string }>; aborts: Array<{ userId: string; sessionId: string }>; fail?: boolean } {
   const replies: Array<{ userId: string; requestID: string; reply: string }> = [];
@@ -46,15 +51,15 @@ function stubClient(): { client: OcClient; replies: Array<{ userId: string; requ
 
 describe("buildPermissionBlocks — buttons route by value (§4.3)", () => {
   test("each button carries the requestID in value", () => {
-    const blocks = buildPermissionBlocks({ requestID: "per_9", permission: "bash", patterns: ["echo *"] }) as any[];
+    const blocks = buildPermissionBlocks({ requestID: "per_9", permission: "bash", patterns: ["echo *"] }) as KitBlock[];
     const actions = blocks.find((b) => b.type === "actions");
-    const ids = actions.elements.map((e: any) => e.action_id);
+    const ids = actions.elements.map((e: KitEl) => e.action_id);
     expect(ids).toEqual([ACTION_PERM_ONCE, ACTION_PERM_ALWAYS, ACTION_PERM_DENY]);
     for (const el of actions.elements) expect(el.value).toBe("per_9");
   });
 
   test("the prompt section names the permission + patterns", () => {
-    const blocks = buildPermissionBlocks({ requestID: "per_1", permission: "bash", patterns: ["echo *"] }) as any[];
+    const blocks = buildPermissionBlocks({ requestID: "per_1", permission: "bash", patterns: ["echo *"] }) as KitBlock[];
     expect(blocks[0].text.text).toContain("bash");
     expect(blocks[0].text.text).toContain("echo *");
   });
@@ -62,7 +67,7 @@ describe("buildPermissionBlocks — buttons route by value (§4.3)", () => {
 
 describe("buildAnswerBlocks — Stop button carries the sessionId", () => {
   test("stop button value is the sessionId", () => {
-    const blocks = buildAnswerBlocks("hello", "ses_42") as any[];
+    const blocks = buildAnswerBlocks("hello", "ses_42") as KitBlock[];
     const actions = blocks.find((b) => b.type === "actions");
     expect(actions.elements[0].value).toBe("ses_42");
   });
@@ -70,7 +75,7 @@ describe("buildAnswerBlocks — Stop button carries the sessionId", () => {
 
 describe("buildToolBlocks — context block names the tool + status", () => {
   test("renders tool + status", () => {
-    const blocks = buildToolBlocks({ callID: "c1", tool: "bash", status: "running", title: "echo hi" }) as any[];
+    const blocks = buildToolBlocks({ callID: "c1", tool: "bash", status: "running", title: "echo hi" }) as KitBlock[];
     expect(blocks[0].type).toBe("context");
     expect(blocks[0].elements[0].text).toContain("bash");
     expect(blocks[0].elements[0].text).toContain("echo hi");
@@ -80,7 +85,7 @@ describe("buildToolBlocks — context block names the tool + status", () => {
     // Regression: a tool frame with empty status/title must not yield empty text.
     // The Discord equivalent (empty footer/description) threw shapeshift's
     // "Received one or more errors" and aborted the whole turn.
-    const blocks = buildToolBlocks({ callID: "c1", tool: "", status: "", title: "" }) as any[];
+    const blocks = buildToolBlocks({ callID: "c1", tool: "", status: "", title: "" }) as KitBlock[];
     const text = blocks[0].elements[0].text as string;
     expect(text.length).toBeGreaterThan(0);
     expect(text).toContain("tool"); // name fallback
@@ -97,7 +102,7 @@ describe("SlackPermissionRegistry — interaction identity + reply relay (§4.3)
     const out = await reg.handlePermissionClick("per_1", ACTION_PERM_ONCE, "U1");
     expect(out).not.toBeNull();
     expect(replies).toEqual([{ userId: "slack:U1", requestID: "per_1", reply: "once" }]);
-    expect(out!.text).toContain("once");
+    expect(out?.text).toContain("once");
   });
 
   test("Always → reply:always; Deny → reply:reject", async () => {
@@ -139,7 +144,7 @@ describe("SlackPermissionRegistry — interaction identity + reply relay (§4.3)
     reg.registerPermission("per_1", { userId: "slack:U1", requestingUserId: "U1", permission: "bash", channel: "C1", ts: "1.1" });
     const out = await reg.handlePermissionClick("per_1", ACTION_PERM_ONCE, "U1");
     expect(out).not.toBeNull();
-    expect(out!.text).toContain("Could not record");
+    expect(out?.text).toContain("Could not record");
     // second click finds nothing (entry cleared)
     expect(await reg.handlePermissionClick("per_1", ACTION_PERM_ONCE, "U1")).toBeNull();
     expect(replies).toHaveLength(0);

--- a/scripts/bump-unit.mjs
+++ b/scripts/bump-unit.mjs
@@ -140,7 +140,7 @@ function stampSetupScripts(version) {
 
 function stampVersionFile(file, version) {
   if (!existsSync(file)) throw new Error(`Cannot stamp: file not found: ${file}`);
-  writeFileSync(file, version + '\n');
+  writeFileSync(file, `${version}\n`);
   console.log(`  ${file} → ${version}`);
 }
 
@@ -232,11 +232,11 @@ if (unit === 'images') {
   newVersion = currentVersion;
   console.log(`images: using current platform version ${newVersion} (no bump; use version override for a new tag)`);
   if (out) {
-    appendFileSync(out, [
+    appendFileSync(out, `${[
       `current_version=${currentVersion}`,
       `new_version=${newVersion}`,
       `tag_prefix=images`,
-    ].join('\n') + '\n');
+    ].join('\n')}\n`);
   }
 } else if (unit === 'all') {
   // All-units release: stamp every unit to the same version using the specified bump type.
@@ -261,12 +261,12 @@ if (unit === 'images') {
   // Emit per-unit tag list for the all-units release job
   const allTags = Object.keys(UNITS).filter(n => n !== 'images').map(n => `${n}-${newVersion}`);
   if (out) {
-    appendFileSync(out, [
+    appendFileSync(out, `${[
       `current_version=${currentVersion}`,
       `new_version=${newVersion}`,
       `tag_prefix=all`,
       `all_tags=${JSON.stringify(allTags)}`,
-    ].join('\n') + '\n');
+    ].join('\n')}\n`);
   }
 } else {
   const cfg = UNITS[unit];
@@ -283,11 +283,11 @@ if (unit === 'images') {
     console.log('  (STAMP=false — preview only)');
   }
   if (out) {
-    appendFileSync(out, [
+    appendFileSync(out, `${[
       `current_version=${currentVersion}`,
       `new_version=${newVersion}`,
       `tag_prefix=${unit}`,
-    ].join('\n') + '\n');
+    ].join('\n')}\n`);
   }
 }
 

--- a/scripts/oc-e2e.ts
+++ b/scripts/oc-e2e.ts
@@ -59,7 +59,7 @@ while (Date.now() < deadline) {
     const d = extractTextDelta(e, session.id, reasoningParts);
     if (d) { text += d; continue; }
     const t = extractToolUpdate(e, session.id);
-    if (t && t.callID) { tool = `${t.tool}:${t.status}`; continue; }
+    if (t?.callID) { tool = `${t.tool}:${t.status}`; continue; }
     const ask = extractPermissionAsk(e, session.id);
     if (ask && expectTool && !permissionReplied) {
       log("permission.asked:", JSON.stringify(ask));

--- a/scripts/set-version.mjs
+++ b/scripts/set-version.mjs
@@ -38,7 +38,7 @@ export function setVersion(file, version) {
       pkg[field]['@openpalm/skeleton'] = version;
     }
   }
-  writeFileSync(file, JSON.stringify(pkg, null, 2) + '\n');
+  writeFileSync(file, `${JSON.stringify(pkg, null, 2)}\n`);
   return version;
 }
 

--- a/scripts/set-version.test.ts
+++ b/scripts/set-version.test.ts
@@ -19,7 +19,11 @@ type Pkg = {
   peerDependencies: Record<string, string>;
 };
 function read(f: string): Pkg {
-  return JSON.parse(readFileSync(f, "utf-8"));
+  // Normalize missing maps to {} so the return value actually matches Pkg at
+  // runtime (a package.json may omit dependencies/peerDependencies); keeps the
+  // type sound for tests that read those keys.
+  const raw = JSON.parse(readFileSync(f, "utf-8")) as Pkg;
+  return { dependencies: {}, peerDependencies: {}, ...raw };
 }
 
 describe("set-version", () => {

--- a/scripts/set-version.test.ts
+++ b/scripts/set-version.test.ts
@@ -10,10 +10,15 @@ afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
 
 function write(pkg: unknown): string {
   const f = join(dir, "package.json");
-  writeFileSync(f, JSON.stringify(pkg, null, 2) + "\n");
+  writeFileSync(f, `${JSON.stringify(pkg, null, 2)}\n`);
   return f;
 }
-function read(f: string): any {
+type Pkg = {
+  version: string;
+  dependencies: Record<string, string>;
+  peerDependencies: Record<string, string>;
+};
+function read(f: string): Pkg {
   return JSON.parse(readFileSync(f, "utf-8"));
 }
 

--- a/scripts/test-isolate-op-home.ts
+++ b/scripts/test-isolate-op-home.ts
@@ -42,9 +42,9 @@ const FORBIDDEN: string[] = [
 function isForbidden(p: string): boolean {
   try {
     const real = realpathSync(p);
-    return FORBIDDEN.some((f) => real === f || real.startsWith(f + "/"));
+    return FORBIDDEN.some((f) => real === f || real.startsWith(`${f}/`));
   } catch {
-    return FORBIDDEN.some((f) => p === f || p.startsWith(f + "/"));
+    return FORBIDDEN.some((f) => p === f || p.startsWith(`${f}/`));
   }
 }
 


### PR DESCRIPTION
## Summary

Follow-up to the code-quality PR (#543). Drives the repo's Biome lint warnings from **1,448 → 0**, behavior-preserving, and closes the remaining self-contained tech debt. `bun run lint` is now clean (1 informational Biome self-deprecation notice remains).

The headline number was mostly noise; diagnosing that was the key step:

- **~1,062 were `.svelte` false positives.** Biome parses the `<script>` block but not the Svelte template, so template-referenced vars/imports were mis-flagged as unused (verified: e.g. `loading` used 8× in one component). Deleting them would break the UI. Fixed by **excluding `.svelte` from Biome** — Svelte is already linted correctly by `svelte-check` + `eslint-plugin-svelte`; Biome owns the `.ts`/`.js`/`.json` surface.
- **258 were idiomatic/intentional**, resolved as documented rule policy in `biome.jsonc`:
  - `noNonNullAssertion` **off** — `!` is deliberate TypeScript across ~234 already-narrowed sites; strict null checks remain the real gate.
  - `noTemplateCurlyInString` **off** — every hit is a test/fixture asserting on a literal `${VAR}` Docker-Compose / env-substitution string.
- **Safe Biome auto-fixes** applied (`useOptionalChain`, `useImportType`, `useArrowFunction`, `useConst`, `useBiomeIgnoreFolder`, safe unused-import removal).
- **The remaining ~88 genuinely-actionable `.ts` warnings** (dead imports/vars, `any`-types, `useOptionalChain`, `isNaN`→`Number.isNaN`, misc) were fixed per-package.
- **Edge cases:** excluded `docs/providers.json` (4.3 MiB data blob over Biome's size limit); suppressed the intentional `100vh`/`100dvh` progressive-enhancement `min-height` fallback in `app.css`; converted one `window.matchMedia && …` to optional chaining in `app.html`.

## Tech debt closed alongside

- Hardened the setup-state `reset()` test to a **full-store `toEqual` snapshot** (was asserting ~21 of 51 fields).
- Deduped default UI/assistant **port constants** in CLI and Electron (named consts instead of inline magic numbers).
- Refreshed the **stale portal Dockerfile-bake test** — it asserted a `COPY portals/discord` shape that no longer exists (adapters now install from npm).

## Testing

Per-package suites all green (same documented pre-existing environmental failures only — root-uid ownership tests, one IPv6 guardian bind; the sandbox runs as uid 0):

- guardian 190 pass / 1 pre-existing · lib 723 / 12 pre-existing · cli 71 / 1 pre-existing · electron 75/75 · portals+SDK+containers 287/0 (includes the refreshed bake test) · UI vitest 557 pass · `svelte-check` 0 errors.
- `bun run lint` → **0 warnings**. Zero behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NDPRjdj7sQejNRahQZdubh)_