### PR TITLE
Cleanup: resolve non-null assertions, fold setup prop-drilling, sweep stale docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,7 +32,7 @@ See [`docs/technical/core-principles.md`](docs/technical/core-principles.md) for
 - **Lib** (`packages/lib/`) — Shared control-plane library (`@openpalm/lib`). All portable lifecycle, staging, secrets, portal discovery, connections, scheduler logic. Both CLI and UI import from this package.
 - **CLI** (`packages/cli/`) — Host-side orchestrator. Manages Docker Compose directly. Serves setup wizard during install. Self-sufficient without UI.
 - **UI** (`packages/ui/`) — SvelteKit app: operator web UI + API. Served as a host process by `openpalm ui serve` (no container). Accesses Docker socket directly on the host.
-- **Guardian** (`containers/guardian/`) — Bun HTTP server: principal auth, allowlisted `/oc/*` proxying, ownership checks, rate limiting, and opt-in fail-closed content validation of inbound messages (`GUARDIAN_CONTENT_VALIDATION`, off by default).
+- **Guardian** (`packages/guardian/`, `@openpalm/guardian`; image build assets in `containers/guardian/`) — Bun HTTP server: principal auth, allowlisted `/oc/*` proxying, ownership checks, rate limiting, and opt-in fail-closed content validation of inbound messages (`GUARDIAN_CONTENT_VALIDATION`, off by default).
 - **Assistant** (`containers/assistant/`) — OpenCode runtime with tools/skills. No Docker socket and no admin network path. When UI is absent, only the akm-backed memory/knowledge tools are available. Memory/skills/lessons are served by the akm CLI (akm-opencode plugin) via a shared akm stash bind-mounted from `~/.openpalm/knowledge/`.
 - **Scheduler** — OS cron daemon (`crond`) started by the assistant container entrypoint. No network port. Automations are AKM YAML task files (`*.yml`) in `knowledge/tasks/`; `akm tasks sync` registers them with cron at container startup and re-syncs every 60 s to pick up new files.
 - **Portal runtime** (`containers/portal/`) — Unified `portal` image build for baked first-party adapters.
@@ -52,7 +52,7 @@ npm run build                                       # Production build
 npm run check                                       # svelte-check + TypeScript
 
 # Guardian (Bun)
-cd containers/guardian && bun install && bun run src/server.ts
+cd packages/guardian && bun install && bun run src/server.ts
 
 # Root shortcuts
 bun run ui:dev     # Runs UI dev from root
@@ -85,7 +85,7 @@ The project has ~100 test files across all packages using Bun test, Vitest, and 
 | Runner | Command | Scope |
 |--------|---------|-------|
 | `bun test` (root) | `bun run test` | guardian, cli, all portal packages (excludes ui) |
-| `bun test` (guardian) | `bun run guardian:test` | containers/guardian security tests |
+| `bun test` (guardian) | `bun run guardian:test` | packages/guardian security tests |
 | `bun test` (cli) | `bun run cli:test` | packages/cli tests |
 | Vitest (UI) | `bun run ui:test:unit` | packages/ui unit + browser component tests |
 | Playwright (UI integration) | `bun run ui:test:e2e` | packages/ui integration tests (no browser route mocks) |
@@ -95,10 +95,10 @@ The project has ~100 test files across all packages using Bun test, Vitest, and 
 
 ```bash
 # Run guardian tests
-cd containers/guardian && bun test
+cd packages/guardian && bun test
 
 # Run a single test file
-cd containers/guardian && bun test src/server.test.ts
+cd packages/guardian && bun test src/server.test.ts
 
 # Run UI unit tests (Vitest, CI-friendly)
 bun run ui:test:unit
@@ -204,7 +204,11 @@ Read these before making significant changes. They are the authoritative sources
 
 ### Formatting
 
-No Prettier or ESLint configured. Match the existing file style:
+Biome is configured repo-wide (`biome.jsonc`) and enforced by a CI gate
+(`.github/workflows/lint.yml`). Run `bun run lint` (or `bun run lint:fix` /
+`bun run format`) before committing. `.svelte` files are excluded from Biome —
+they are linted by `svelte-check` + `eslint-plugin-svelte` in `packages/ui`.
+Match the existing file style:
 - 2-space indentation
 - Single quotes in JS/TS, double quotes in JSON
 - Trailing commas in multi-line arrays/objects
@@ -286,11 +290,11 @@ Before submitting any change:
 | `packages/ui/src/lib/server/helpers.ts` | Shared request/response utilities |
 | `packages/ui/src/lib/types.ts` | Shared TypeScript types |
 | `packages/ui/src/lib/auth.ts` | Auth utilities |
-| `packages/ui/src/lib/api.ts` | API call functions |
+| `packages/ui/src/lib/api.ts` | Barrel re-exporting the per-domain admin API clients in `packages/ui/src/lib/api/*` (`core`, `chat`, `voice`, `versions`, `akm`, …) |
 | `packages/cli/src/lib/cli-state.ts` | CLI state helpers (ensureValidState) |
 | `packages/cli/src/commands/install.ts` | CLI install (setup wizard + compose up) |
-| `containers/guardian/src/server.ts` | HMAC-signed message guardian |
-| `containers/guardian/src/logger.ts` | Guardian-local logger (createLogger factory) |
+| `packages/guardian/src/server.ts` | HMAC-signed message guardian (`@openpalm/guardian`; `containers/guardian/` holds only the Dockerfile + entrypoint) |
+| `packages/guardian/src/logger.ts` | Guardian-local logger (createLogger factory) |
 | `.openpalm/config/stack/core.compose.yml` | Core service definitions (assistant + guardian) |
 | `.openpalm/config/stack/` | Fixed stack compose files and enabled-addon state |
 | `.opencode/opencode.json` | OpenCode project configuration |

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -42,7 +42,8 @@
   "linter": {
     "enabled": true,
     "rules": {
-      "recommended": true,
+      // The recommended preset is Biome's default when the linter is enabled, so it
+      // is not set explicitly (the old `recommended: true` field is deprecated).
       "suspicious": {
         // Downgraded error -> warn: each already fires on existing source, so keeping
         // them as errors would fail the gate on legacy code. They stay visible as
@@ -57,11 +58,11 @@
         "noTemplateCurlyInString": "off"
       },
       "style": {
-        // Off: non-null assertions (`x!`) are idiomatic, deliberate TypeScript used
-        // throughout this codebase (~234 sites) where the author has already narrowed
-        // the value. Mechanically rewriting each to a runtime guard would add noise and
-        // risk with no correctness benefit; TS's strict null checks remain the real gate.
-        "noNonNullAssertion": "off"
+        // Warn (enforced-visible, non-gating): non-null assertions are addressed
+        // per-site — converted to optional chaining / guards where that is a genuine,
+        // behavior-preserving improvement, and kept with a documented `biome-ignore`
+        // where `x!` is a deliberate, correct invariant. New violations stay visible.
+        "noNonNullAssertion": "warn"
       }
     }
   },

--- a/containers/guardian/README.md
+++ b/containers/guardian/README.md
@@ -1,5 +1,8 @@
 # containers/guardian — Message Guardian
 
+> Source code lives in the `@openpalm/guardian` workspace at `packages/guardian/`.
+> This directory holds only the image build assets (Dockerfile, entrypoint, baked tools).
+
 Bun HTTP server that acts as the security checkpoint for all inbound portal traffic. Every first-party portal adapter and direct MCP/API ingress path passes through the guardian before reaching the assistant.
 
 The image also ships the OpenCode binary (pinned to the same `OPENCODE_VERSION` as the assistant). Guardian-side OpenCode instances read their global config from `/etc/opencode` (bind-mounted from `OP_HOME/config/guardian`, set via `OPENCODE_CONFIG_DIR`) and share provider credentials with the assistant through the read-only `auth.json` mount (from `OP_HOME/knowledge/secrets/auth.json`).
@@ -24,7 +27,7 @@ that it is *safe*. When `GUARDIAN_CONTENT_VALIDATION` is enabled, step 6 adds a
 semantic layer that inspects what the message is actually trying to do, using a
 local OpenCode moderator. It is layered cheap → expensive:
 
-- **Heuristic pre-screen** (`containers/guardian/src/content-screen.ts`): pure,
+- **Heuristic pre-screen** (`packages/guardian/src/content-screen.ts`): pure,
   in-process pattern matching that scores prompt-injection / jailbreak /
   exfiltration / obfuscation signals. Most traffic scores 0 and is forwarded
   without ever touching a model.
@@ -71,7 +74,7 @@ contract live in `config/guardian/instructions/moderation.md`.
 ## Development
 
 ```bash
-bun run src/server.ts
+cd packages/guardian && bun run src/server.ts
 ```
 
 Or from the repo root:
@@ -84,5 +87,5 @@ bun run guardian:test
 ## Testing
 
 ```bash
-cd containers/guardian && bun test
+cd packages/guardian && bun test
 ```

--- a/docs/portals/community-portals.md
+++ b/docs/portals/community-portals.md
@@ -58,7 +58,7 @@ policy, Basic-auth `/oc/*` calls, and session/stream behavior.
 
 ## Built-in examples
 
-- `containers/guardian/src/openai-api.ts` (guardian-hosted OpenAI-compatible API)
+- `packages/guardian/src/openai-api.ts` (guardian-hosted OpenAI-compatible API)
 - `portals/discord/README.md`
 - `portals/slack/README.md`
 

--- a/docs/technical/core-principles.md
+++ b/docs/technical/core-principles.md
@@ -261,7 +261,7 @@ This ensures each service's local runtime dependencies are available at runtime.
 **Rules:**
 
 - Every Dockerfile that bakes a service from the workspace must install that service's declared runtime dependencies during the image build.
-- Guardian-local helpers stay in `containers/guardian/src/`; adapter-local helpers stay inside the adapter package that uses them.
+- Guardian-local helpers stay in `packages/guardian/src/` (`@openpalm/guardian`); adapter-local helpers stay inside the adapter package that uses them.
 - The assistant **and the guardian** images install the OpenCode binary (the guardian uses it for content validation). Keep `OPENCODE_VERSION` in lockstep between `containers/assistant/Dockerfile` and `containers/guardian/Dockerfile`.
 
 ---

--- a/docs/technical/foundations.md
+++ b/docs/technical/foundations.md
@@ -174,8 +174,8 @@ Field length validation is enforced by the active guardian and portal runtime re
 
 Content validation (opt-in, off by default):
 
-- The limits above are *structural* — they confirm a message is well-formed and signed, not that it is safe. When `GUARDIAN_CONTENT_VALIDATION` is enabled, the guardian adds a semantic stage before forwarding (`containers/guardian/src/moderation.ts`).
-- A deterministic heuristic pre-screen (`containers/guardian/src/content-screen.ts`) scores prompt-injection / jailbreak / exfiltration / obfuscation signals. Clean traffic (score 0) forwards without touching a model.
+- The limits above are *structural* — they confirm a message is well-formed and signed, not that it is safe. When `GUARDIAN_CONTENT_VALIDATION` is enabled, the guardian adds a semantic stage before forwarding (`packages/guardian/src/moderation.ts`).
+- A deterministic heuristic pre-screen (`packages/guardian/src/content-screen.ts`) scores prompt-injection / jailbreak / exfiltration / obfuscation signals. Clean traffic (score 0) forwards without touching a model.
 - Messages over `GUARDIAN_MODERATION_THRESHOLD` escalate to the guardian's local OpenCode moderator (loopback `:4097`, started by the guardian entrypoint, small model pinned in `config/guardian/opencode.jsonc`, shared `auth.json` provider creds), which returns an allow/flag/block JSON verdict.
 - **Fail-closed:** an escalated message the moderator cannot classify (down, timeout, unparseable) is blocked (`403 content_blocked`). The taxonomy + output contract live in `config/guardian/instructions/moderation.md`.
 

--- a/docs/technical/portal-rich-ux-design.md
+++ b/docs/technical/portal-rich-ux-design.md
@@ -1,6 +1,6 @@
 # Portal Rich-UX Design — Guardian as a Filtering OpenCode Proxy
 
-**Status:** Design / validation (pre-implementation). Incorporates a three-perspective expert review (security, OpenPalm architecture, OpenCode-API correctness); §11 records what changed.
+**Status:** Implemented (historical design record). The guardian proxy fan-out and the shared portal renderers described here have shipped — the shared code now lives in the `@openpalm/portal-sdk` package (`packages/portal-sdk/`: `oc-events.ts`, `render-turn.ts`, `OcClient`, `BasePortal`). Incorporates a three-perspective expert review (security, OpenPalm architecture, OpenCode-API correctness); §11 records what changed. File/line citations below reflect the pre-implementation tree and may no longer resolve.
 **Scope:** Give portal conversations (Discord first, then Slack, the API portal, and future add-ons) the native OpenCode experience — live streaming output, tool-call visibility, and **interactive permission prompts** — by making the guardian a **transparent OpenCode API reverse proxy with security gates that short-circuit malicious requests**, rather than inventing a custom portal contract.
 **Audience:** Implementers of the guardian proxy and the portal renderers, and reviewers of the security posture.
 
@@ -177,7 +177,7 @@ Everything else denied. Dedicated deny-tests: `/shell`, `/pty`, `/share`, `/fork
 
 ### 3.4 Session- and permission-ownership authorization
 
-- **Session create rewrites the body (security review F5a):** on `POST /session` the guardian **constructs** the body itself — `{ title: "${portal}:${sessionKey}" }` — and **discards** any client-supplied title/body. `sessionKey` derives from validated metadata as today (`forward.ts:79-93`), but the portal can no longer inject an arbitrary session title (a prompt-injection / moderation-bypass surface). It then records `sessionId → principal` (TTL mirroring the existing session cache; pruned on delete/TTL/hard-cap).
+- **Session create rewrites the body (security review F5a):** on `POST /session` the guardian **constructs** the body itself — `{ title: "${portal}:${sessionKey}" }` — and **discards** any client-supplied title/body. `sessionKey` derives from validated metadata as today (`resolveSessionTarget` in `packages/guardian/src/session-target.ts`; the old `forward.ts` was deleted), but the portal can no longer inject an arbitrary session title (a prompt-injection / moderation-bypass surface). It then records `sessionId → principal` (TTL mirroring the existing session cache; pruned on delete/TTL/hard-cap).
 - **Session calls** (`GET/DELETE /session/{id}`, `message`, `prompt_async`, `abort`): assert the principal owns `{id}`, else `403`. Replaces the implicit server-side derivation with an explicit ownership check — same isolation guarantee.
 - **`GET /session`** response is filtered to the principal's own sessions (the raw list must not leak other principals' titles).
 - **Permission replies are ownership-checked by `requestID` (API review, authz consequence of the corrected endpoint):** because `POST /permission/{requestID}/reply` is keyed by `requestID` (not `sessionID`), the guardian records `requestID → principal` **when it relays the `permission.asked` frame** to that principal, and authorizes the reply against that record. Prevents principal A answering principal B's permission request.
@@ -305,8 +305,8 @@ Each stage ships independently; the buffered path is the safe default throughout
 ## 10. References
 
 - `packages/ui/src/routes/proxy/assistant/[...path]/+server.ts` — the transparent streaming proxy precedent.
-- `containers/guardian/src/{server,forward,replay,rate-limit,signature}.ts` — current pipeline and guardian-local runtime state pattern.
-- `packages/portals-sdk/src/crypto.ts` — signing primitives to generalize.
+- `packages/guardian/src/{server,proxy,rate-limit,session-target}.ts` — current pipeline and guardian-local runtime state pattern (the old `forward.ts` was deleted; session targeting now lives in `session-target.ts`).
+- `packages/guardian/src/crypto.ts` — signing/verification primitives (kept guardian-local, not in a shared `portal-sdk` package).
 - `.openpalm/config/assistant/opencode.jsonc` — assistant permission config (§1.2).
 - Live OpenCode OpenAPI: `curl http://127.0.0.1:3800/doc` (assistant on :3800 → OpenCode :4096).
 

--- a/docs/technical/runtime-npm-container-design.md
+++ b/docs/technical/runtime-npm-container-design.md
@@ -35,6 +35,13 @@ The current package model is close to publishable, but not actually published.
 - `portals/slack/package.json:2-5` is named `@openpalm/slack-portal`, versioned, and marked `private: true`.
 - Both packages already have `repository`, `license`, `files`, and `main` metadata (`portals/discord/package.json:7-20`, `portals/slack/package.json:7-20`).
 
+> **Update (superseded):** The duplicated runtime/helper layer described in this
+> section has since been extracted into the shared `@openpalm/portal-sdk`
+> package (`packages/portal-sdk/`, exporting `BasePortal`, `OcClient`, the event
+> interpreters, and `renderTurn`). The per-portal `runtime.ts`/`oc-events.ts`
+> copies referenced below no longer exist; both adapters now build on the SDK.
+> The distribution/publication analysis below is retained as a historical record.
+
 The current repo no longer contains the `packages/channels-sdk/` path requested in the research brief. In the current tree, the portal packages do not depend on a shared internal SDK package. Instead, they duplicate a small runtime/helper layer.
 
 - `portals/discord/src/runtime.ts:1-211` and `portals/slack/src/runtime.ts:1-211` are effectively parallel copies.
@@ -336,7 +343,7 @@ Guardian is a strong candidate for the same pattern, but not all of it should mo
 
 What can become runtime-installed later:
 
-- The Bun application code under `containers/guardian/src/`.
+- The Bun application code under `packages/guardian/src/`.
 
 What likely stays baked:
 

--- a/packages/guardian/src/openai-api-stream.test.ts
+++ b/packages/guardian/src/openai-api-stream.test.ts
@@ -40,6 +40,7 @@ function stubGuardian(opts: StubOpts): void {
 }
 
 async function readAll(resp: Response): Promise<string> {
+  // biome-ignore lint/style/noNonNullAssertion: readAll is only called on streaming responses that always carry a body; a null body here is a real defect that should throw, not silently no-op.
   const reader = resp.body!.getReader();
   const decoder = new TextDecoder();
   let out = '';
@@ -176,7 +177,7 @@ describe('streamTurn — non-interactive permission policy', () => {
     await readAll(resp);
     const reply = calls.find((call) => call.path === '/permission/per_42/reply');
     expect(reply).toBeDefined();
-    expect(JSON.parse(reply!.body).reply).toBe('reject');
+    expect(JSON.parse(reply?.body ?? '').reply).toBe('reject');
   });
 
   test('auto policy with an allowlist approves the matching tool', async () => {
@@ -193,7 +194,8 @@ describe('streamTurn — non-interactive permission policy', () => {
     const resp = streamTurn({ client, policy: loadPermissionPolicy({ OP_API_PERMISSION_MODE: 'auto', OP_API_PERMISSION_ALLOWLIST: 'bash' }), userId: 'api:u1', sessionKey: 'api:u1', text: 'run bash', framer: openAiChatFramer('chatcmpl-test', 'gpt-4') });
     await readAll(resp);
     const reply = calls.find((call) => call.path === '/permission/per_99/reply');
-    expect(JSON.parse(reply!.body).reply).toBe('once');
+    expect(reply).toBeDefined();
+    expect(JSON.parse(reply?.body ?? '').reply).toBe('once');
   });
 });
 

--- a/packages/guardian/src/proxy-direct.test.ts
+++ b/packages/guardian/src/proxy-direct.test.ts
@@ -235,7 +235,7 @@ describe("/oc proxy — direct tier: moderation block → prompt-rewrite (not 40
     expect(messageHits).toBe(before + 1);
     // The rewritten body sent to upstream contains the refusal instruction.
     expect(lastMessageBody).not.toBeNull();
-    const parsed = JSON.parse(lastMessageBody!);
+    const parsed = JSON.parse(lastMessageBody ?? "");
     const firstText = parsed?.parts?.[0]?.text as string | undefined;
     expect(typeof firstText).toBe("string");
     expect(firstText).toContain("blocked by the guardian safety policy");
@@ -256,7 +256,7 @@ describe("/oc proxy — direct tier: moderation block → prompt-rewrite (not 40
     expect(resp.status).not.toBe(403);
     expect(messageHits).toBe(before + 1);
     expect(lastMessageBody).not.toBeNull();
-    const parsed = JSON.parse(lastMessageBody!);
+    const parsed = JSON.parse(lastMessageBody ?? "");
     const firstText = parsed?.parts?.[0]?.text as string | undefined;
     expect(typeof firstText).toBe("string");
     expect(firstText).toContain("blocked by the guardian safety policy");
@@ -279,7 +279,7 @@ describe("/oc proxy — direct tier: moderation block → prompt-rewrite (not 40
     // Upstream IS contacted with the rewritten body.
     expect(messageHits).toBe(before + 1);
     expect(lastMessageBody).not.toBeNull();
-    const parsed = JSON.parse(lastMessageBody!);
+    const parsed = JSON.parse(lastMessageBody ?? "");
     const firstText = parsed?.parts?.[0]?.text as string | undefined;
     expect(typeof firstText).toBe("string");
     expect(firstText).toContain("blocked by the guardian safety policy");

--- a/packages/guardian/src/proxy.test.ts
+++ b/packages/guardian/src/proxy.test.ts
@@ -578,6 +578,7 @@ describe("/oc proxy — /event filtered stream (§3.2)", () => {
  * instead of hanging the suite.
  */
 async function readStreamUntil(resp: Response, needle: string, maxMs = 2000): Promise<string> {
+  // biome-ignore lint/style/noNonNullAssertion: readStreamUntil is only called on SSE responses that always carry a body; a null body here is a real defect that should throw, not silently no-op.
   const reader = resp.body!.getReader();
   const decoder = new TextDecoder();
   let out = "";

--- a/packages/guardian/src/proxy.ts
+++ b/packages/guardian/src/proxy.ts
@@ -280,6 +280,7 @@ async function routeAllowed(
   search: string,
   body: string,
 ): Promise<Response> {
+  // biome-ignore lint/style/noNonNullAssertion: routeAllowed is only reached after the `!match.allowed` guard in handle(); every allowed AllowlistMatch (from matchAllowlist and allowDirect/directRouteFor) sets `route`, so it is provably non-null here.
   const template = match.route!.template;
   const params = match.params ?? {};
   const sessionId = params.id;

--- a/packages/guardian/src/state-db.ts
+++ b/packages/guardian/src/state-db.ts
@@ -133,6 +133,7 @@ export function upsertPrincipal(input: { id: string; kind: PrincipalKind; label?
       token_hash = excluded.token_hash,
       enabled = excluded.enabled
   `).run(input.id, input.kind, label, hashToken(input.token), input.enabled === false ? 0 : 1, createdAt);
+  // biome-ignore lint/style/noNonNullAssertion: the INSERT ... ON CONFLICT DO UPDATE above guarantees a row with input.id exists, so the immediate re-read cannot be null.
   return getPrincipalRecord(input.id)!;
 }
 

--- a/packages/lib/src/control-plane/addons.test.ts
+++ b/packages/lib/src/control-plane/addons.test.ts
@@ -26,12 +26,14 @@ import {
 import { readSecret } from './secrets-files.js';
 
 let tempDir = '';
+let homeDir = '';
 let originalHome: string | undefined;
 
 beforeEach(() => {
   tempDir = mkdtempSync(join(tmpdir(), 'registry-test-'));
   originalHome = process.env.OP_HOME;
-  process.env.OP_HOME = join(tempDir, 'home');
+  homeDir = join(tempDir, 'home');
+  process.env.OP_HOME = homeDir;
 });
 
 afterEach(() => {
@@ -70,52 +72,52 @@ describe('builtin addon metadata', () => {
 
 describe('addon runtime state', () => {
   it('ignores COMPOSE_PROFILES when resolving enabled addons', () => {
-    const envDir = join(process.env.OP_HOME!, 'knowledge', 'env');
+    const envDir = join(homeDir, 'knowledge', 'env');
     mkdirSync(envDir, { recursive: true });
     writeFileSync(join(envDir, 'stack.env'), 'COMPOSE_PROFILES=addon.chat\n');
 
-    expect(listEnabledAddonIds(process.env.OP_HOME!)).toEqual([]);
+    expect(listEnabledAddonIds(homeDir)).toEqual([]);
   });
 
   it('treats canonical hardware profile selections as addon enablement', () => {
-    const envDir = join(process.env.OP_HOME!, 'knowledge', 'env');
+    const envDir = join(homeDir, 'knowledge', 'env');
     mkdirSync(envDir, { recursive: true });
     writeFileSync(join(envDir, 'stack.env'), 'OP_VOICE_PROFILE=addon.voice.cuda\n');
 
-    expect(listEnabledAddonIds(process.env.OP_HOME!)).toEqual(['voice']);
+    expect(listEnabledAddonIds(homeDir)).toEqual(['voice']);
   });
 
   it('returns addon service names from fixed compose files', () => {
     // custom.compose.yml is USER-owned → config/stack, not system/stack.
-    const stackDir = join(process.env.OP_HOME!, 'config', 'stack');
+    const stackDir = join(homeDir, 'config', 'stack');
     mkdirSync(stackDir, { recursive: true });
     writeFileSync(join(stackDir, 'custom.compose.yml'), 'services:\n  proxy-test:\n    profiles: ["addon.proxy-test"]\n    image: image-a\n  proxy-test-worker:\n    profiles: ["addon.proxy-test"]\n    image: image-b\n');
 
-    expect(getAddonServiceNames(process.env.OP_HOME!, 'proxy-test')).toEqual(['proxy-test', 'proxy-test-worker']);
+    expect(getAddonServiceNames(homeDir, 'proxy-test')).toEqual(['proxy-test', 'proxy-test-worker']);
   });
 
   it('toggles addons and generates channel secrets for channel addons', () => {
-    const stackDir = join(process.env.OP_HOME!, 'system', 'stack');
+    const stackDir = join(homeDir, 'system', 'stack');
     mkdirSync(stackDir, { recursive: true });
 
-    const enabled = setAddonEnabled(process.env.OP_HOME!, 'discord', true);
+    const enabled = setAddonEnabled(homeDir, 'discord', true);
     expect(enabled.ok).toBe(true);
     expect(enabled.enabled).toBe(true);
     expect(enabled.changed).toBe(true);
     expect(enabled.services).toEqual(expect.arrayContaining(['guardian']));
-    expect(listEnabledAddonIds(process.env.OP_HOME!)).toEqual(['discord']);
-    expect(readSecret(process.env.OP_HOME!, 'portal_discord_secret')).toBeTruthy();
+    expect(listEnabledAddonIds(homeDir)).toEqual(['discord']);
+    expect(readSecret(homeDir, 'portal_discord_secret')).toBeTruthy();
 
-    const disabled = setAddonEnabled(process.env.OP_HOME!, 'discord', false);
+    const disabled = setAddonEnabled(homeDir, 'discord', false);
     expect(disabled.ok).toBe(true);
     expect(disabled.enabled).toBe(false);
     expect(disabled.changed).toBe(true);
     expect(disabled.services).toEqual(expect.arrayContaining(['guardian']));
-    expect(listEnabledAddonIds(process.env.OP_HOME!)).toEqual([]);
+    expect(listEnabledAddonIds(homeDir)).toEqual([]);
   });
 
   it('reads bundled addon profiles from the shipped compose assets', () => {
-    expect(getAddonProfiles(process.env.OP_HOME!, 'voice')).toEqual([
+    expect(getAddonProfiles(homeDir, 'voice')).toEqual([
       { id: 'addon.voice.cpu', services: ['voice'], label: 'CPU', default: true },
       { id: 'addon.voice.cuda', services: ['voice-cuda'], label: 'NVIDIA (CUDA 12.1)', requires: 'nvidia-container-toolkit' },
       { id: 'addon.voice.rocm', services: ['voice-rocm'], label: 'AMD (ROCm 6.x)', requires: 'amdgpu kernel module' },
@@ -123,16 +125,16 @@ describe('addon runtime state', () => {
   });
 
   it('round-trips addon profile selection, written to state/ not stack.env (constitution §1)', () => {
-    const stackDir = join(process.env.OP_HOME!, 'system', 'stack');
-    const stackEnv = join(process.env.OP_HOME!, 'knowledge', 'env', 'stack.env');
-    const stateEnv = join(process.env.OP_HOME!, 'state', 'stack.state.env');
+    const stackDir = join(homeDir, 'system', 'stack');
+    const stackEnv = join(homeDir, 'knowledge', 'env', 'stack.env');
+    const stateEnv = join(homeDir, 'state', 'stack.state.env');
     mkdirSync(stackDir, { recursive: true });
-    mkdirSync(join(process.env.OP_HOME!, 'knowledge', 'env'), { recursive: true });
+    mkdirSync(join(homeDir, 'knowledge', 'env'), { recursive: true });
     writeFileSync(stackEnv, '');
 
-    expect(getAddonProfileSelection(process.env.OP_HOME!, 'voice')).toBeNull();
-    setAddonProfileSelection(process.env.OP_HOME!, 'voice', 'addon.voice.cuda');
-    expect(getAddonProfileSelection(process.env.OP_HOME!, 'voice')).toBe('addon.voice.cuda');
+    expect(getAddonProfileSelection(homeDir, 'voice')).toBeNull();
+    setAddonProfileSelection(homeDir, 'voice', 'addon.voice.cuda');
+    expect(getAddonProfileSelection(homeDir, 'voice')).toBe('addon.voice.cuda');
     // App-written addon state lands in state/, and never in the operator-facing stack.env.
     expect(readFileSync(stateEnv, 'utf-8')).toContain('OP_VOICE_PROFILE=addon.voice.cuda');
     expect(readFileSync(stackEnv, 'utf-8')).not.toContain('OP_VOICE_PROFILE');
@@ -141,8 +143,8 @@ describe('addon runtime state', () => {
 
 describe('removed-addon state cleanup (R8: stale ssh)', () => {
   function seedStateEnv(contents: string): string {
-    const stateEnv = join(process.env.OP_HOME!, 'state', 'stack.state.env');
-    mkdirSync(join(process.env.OP_HOME!, 'state'), { recursive: true });
+    const stateEnv = join(homeDir, 'state', 'stack.state.env');
+    mkdirSync(join(homeDir, 'state'), { recursive: true });
     writeFileSync(stateEnv, contents);
     return stateEnv;
   }
@@ -152,10 +154,10 @@ describe('removed-addon state cleanup (R8: stale ssh)', () => {
 
     // ssh is no longer built in, so it is hidden from the effective set but
     // still present in the raw env until pruned.
-    expect(listEnabledAddonIds(process.env.OP_HOME!)).toEqual(['voice']);
+    expect(listEnabledAddonIds(homeDir)).toEqual(['voice']);
     expect(readFileSync(stateEnv, 'utf-8')).toContain('ssh');
 
-    const result = pruneRemovedAddonState(process.env.OP_HOME!);
+    const result = pruneRemovedAddonState(homeDir);
     expect(result.changed).toBe(true);
     expect(result.removedAddons).toEqual(['ssh']);
     expect(result.removedEnvKeys).toEqual(['OPENCODE_ENABLE_SSH']);
@@ -168,11 +170,11 @@ describe('removed-addon state cleanup (R8: stale ssh)', () => {
 
   it('is idempotent — a second prune is a no-op that writes nothing', () => {
     seedStateEnv('OP_ENABLED_ADDONS=ssh\nOPENCODE_ENABLE_SSH=1\n');
-    expect(pruneRemovedAddonState(process.env.OP_HOME!).changed).toBe(true);
+    expect(pruneRemovedAddonState(homeDir).changed).toBe(true);
 
-    const stateEnv = join(process.env.OP_HOME!, 'state', 'stack.state.env');
+    const stateEnv = join(homeDir, 'state', 'stack.state.env');
     const contentAfterFirst = readFileSync(stateEnv, 'utf-8');
-    const second = pruneRemovedAddonState(process.env.OP_HOME!);
+    const second = pruneRemovedAddonState(homeDir);
     expect(second.changed).toBe(false);
     expect(second.removedAddons).toEqual([]);
     expect(second.removedEnvKeys).toEqual([]);
@@ -183,20 +185,20 @@ describe('removed-addon state cleanup (R8: stale ssh)', () => {
     const stateEnv = seedStateEnv('OP_ENABLED_ADDONS=voice\n');
     const before = readFileSync(stateEnv, 'utf-8');
 
-    const result = pruneRemovedAddonState(process.env.OP_HOME!);
+    const result = pruneRemovedAddonState(homeDir);
     expect(result).toEqual({ changed: false, removedAddons: [], removedEnvKeys: [] });
     expect(readFileSync(stateEnv, 'utf-8')).toBe(before);
   });
 
   it('is a no-op when there is no state env at all', () => {
-    const result = pruneRemovedAddonState(process.env.OP_HOME!);
+    const result = pruneRemovedAddonState(homeDir);
     expect(result.changed).toBe(false);
   });
 
   it('disables a lingering ssh entry via setAddonEnabled', () => {
     const stateEnv = seedStateEnv('OP_ENABLED_ADDONS=ssh,voice\nOPENCODE_ENABLE_SSH=1\n');
 
-    const disabled = setAddonEnabled(process.env.OP_HOME!, 'ssh', false);
+    const disabled = setAddonEnabled(homeDir, 'ssh', false);
     expect(disabled.ok).toBe(true);
     if (disabled.ok) expect(disabled.changed).toBe(true);
 
@@ -207,20 +209,20 @@ describe('removed-addon state cleanup (R8: stale ssh)', () => {
   });
 
   it('still rejects ENABLING a non-built-in addon (validation unchanged)', () => {
-    const result = setAddonEnabled(process.env.OP_HOME!, 'ssh', true);
+    const result = setAddonEnabled(homeDir, 'ssh', true);
     expect(result).toEqual({ ok: false, error: 'Addon "ssh" is not built in' });
   });
 
   it('treats disabling an absent removed addon as a no-op success', () => {
     seedStateEnv('OP_ENABLED_ADDONS=voice\n');
-    const result = setAddonEnabled(process.env.OP_HOME!, 'ssh', false);
+    const result = setAddonEnabled(homeDir, 'ssh', false);
     expect(result).toEqual({ ok: true, enabled: false, changed: false, services: [] });
   });
 });
 
 describe('automation install helpers', () => {
   it('installs and uninstalls automations through knowledge/tasks', () => {
-    const stashDir = join(process.env.OP_HOME!, 'knowledge');
+    const stashDir = join(homeDir, 'knowledge');
     expect(installAutomationFromRegistry('akm-improve', stashDir)).toEqual({ ok: true });
     expect(readFileSync(join(stashDir, 'tasks', 'akm-improve.yml'), 'utf-8')).toContain('akm improve');
 
@@ -231,21 +233,22 @@ describe('automation install helpers', () => {
 
 describe('backup helpers', () => {
   it('backs up config/state trees but EXCLUDES the regenerable data/ tree', () => {
-    mkdirSync(join(process.env.OP_HOME!, 'config'), { recursive: true });
-    mkdirSync(join(process.env.OP_HOME!, 'data', 'backups', 'old-backup'), { recursive: true });
-    mkdirSync(join(process.env.OP_HOME!, 'data', 'assistant'), { recursive: true });
-    writeFileSync(join(process.env.OP_HOME!, 'config', 'stack.yml'), 'llm: test\n');
-    writeFileSync(join(process.env.OP_HOME!, 'data', 'backups', 'old-backup', 'marker.txt'), 'old\n');
-    writeFileSync(join(process.env.OP_HOME!, 'data', 'assistant', 'cache.bin'), 'big\n');
+    mkdirSync(join(homeDir, 'config'), { recursive: true });
+    mkdirSync(join(homeDir, 'data', 'backups', 'old-backup'), { recursive: true });
+    mkdirSync(join(homeDir, 'data', 'assistant'), { recursive: true });
+    writeFileSync(join(homeDir, 'config', 'stack.yml'), 'llm: test\n');
+    writeFileSync(join(homeDir, 'data', 'backups', 'old-backup', 'marker.txt'), 'old\n');
+    writeFileSync(join(homeDir, 'data', 'assistant', 'cache.bin'), 'big\n');
 
-    const backupDir = backupOpenPalmHome(process.env.OP_HOME!);
+    const backupDir = backupOpenPalmHome(homeDir);
 
     expect(backupDir).not.toBeNull();
-    expect(existsSync(join(backupDir!, 'config', 'stack.yml'))).toBe(true);
-    expect(existsSync(join(backupDir!, 'cache'))).toBe(false);
+    if (backupDir === null) return; // narrow for TS; the expect above already failed the test if null
+    expect(existsSync(join(backupDir, 'config', 'stack.yml'))).toBe(true);
+    expect(existsSync(join(backupDir, 'cache'))).toBe(false);
     // The whole data/ tree is excluded — it's large, regenerable runtime state
     // (this is the fix for snapshots ballooning to GBs and filling the disk).
-    expect(existsSync(join(backupDir!, 'data'))).toBe(false);
+    expect(existsSync(join(backupDir, 'data'))).toBe(false);
   });
 
   it('writes backups under the provided homeDir even when OP_HOME points elsewhere', () => {
@@ -261,8 +264,9 @@ describe('backup helpers', () => {
     const backupDir = backupOpenPalmHome(actualHome);
 
     expect(backupDir).not.toBeNull();
-    expect(backupDir!.startsWith(join(actualHome, 'data', 'backups'))).toBe(true);
-    expect(existsSync(join(backupDir!, 'config', 'stack.yml'))).toBe(true);
+    if (backupDir === null) return; // narrow for TS; the expect above already failed the test if null
+    expect(backupDir.startsWith(join(actualHome, 'data', 'backups'))).toBe(true);
+    expect(existsSync(join(backupDir, 'config', 'stack.yml'))).toBe(true);
     expect(existsSync(join(otherHome, 'data', 'backups', 'config', 'stack.yml'))).toBe(false);
   });
 });

--- a/packages/lib/src/control-plane/apply-stack-service.test.ts
+++ b/packages/lib/src/control-plane/apply-stack-service.test.ts
@@ -129,7 +129,7 @@ describe("applyStack({ kind: 'service' }) — scoped single-service update", () 
     expect(pullCall).toContain("assistant");
     // Must NOT be a bare `pull` (which would pull all images)
     // The pull args end with the service name, not empty.
-    expect(pullCall!.trim().endsWith("assistant")).toBe(true);
+    expect(pullCall?.trim().endsWith("assistant")).toBe(true);
   });
 
   it("(b) issues up with --force-recreate --no-deps <service> (not --remove-orphans)", () => {

--- a/packages/lib/src/control-plane/cleanup-guardrails.test.ts
+++ b/packages/lib/src/control-plane/cleanup-guardrails.test.ts
@@ -35,7 +35,7 @@ describe("guardrail: no config/components runtime references", () => {
     const violations: string[] = [];
 
     for (const { path, content } of files) {
-      const filename = path.split("/").pop()!;
+      const filename = path.slice(path.lastIndexOf("/") + 1);
       // Skip this test file itself
       if (filename === "cleanup-guardrails.test.ts") continue;
 
@@ -177,7 +177,7 @@ describe("guardrail: no deprecated OP_CONFIG_HOME/OP_STATE_HOME/OP_DATA_HOME", (
     const violations: string[] = [];
 
     for (const { path, content } of files) {
-      const filename = path.split("/").pop()!;
+      const filename = path.slice(path.lastIndexOf("/") + 1);
       if (filename === "cleanup-guardrails.test.ts") continue;
       // home.ts may contain backward-compat resolution — skip it
       if (filename === "home.ts") continue;
@@ -206,7 +206,7 @@ describe("guardrail: no secrets.env references", () => {
     const violations: string[] = [];
 
     for (const { path, content } of files) {
-      const filename = path.split("/").pop()!;
+      const filename = path.slice(path.lastIndexOf("/") + 1);
       if (filename === "cleanup-guardrails.test.ts") continue;
 
       const lines = content.split("\n");
@@ -249,7 +249,7 @@ describe("guardrail: .openpalm/stack/start.sh is absent", () => {
     const violations: string[] = [];
 
     for (const { path, content } of files) {
-      const filename = path.split("/").pop()!;
+      const filename = path.slice(path.lastIndexOf("/") + 1);
       if (filename === "cleanup-guardrails.test.ts") continue;
 
       const lines = content.split("\n");

--- a/packages/lib/src/control-plane/core-assets.test.ts
+++ b/packages/lib/src/control-plane/core-assets.test.ts
@@ -23,7 +23,7 @@ const MANAGED_FILES = [
   "system/stack/services.compose.yml",
   "system/stack/portals.compose.yml",
   "system/assistant/opencode.jsonc",
-];
+] as const;
 
 function seedSource(content: string): void {
   for (const rel of MANAGED_FILES) {
@@ -47,7 +47,7 @@ afterEach(() => {
 });
 
 describe("overwriteSystemTree", () => {
-  const first = MANAGED_FILES[0]!;
+  const first = MANAGED_FILES[0];
 
   it("writes every managed system/ file when absent", () => {
     seedSource("# fresh\n");
@@ -67,7 +67,8 @@ describe("overwriteSystemTree", () => {
     expect(readFileSync(join(opHome, first), "utf-8")).toBe("new\n");
     expect(updated).toContain(first);
     expect(backupDir).not.toBeNull();
-    expect(readFileSync(join(backupDir!, first), "utf-8")).toBe("old\n");
+    if (backupDir === null) return; // narrow for TS; the expect above already failed the test if null
+    expect(readFileSync(join(backupDir, first), "utf-8")).toBe("old\n");
   });
 
   it("skips when on-disk content already matches the source", () => {

--- a/packages/lib/src/control-plane/env.ts
+++ b/packages/lib/src/control-plane/env.ts
@@ -135,10 +135,11 @@ export function mergeEnvContent(
     const eq = testLine.indexOf('=');
     if (eq <= 0) continue;
     const key = testLine.slice(0, eq).trim();
-    if (remaining.has(key)) {
+    const value = remaining.get(key);
+    if (value !== undefined) {
       // Preserve the export prefix if the original line had one
       const prefix = hadExport ? 'export ' : '';
-      lines[i] = `${prefix}${key}=${quoteEnvValue(remaining.get(key)!)}`;
+      lines[i] = `${prefix}${key}=${quoteEnvValue(value)}`;
       remaining.delete(key);
     }
   }

--- a/packages/lib/src/control-plane/host-identity.test.ts
+++ b/packages/lib/src/control-plane/host-identity.test.ts
@@ -98,7 +98,9 @@ describe('detectHostIdentity', () => {
     }
     // Session identity from resolveSessionIdentity — the live process uid — so a
     // moved drive whose files are owned by a stale uid cannot mask a host swap.
+    // biome-ignore lint/style/noNonNullAssertion: process.getuid is defined on POSIX (win32 returned early).
     expect(identity.uid).toBe(process.getuid!());
+    // biome-ignore lint/style/noNonNullAssertion: process.getgid is defined on POSIX (win32 returned early).
     expect(identity.gid).toBe(process.getgid!());
   });
 });

--- a/packages/lib/src/control-plane/iu-harness.ts
+++ b/packages/lib/src/control-plane/iu-harness.ts
@@ -83,6 +83,7 @@ export function makeHome(): Home {
     "data/logs/app.log": "log line\n",
     "state/stack.state.env": "OP_ASSISTANT_VERSION=0.11.0\nOP_ENABLED_ADDONS=discord\n",
   };
+  // biome-ignore lint/style/noNonNullAssertion: seed defines an entry for every relative path enumerated in files (the two literals are kept in sync above).
   for (const rels of Object.values(files)) for (const rel of rels) write(join(dir, rel), seed[rel]!);
   return {
     dir,

--- a/packages/lib/src/control-plane/iu-invariants.integration.test.ts
+++ b/packages/lib/src/control-plane/iu-invariants.integration.test.ts
@@ -41,7 +41,10 @@ import {
 
 const cleanups: Array<() => void> = [];
 afterEach(() => {
-  while (cleanups.length) cleanups.pop()!();
+  while (cleanups.length) {
+    const cleanup = cleanups.pop();
+    cleanup?.();
+  }
 }, 60_000); // docker compose down can take a few seconds; don't let teardown time out
 
 describe.skipIf(SKIP_DOCKER)("install/update invariants (Phase 0 baseline)", () => {
@@ -120,11 +123,11 @@ describe.skipIf(SKIP_DOCKER)("install/update invariants (Phase 0 baseline)", () 
     expect(proj.up(envA).ok).toBe(true);
     const running = proj.runningImage("svc");
     expect(running).not.toBeNull();
-    expect(running!.tag).toBe("alpine:3.19");
-    expect(running!.digest).toMatch(/^sha256:/);
+    expect(running?.tag).toBe("alpine:3.19");
+    expect(running?.digest).toMatch(/^sha256:/);
     // The "pin" now says 3.22 but we DON'T recreate — the container is still 3.19.
     writeFileSync(join(proj.dir, "b.env"), "SVC_TAG=3.22\n");
-    expect(running!.tag).toBe("alpine:3.19"); // reality, not the pin
+    expect(running?.tag).toBe("alpine:3.19"); // reality, not the pin
   });
 
   // ── INV4 [MODEL/docker] — a pin to a missing image fails loudly on pull ─────
@@ -164,9 +167,9 @@ describe.skipIf(SKIP_DOCKER)("install/update invariants (Phase 0 baseline)", () 
     const after = await getRunningImages({ files: [proj.file], envFiles: [envFile], profiles: [] });
     const svcInfo = after.svc;
     expect(svcInfo).not.toBeUndefined();
-    expect(svcInfo!.state).toBe("running");
-    expect(svcInfo!.digest).toMatch(/^sha256:/);
-    expect(svcInfo!.tag).toContain("alpine");
+    expect(svcInfo?.state).toBe("running");
+    expect(svcInfo?.digest).toMatch(/^sha256:/);
+    expect(svcInfo?.tag).toContain("alpine");
 
     // A separate inspect of a non-existent container returns not_installed
     const { inspectContainerImage } = await import("./docker.js");
@@ -264,8 +267,9 @@ describe.skipIf(SKIP_DOCKER)("install/update invariants (Phase 0 baseline)", () 
     expect(readFileSync(join(dataUi, UI_VERSION_STAMP), "utf8").trim()).toBe("0.12.0");
     // Backup of the OLD build exists
     expect(result.backupDir).toBeTruthy();
-    expect(existsSync(join(result.backupDir!, "index.js"))).toBe(true);
-    expect(readFileSync(join(result.backupDir!, "index.js"), "utf8")).toContain("old build");
+    if (!result.backupDir) return; // narrow for TS; the expect above already failed the test if falsy
+    expect(existsSync(join(result.backupDir, "index.js"))).toBe(true);
+    expect(readFileSync(join(result.backupDir, "index.js"), "utf8")).toContain("old build");
   });
 
   test("INV8b UI build hot-swap: bad integrity aborts and prior build is untouched", async () => {
@@ -389,7 +393,9 @@ describe.skipIf(SKIP_DOCKER)("install/update invariants (Phase 0 baseline)", () 
       ? readdirSync(backupsDir).filter((n: string) => n.startsWith("skeleton-"))
       : [];
     expect(skelBackups.length).toBeGreaterThan(0);
-    const skelBackupDir = join(backupsDir, skelBackups[0]!);
+    const firstSkelBackup = skelBackups[0];
+    if (firstSkelBackup === undefined) return; // narrow for TS; the expect above already failed the test if empty
+    const skelBackupDir = join(backupsDir, firstSkelBackup);
     expect(existsSync(join(skelBackupDir, "stack", "core.compose.yml"))).toBe(true);
     expect(readFileSync(join(skelBackupDir, "stack", "core.compose.yml"), "utf8")).toContain("image: old");
   });
@@ -440,7 +446,10 @@ describe.skipIf(SKIP_DOCKER)("install/update invariants (Phase 0 baseline)", () 
 describe("install/update invariants (filesystem-only, always runs)", () => {
   const cleanups: Array<() => void> = [];
   afterEach(() => {
-    while (cleanups.length) cleanups.pop()!();
+    while (cleanups.length) {
+      const cleanup = cleanups.pop();
+      cleanup?.();
+    }
   });
 
   // INV7 [Phase 2] — apply() overwrites system/, seeds user trees once, is idempotent.

--- a/packages/lib/src/control-plane/launch-status.ts
+++ b/packages/lib/src/control-plane/launch-status.ts
@@ -124,6 +124,7 @@ export function deriveLaunchStatus(input: { local: LocalStatus; remotes?: Remote
 
   let activeAssistant: ActiveAssistant = null;
   if (recommendedRoute === "chat") {
+    // biome-ignore lint/style/noNonNullAssertion: reached only when recommendedRoute==='chat' && !hasHealthyLocal, which requires (state==='not_installed' && hasAccessibleRemote), so accessibleRemotes is non-empty.
     activeAssistant = hasHealthyLocal ? { kind: "local" } : { kind: "remote", id: accessibleRemotes[0]!.id };
   }
 

--- a/packages/lib/src/control-plane/operator-ids.test.ts
+++ b/packages/lib/src/control-plane/operator-ids.test.ts
@@ -25,8 +25,8 @@ describe("resolveOperatorIds", () => {
       return;
     }
     expect(ids).not.toBeNull();
-    expect(ids!.uid).toBe(expected.uid);
-    expect(ids!.gid).toBe(expected.gid);
+    expect(ids?.uid).toBe(expected.uid);
+    expect(ids?.gid).toBe(expected.gid);
   });
 
   test("falls back to process UID when homeDir does not exist", () => {
@@ -37,9 +37,12 @@ describe("resolveOperatorIds", () => {
       return;
     }
     expect(ids).not.toBeNull();
-    // process.getuid is guaranteed on POSIX runtimes used by this test
-    expect(ids!.uid).toBe(process.getuid!());
-    expect(ids!.gid).toBe(process.getgid!());
+    // process.getuid/getgid are guaranteed on the POSIX runtimes used by this
+    // test (the win32 branch returned early above), so the calls never throw.
+    // biome-ignore lint/style/noNonNullAssertion: process.getuid is defined on POSIX (win32 returned early).
+    expect(ids?.uid).toBe(process.getuid!());
+    // biome-ignore lint/style/noNonNullAssertion: process.getgid is defined on POSIX (win32 returned early).
+    expect(ids?.gid).toBe(process.getgid!());
   });
 
   test("never returns 0 (root) — falls back to process UID when homeDir is root-owned", () => {
@@ -57,8 +60,8 @@ describe("resolveOperatorIds", () => {
       return;
     }
     expect(ids).not.toBeNull();
-    expect(ids!.uid).toBeGreaterThan(0);
-    expect(ids!.gid).toBeGreaterThan(0);
+    expect(ids?.uid).toBeGreaterThan(0);
+    expect(ids?.gid).toBeGreaterThan(0);
   });
 
   test("returns null when BOTH homeDir owner and process UID/GID are 0 (root install on root-owned OP_HOME)", () => {
@@ -119,15 +122,19 @@ describe("resolveSessionIdentity", () => {
     // session the result is the process uid regardless of homeDir.
     const ids = resolveSessionIdentity(tempDir);
     expect(ids).not.toBeNull();
-    expect(ids!.uid).toBe(process.getuid!());
-    expect(ids!.gid).toBe(process.getgid!());
+    // process.getuid/getgid are defined on POSIX (win32 returned early above).
+    // biome-ignore lint/style/noNonNullAssertion: process.getuid is defined on POSIX (win32 returned early).
+    expect(ids?.uid).toBe(process.getuid!());
+    // biome-ignore lint/style/noNonNullAssertion: process.getgid is defined on POSIX (win32 returned early).
+    expect(ids?.gid).toBe(process.getgid!());
   });
 
   test("ignores a missing homeDir for a non-root session (uses process ids)", () => {
     if (process.platform === "win32") return;
     const ids = resolveSessionIdentity(join(tempDir, "does-not-exist"));
     expect(ids).not.toBeNull();
-    expect(ids!.uid).toBe(process.getuid!());
+    // biome-ignore lint/style/noNonNullAssertion: process.getuid is defined on POSIX (win32 returned early).
+    expect(ids?.uid).toBe(process.getuid!());
   });
 
   test("falls back to the disk-owner-preferring resolver for a root session", () => {

--- a/packages/lib/src/control-plane/ownership-reconcile.test.ts
+++ b/packages/lib/src/control-plane/ownership-reconcile.test.ts
@@ -202,7 +202,10 @@ describe('reconcileHostOwnership swap block + fast path (R2/R4)', () => {
   test('skips the repair walk (no docker) when the marker already matches the session', async () => {
     if (process.platform === 'win32') return;
     const state = makeState();
+    // process.getuid/getgid are defined on POSIX (win32 returned early above).
+    // biome-ignore lint/style/noNonNullAssertion: process.getuid is defined on POSIX (win32 returned early).
     const sessionUid = process.getuid!();
+    // biome-ignore lint/style/noNonNullAssertion: process.getgid is defined on POSIX (win32 returned early).
     const sessionGid = process.getgid!();
     // Marker present + match decision → needsRepair false → no docker invoked.
     writeOwnershipRepairMarker(state.homeDir, { uid: sessionUid, gid: sessionGid });

--- a/packages/lib/src/control-plane/portal-secret-contract.test.ts
+++ b/packages/lib/src/control-plane/portal-secret-contract.test.ts
@@ -80,8 +80,8 @@ describe("portal verification-secret contract (compose ↔ portalSecretName ↔ 
         expect(decl, `top-level secrets: must declare ${expectedSecret}`).toBeDefined();
         // The container reads the file the migration/seeder writes — the basename
         // MUST equal the secret name, under knowledge/secrets/.
-        expect(basename(decl!.file ?? "")).toBe(expectedSecret);
-        expect(decl!.file).toContain("/knowledge/secrets/");
+        expect(basename(decl?.file ?? "")).toBe(expectedSecret);
+        expect(decl?.file).toContain("/knowledge/secrets/");
       });
     });
   }

--- a/packages/lib/src/control-plane/provider-models.ts
+++ b/packages/lib/src/control-plane/provider-models.ts
@@ -32,7 +32,8 @@ function resolveApiKey(apiKeyRef: string, homeDir: string): string {
   if (!apiKeyRef.startsWith("env:")) return apiKeyRef;
 
   const varName = apiKeyRef.slice(4);
-  if (process.env[varName]) return process.env[varName]!;
+  const fromProcessEnv = process.env[varName];
+  if (fromProcessEnv) return fromProcessEnv;
 
   const secrets = readStackRuntimeEnv(homeDir);
   return secrets[varName] ?? "";

--- a/packages/lib/src/control-plane/secret-strip-notice.test.ts
+++ b/packages/lib/src/control-plane/secret-strip-notice.test.ts
@@ -38,10 +38,10 @@ describe('#502 secret-strip notice', () => {
 
     const notice = readSecretStripNotice(state);
     expect(notice).not.toBeNull();
-    expect(notice!.keys).toContain('OPENAI_API_KEY');
-    expect(notice!.keys).toContain('DISCORD_BOT_TOKEN');
-    expect(notice!.keys).not.toContain('OP_LOG_LEVEL');
-    expect(typeof notice!.at).toBe('string');
+    expect(notice?.keys).toContain('OPENAI_API_KEY');
+    expect(notice?.keys).toContain('DISCORD_BOT_TOKEN');
+    expect(notice?.keys).not.toContain('OP_LOG_LEVEL');
+    expect(typeof notice?.at).toBe('string');
   });
 
   it('does not create a notice when there are no secret-like keys', () => {
@@ -71,8 +71,9 @@ describe('#502 secret-strip notice', () => {
     writeSystemEnv(state);
 
     const notice = readSecretStripNotice(state);
-    expect(notice!.keys).toContain('OPENAI_API_KEY');
-    expect(notice!.keys).toContain('GROQ_API_KEY');
+    expect(notice).not.toBeNull();
+    expect(notice?.keys).toContain('OPENAI_API_KEY');
+    expect(notice?.keys).toContain('GROQ_API_KEY');
 
     dismissSecretStripNotice(state);
     expect(readSecretStripNotice(state)).toBeNull();

--- a/packages/lib/src/control-plane/secrets-files.test.ts
+++ b/packages/lib/src/control-plane/secrets-files.test.ts
@@ -68,7 +68,7 @@ describe('secrets-dir file browser API (admin Secrets tab)', () => {
     const names = files.map((f) => f.name);
     expect(names).toContain('auth.json');           // included (strict listSecretNames would exclude it)
     expect(names).toContain('portal_api_secret');
-    expect(files.find((f) => f.name === 'auth.json')!.size).toBe('{"k":1}'.length);
+    expect(files.find((f) => f.name === 'auth.json')?.size).toBe('{"k":1}'.length);
     // strict API still excludes the dotted file
     expect(listSecretNames(stackDir)).not.toContain('auth.json');
   });

--- a/packages/lib/src/control-plane/task-files.test.ts
+++ b/packages/lib/src/control-plane/task-files.test.ts
@@ -22,7 +22,7 @@ describe('task-files', () => {
     expect(names).toContain('health-check.yml');
     expect(names).toContain('notes.md');
     expect(names).not.toContain('ignore.txt');
-    expect(files.find((f) => f.name === 'health-check.yml')!.size).toBe('enabled: false\n'.length);
+    expect(files.find((f) => f.name === 'health-check.yml')?.size).toBe('enabled: false\n'.length);
   });
 
   it('reads, writes (0644), and removes a task file', () => {

--- a/packages/lib/src/control-plane/ui-assets.test.ts
+++ b/packages/lib/src/control-plane/ui-assets.test.ts
@@ -828,7 +828,9 @@ describe("checkAndUpdateSkeleton", () => {
     const backupsDir = join(skelDataDir, "backups");
     const skelBackups = existsSync(backupsDir) ? readdirSync(backupsDir).filter((n: string) => n.startsWith("skeleton-")) : [];
     expect(skelBackups.length).toBeGreaterThan(0);
-    const backup = join(backupsDir, skelBackups[0]!);
+    const firstSkelBackup = skelBackups[0];
+    if (firstSkelBackup === undefined) return; // narrow for TS; the expect above already failed the test if empty
+    const backup = join(backupsDir, firstSkelBackup);
     expect(existsSync(join(backup, "stack", "core.compose.yml"))).toBe(true);
     expect(readFileSync(join(backup, "stack", "core.compose.yml"), "utf8")).toContain("image: old");
   });

--- a/packages/lib/src/control-plane/versioning.ts
+++ b/packages/lib/src/control-plane/versioning.ts
@@ -55,6 +55,7 @@ function comparePrerelease(a: string, b: string): number {
       continue;
     }
     if (aIsNum !== bIsNum) return aIsNum ? -1 : 1;
+    // biome-ignore lint/style/noNonNullAssertion: the two guards above (i >= aParts.length / i >= bParts.length) prove i is in bounds for both arrays here.
     if (aParts[i] !== bParts[i]) return aParts[i]! > bParts[i]! ? 1 : -1;
   }
   return 0;
@@ -75,8 +76,8 @@ export function compareComparableVersions(a: string, b: string): number {
 }
 
 export function majorVersionOf(version: string | null | undefined): number | null {
-  if (!isComparableSemver(version)) return null;
-  return parseComparableVersion(version!).major;
+  if (version == null || !isComparableSemver(version)) return null;
+  return parseComparableVersion(version).major;
 }
 
 export function isSameMajorVersion(a: string | null | undefined, b: string | null | undefined): boolean {
@@ -107,8 +108,8 @@ export function normalizeVersion(version: string | null | undefined): string {
  * Build metadata (`+build.5`) is NOT a pre-release. Non-semver → false.
  */
 export function isPrerelease(version: string | null | undefined): boolean {
-  if (!isComparableSemver(version)) return false;
-  return parseComparableVersion(version!).prerelease !== null;
+  if (version == null || !isComparableSemver(version)) return false;
+  return parseComparableVersion(version).prerelease !== null;
 }
 
 /**

--- a/packages/ui/src/hooks.server.vitest.ts
+++ b/packages/ui/src/hooks.server.vitest.ts
@@ -103,7 +103,7 @@ describe('hooks.server — sliding renewal', () => {
     // Extract the new token value from the Set-Cookie header.
     const match = setCookie.match(new RegExp(`${SESSION_COOKIE_NAME}=([^;]+)`));
     expect(match, 'Set-Cookie must contain a session token').toBeTruthy();
-    const newToken = match![1];
+    const newToken = match?.[1];
 
     // The new token must be DIFFERENT from the original.
     // If it were the same, the sliding window would never extend the expiry.

--- a/packages/ui/src/lib/chat/chat-state.svelte.vitest.ts
+++ b/packages/ui/src/lib/chat/chat-state.svelte.vitest.ts
@@ -307,9 +307,9 @@ describe('tool grouping — finalized turn', () => {
 
     const assistantEntry = assistantEntries[0] as ChatMessage;
     expect(assistantEntry.toolStates).toBeDefined();
-    expect(assistantEntry.toolStates!.length).toBe(2);
-    expect(assistantEntry.toolStates![0].id).toBe('c1');
-    expect(assistantEntry.toolStates![1].id).toBe('c2');
+    expect(assistantEntry.toolStates?.length).toBe(2);
+    expect(assistantEntry.toolStates?.[0].id).toBe('c1');
+    expect(assistantEntry.toolStates?.[1].id).toBe('c2');
 
     // No standalone tool-group entries in the transcript.
     const toolEntries = chat.entries.filter(
@@ -340,7 +340,7 @@ describe('tool grouping — finalized turn', () => {
       (e) => !e.type && (e as ChatMessage).role === 'assistant'
     ) as ChatMessage | undefined;
     expect(assistantEntry).toBeDefined();
-    expect(assistantEntry!.toolStates).toBeUndefined();
+    expect(assistantEntry?.toolStates).toBeUndefined();
   });
 });
 
@@ -372,7 +372,7 @@ describe('tool grouping — session reload (getSessionMessages)', () => {
     const entry = chat.entries[0] as ChatMessage;
     expect(entry.role).toBe('assistant');
     expect(entry.toolStates).toBeDefined();
-    expect(entry.toolStates![0].id).toBe('c1');
+    expect(entry.toolStates?.[0].id).toBe('c1');
   });
 });
 

--- a/packages/ui/src/lib/components/admin/automations/task-form.ts
+++ b/packages/ui/src/lib/components/admin/automations/task-form.ts
@@ -128,11 +128,11 @@ export function validateCron(cron: string): string | null {
     [1, 12],   // month
     [0, 7],    // day-of-week (0 and 7 are both Sunday)
   ] as const;
-  for (let i = 0; i < 5; i++) {
-    const field = parts[i]!;
+  for (const [i, field] of parts.entries()) {
     if (field === '*' || /^\*\/\d+$/.test(field)) continue;
     const n = parseInt(field, 10);
     if (Number.isNaN(n)) return `Field ${i + 1} is not a valid number or wildcard`;
+    // biome-ignore lint/style/noNonNullAssertion: parts.length === 5 checked above and ranges is a fixed 5-element tuple, so ranges[i] is defined for every i.
     const [min, max] = ranges[i]!;
     if (n < min || n > max) return `Field ${i + 1} must be ${min}–${max}`;
   }

--- a/packages/ui/src/lib/components/admin/updates/UpdatesTab.svelte.vitest.ts
+++ b/packages/ui/src/lib/components/admin/updates/UpdatesTab.svelte.vitest.ts
@@ -323,7 +323,7 @@ describe('UpdatesTab — UI update', () => {
     await vi.waitFor(() => {
       expect(downloadUiVersion).toHaveBeenCalledTimes(1);
     });
-    expect(window.openpalm!.restartUiServer).toHaveBeenCalledTimes(1);
+    expect(window.openpalm?.restartUiServer).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/packages/ui/src/lib/components/akm/AkmTab.roundtrip.vitest.ts
+++ b/packages/ui/src/lib/components/akm/AkmTab.roundtrip.vitest.ts
@@ -219,7 +219,7 @@ function load(config: Record<string, unknown>): Loaded {
 	const fbRequireReason: Tri =
 		typeof feedback?.requireReason === 'boolean' ? (feedback.requireReason ? 'on' : 'off') : '';
 	const fbFailureModes = Array.isArray(feedback?.allowedFailureModes)
-		? (feedback!.allowedFailureModes as string[]).join(', ')
+		? (feedback?.allowedFailureModes as string[]).join(', ')
 		: '';
 	const indexJson = config.index && typeof config.index === 'object' ? JSON.stringify(config.index, null, 2) : '';
 

--- a/packages/ui/src/lib/components/chat/ToolLog.svelte.vitest.ts
+++ b/packages/ui/src/lib/components/chat/ToolLog.svelte.vitest.ts
@@ -44,7 +44,9 @@ describe('ToolLog', () => {
   test('clicking a summary expands its details, clicking again collapses', async () => {
     const items = [makeTool('c1', 'bash', { detail: 'ls -la', output: 'file.txt' })];
     const { container } = await render(ToolLog, { props: { items } });
-    const summary = container.querySelector<HTMLButtonElement>('.tool-log-summary')!;
+    const summary = container.querySelector<HTMLButtonElement>('.tool-log-summary');
+    expect(summary).not.toBeNull();
+    if (!summary) return;
 
     expect(summary.getAttribute('aria-expanded')).toBe('false');
     summary.click();

--- a/packages/ui/src/lib/components/chrome/TabBar.svelte.vitest.ts
+++ b/packages/ui/src/lib/components/chrome/TabBar.svelte.vitest.ts
@@ -8,8 +8,9 @@ describe('TabBar', () => {
 
     const sectionTablist = document.querySelector('[aria-label="Sections"]');
     expect(sectionTablist).not.toBeNull();
+    if (!sectionTablist) return;
     const sectionTabs = Array.from(
-      sectionTablist!.querySelectorAll<HTMLElement>('[role="tab"]')
+      sectionTablist.querySelectorAll<HTMLElement>('[role="tab"]')
     ).map((t) => t.textContent?.trim() ?? '');
     expect(sectionTabs).toEqual(['Health', 'Mind', 'Voice', 'Routines', 'Capabilities', 'Knowledge']);
   });
@@ -19,8 +20,9 @@ describe('TabBar', () => {
 
     const subtabTablist = document.querySelector('[aria-label="Health tabs"]');
     expect(subtabTablist).not.toBeNull();
+    if (!subtabTablist) return;
     const subtabLabels = Array.from(
-      subtabTablist!.querySelectorAll<HTMLElement>('[role="tab"]')
+      subtabTablist.querySelectorAll<HTMLElement>('[role="tab"]')
     ).map((t) => t.textContent?.trim() ?? '');
     expect(subtabLabels).toEqual(['Overview', 'Activity', 'Systems', 'Journal', 'Check-up', 'Recovery']);
   });
@@ -30,8 +32,9 @@ describe('TabBar', () => {
 
     const subtabTablist = document.querySelector('[aria-label="Knowledge tabs"]');
     expect(subtabTablist).not.toBeNull();
+    if (!subtabTablist) return;
     const subtabLabels = Array.from(
-      subtabTablist!.querySelectorAll<HTMLElement>('[role="tab"]')
+      subtabTablist.querySelectorAll<HTMLElement>('[role="tab"]')
     ).map((t) => t.textContent?.trim() ?? '');
     expect(subtabLabels).toEqual(['Memory', 'Assistant', 'Secrets', 'Sharing']);
   });
@@ -79,7 +82,7 @@ describe('TabBar', () => {
       document.querySelectorAll<HTMLElement>('[aria-label="Sections"] [role="tab"]')
     ).find((t) => t.textContent?.trim() === 'Knowledge');
     expect(knowledge).not.toBeUndefined();
-    knowledge!.click();
+    knowledge?.click();
     expect(onSelect).toHaveBeenCalledWith('akm');
   });
 
@@ -91,7 +94,7 @@ describe('TabBar', () => {
       document.querySelectorAll<HTMLElement>('[aria-label="Sections"] [role="tab"]')
     ).find((t) => t.textContent?.trim() === 'Routines');
     expect(routines).not.toBeUndefined();
-    routines!.click();
+    routines?.click();
     expect(onSelect).toHaveBeenCalledWith('automations');
   });
 
@@ -103,7 +106,7 @@ describe('TabBar', () => {
       document.querySelectorAll<HTMLElement>('[aria-label="Knowledge tabs"] [role="tab"]')
     ).find((t) => t.textContent?.trim() === 'Sharing');
     expect(sharing).not.toBeUndefined();
-    sharing!.click();
+    sharing?.click();
     expect(onSelect).toHaveBeenCalledWith('host-sharing');
   });
 });

--- a/packages/ui/src/lib/server/core-assets.vitest.ts
+++ b/packages/ui/src/lib/server/core-assets.vitest.ts
@@ -37,6 +37,7 @@ describe("readCoreCompose", () => {
   });
 
   test("readCoreCompose returns file content when file exists", () => {
+    // biome-ignore lint/style/noNonNullAssertion: OP_HOME is assigned in beforeEach, so it is defined for every test in this suite.
     const stackDir = join(process.env.OP_HOME!, "system", "stack");
     mkdirSync(stackDir, { recursive: true });
     const composeContent = "services:\n  memory:\n    image: test\n";
@@ -69,6 +70,7 @@ describe("ensureOpenCodeSystemConfig", () => {
 
   test("creates data/assistant/ directory", () => {
     ensureOpenCodeSystemConfig();
+    // biome-ignore lint/style/noNonNullAssertion: OP_HOME is assigned in beforeEach, so it is defined for every test in this suite.
     const assistantDir = join(process.env.OP_HOME!, "data", "assistant");
     expect(existsSync(assistantDir)).toBe(true);
   });
@@ -76,11 +78,13 @@ describe("ensureOpenCodeSystemConfig", () => {
   test("is idempotent", () => {
     ensureOpenCodeSystemConfig();
     ensureOpenCodeSystemConfig();
+    // biome-ignore lint/style/noNonNullAssertion: OP_HOME is assigned in beforeEach, so it is defined for every test in this suite.
     const assistantDir = join(process.env.OP_HOME!, "data", "assistant");
     expect(existsSync(assistantDir)).toBe(true);
   });
 
   test("does not overwrite existing files", () => {
+    // biome-ignore lint/style/noNonNullAssertion: OP_HOME is assigned in beforeEach, so it is defined for every test in this suite.
     const assistantDir = join(process.env.OP_HOME!, "data", "assistant");
     mkdirSync(assistantDir, { recursive: true });
     writeFileSync(join(assistantDir, "opencode.jsonc"), "user-config");

--- a/packages/ui/src/lib/server/helpers.vitest.ts
+++ b/packages/ui/src/lib/server/helpers.vitest.ts
@@ -140,8 +140,8 @@ describe("requireAdmin", () => {
     const event = makeEvent({ "x-admin-token": "test-admin-token-12345" });
     const result = requireAdmin(event as never, "req-1-header");
     expect(result).not.toBeNull();
-    expect(result!.status).toBe(401);
-    const body = await result!.json();
+    expect(result?.status).toBe(401);
+    const body = await result?.json();
     expect(body.error).toBe("unauthorized");
   });
 
@@ -149,15 +149,15 @@ describe("requireAdmin", () => {
     const event = makeEvent({ authorization: "Bearer test-admin-token-12345" });
     const result = requireAdmin(event as never, "req-1-bearer");
     expect(result).not.toBeNull();
-    expect(result!.status).toBe(401);
+    expect(result?.status).toBe(401);
   });
 
   test("returns 401 for missing token", async () => {
     const event = makeEvent({});
     const result = requireAdmin(event as never, "req-2");
     expect(result).not.toBeNull();
-    expect(result!.status).toBe(401);
-    const body = await result!.json();
+    expect(result?.status).toBe(401);
+    const body = await result?.json();
     expect(body.error).toBe("unauthorized");
   });
 
@@ -165,27 +165,27 @@ describe("requireAdmin", () => {
     const event = makeEvent({ cookie: "op_session=wrong-token" });
     const result = requireAdmin(event as never, "req-3");
     expect(result).not.toBeNull();
-    expect(result!.status).toBe(401);
+    expect(result?.status).toBe(401);
   });
 
   test("returns 401 for empty cookie value", async () => {
     const event = makeEvent({ cookie: "op_session=" });
     const result = requireAdmin(event as never, "req-4");
     expect(result).not.toBeNull();
-    expect(result!.status).toBe(401);
+    expect(result?.status).toBe(401);
   });
 
   test("rejects token that differs only in length (timing-safe)", async () => {
     const event = makeEvent({ cookie: "op_session=test-admin-token-1234" }); // one char shorter
     const result = requireAdmin(event as never, "req-5");
     expect(result).not.toBeNull();
-    expect(result!.status).toBe(401);
+    expect(result?.status).toBe(401);
   });
 
   test("includes requestId in error response", async () => {
     const event = makeEvent({});
     const result = requireAdmin(event as never, "my-request-id");
-    const body = await result!.json();
+    const body = await result?.json();
     expect(body.requestId).toBe("my-request-id");
   });
 });
@@ -218,14 +218,14 @@ describe("identifyCallerByToken / requireAdmin (cookie-only after Phase 2)", () 
     const event = makeEvent({ cookie: "op_session=some-stale-value" });
     const result = requireAdmin(event as never, "req-stale");
     expect(result).not.toBeNull();
-    expect(result!.status).toBe(401);
+    expect(result?.status).toBe(401);
   });
 
   test("requireAdmin rejects admin token presented via x-admin-token header", async () => {
     const event = makeEvent({ "x-admin-token": "test-admin-token-12345" });
     const result = requireAdmin(event as never, "req-header");
     expect(result).not.toBeNull();
-    expect(result!.status).toBe(401);
+    expect(result?.status).toBe(401);
   });
 
   test("requireAdmin passes for admin token via cookie", () => {
@@ -237,8 +237,8 @@ describe("identifyCallerByToken / requireAdmin (cookie-only after Phase 2)", () 
     const event = makeEvent({ cookie: "op_session=nope" });
     const result = requireAdmin(event as never, "req-bad");
     expect(result).not.toBeNull();
-    expect(result!.status).toBe(401);
-    const body = await result!.json();
+    expect(result?.status).toBe(401);
+    const body = await result?.json();
     expect(body.requestId).toBe("req-bad");
   });
 });

--- a/packages/ui/src/lib/server/paths.vitest.ts
+++ b/packages/ui/src/lib/server/paths.vitest.ts
@@ -24,6 +24,7 @@ describe("ensureHomeDirs", () => {
 
   test("creates full home directory tree", () => {
     ensureHomeDirs();
+    // biome-ignore lint/style/noNonNullAssertion: OP_HOME is assigned in beforeEach, so it is defined for every test in this suite.
     const home = process.env.OP_HOME!;
 
     // config/ — user-editable + system config files
@@ -79,7 +80,9 @@ describe("ensureHomeDirs", () => {
   test("is idempotent — safe to call multiple times", () => {
     ensureHomeDirs();
     ensureHomeDirs();
+    // biome-ignore lint/style/noNonNullAssertion: OP_HOME is assigned in beforeEach, so it is defined for every test in this suite.
     expect(existsSync(join(process.env.OP_HOME!, "config"))).toBe(true);
+    // biome-ignore lint/style/noNonNullAssertion: OP_HOME is assigned in beforeEach, so it is defined for every test in this suite.
     expect(existsSync(join(process.env.OP_HOME!, "data"))).toBe(true);
   });
 });

--- a/packages/ui/src/lib/server/release-units.ts
+++ b/packages/ui/src/lib/server/release-units.ts
@@ -78,6 +78,7 @@ export function groupReleasesByUnit(raw: RawGitHubRelease[]): GroupedReleases {
     // Per-unit tags first (assistant/guardian/portals) — never carry Electron.
     const unitMatch = UNIT_TAG_PATTERNS.find((p) => p.re.test(rawTag));
     if (unitMatch) {
+      // biome-ignore lint/style/noNonNullAssertion: unitMatch was found via re.test(rawTag), so rawTag.match(unitMatch.re) is non-null and every UNIT_TAG_PATTERN has one capture group, so [1] is defined.
       const tag = rawTag.match(unitMatch.re)![1];
       if (!seenUnit[unitMatch.unit].has(tag)) {
         seenUnit[unitMatch.unit].add(tag);

--- a/packages/ui/src/lib/server/release-units.vitest.ts
+++ b/packages/ui/src/lib/server/release-units.vitest.ts
@@ -24,7 +24,7 @@ describe('groupReleasesByUnit', () => {
     expect(result.unitReleases.guardian.map((r) => r.tag)).toEqual(['0.12.7']);
     expect(result.unitReleases.portals.map((r) => r.tag)).toEqual(['0.12.6']);
     // Unit releases never carry Electron assets.
-    expect(result.unitReleases.guardian[0]!.hasElectronBuild).toBe(false);
+    expect(result.unitReleases.guardian[0]?.hasElectronBuild).toBe(false);
     // Platform list stays empty when no platform/v tags are present.
     expect(result.releases).toEqual([]);
   });
@@ -36,8 +36,8 @@ describe('groupReleasesByUnit', () => {
     ]);
 
     expect(result.releases.map((r) => r.tag)).toEqual(['0.12.5', '0.12.4']);
-    expect(result.releases[0]!.hasElectronBuild).toBe(true);
-    expect(result.releases[1]!.hasElectronBuild).toBe(false);
+    expect(result.releases[0]?.hasElectronBuild).toBe(true);
+    expect(result.releases[1]?.hasElectronBuild).toBe(false);
   });
 
   test('deduplicates platform-X.Y.Z vs legacy vX.Y.Z for the same semver', () => {
@@ -49,7 +49,7 @@ describe('groupReleasesByUnit', () => {
     ]);
 
     expect(result.releases.map((r) => r.tag)).toEqual(['0.12.5']);
-    expect(result.releases[0]!.hasElectronBuild).toBe(true);
+    expect(result.releases[0]?.hasElectronBuild).toBe(true);
   });
 
   test('deduplicates within a unit list by semver', () => {
@@ -78,7 +78,7 @@ describe('groupReleasesByUnit', () => {
     ]);
 
     expect(result.unitReleases.assistant.map((r) => r.tag)).toEqual(['0.13.0-rc.1']);
-    expect(result.unitReleases.assistant[0]!.prerelease).toBe(true);
+    expect(result.unitReleases.assistant[0]?.prerelease).toBe(true);
   });
 
   test('returns empty lists for an empty input', () => {
@@ -98,7 +98,7 @@ describe('selectInstallableReleases', () => {
     ]);
 
     expect(releases.map((r) => r.tag)).toEqual(['0.12.5']);
-    expect(releases[0]!.hasElectronBuild).toBe(true);
+    expect(releases[0]?.hasElectronBuild).toBe(true);
   });
 
   test('skips platform releases without Electron assets', () => {
@@ -117,7 +117,7 @@ describe('selectInstallableReleases', () => {
     ]);
 
     expect(releases).toHaveLength(1);
-    expect(releases[0]!.tag).toBe('0.12.5');
+    expect(releases[0]?.tag).toBe('0.12.5');
   });
 
   test('skips per-unit tags (assistant-*, guardian-*, portals-*)', () => {

--- a/packages/ui/src/lib/server/secrets.vitest.ts
+++ b/packages/ui/src/lib/server/secrets.vitest.ts
@@ -306,6 +306,7 @@ describe("ensureOpenCodeConfig", () => {
   test("seeds opencode.json with schema reference", () => {
     ensureOpenCodeConfig();
 
+    // biome-ignore lint/style/noNonNullAssertion: OP_HOME is assigned in beforeEach, so it is defined for every test in this suite.
     const configFile = join(process.env.OP_HOME!, "config", "assistant", "opencode.json");
     expect(existsSync(configFile)).toBe(true);
     const content = JSON.parse(readFileSync(configFile, "utf-8"));
@@ -314,6 +315,7 @@ describe("ensureOpenCodeConfig", () => {
 
   test("creates tools, plugins, skills subdirs", () => {
     ensureOpenCodeConfig();
+    // biome-ignore lint/style/noNonNullAssertion: OP_HOME is assigned in beforeEach, so it is defined for every test in this suite.
     const base = join(process.env.OP_HOME!, "config", "assistant");
     expect(existsSync(join(base, "tools"))).toBe(true);
     expect(existsSync(join(base, "plugins"))).toBe(true);
@@ -321,6 +323,7 @@ describe("ensureOpenCodeConfig", () => {
   });
 
   test("does not overwrite existing opencode.json", () => {
+    // biome-ignore lint/style/noNonNullAssertion: OP_HOME is assigned in beforeEach, so it is defined for every test in this suite.
     const configHome = join(process.env.OP_HOME!, "config");
     const opencodePath = join(configHome, "assistant");
     mkdirSync(opencodePath, { recursive: true });

--- a/packages/ui/src/routes/admin/akm/health/+server.ts
+++ b/packages/ui/src/routes/admin/akm/health/+server.ts
@@ -32,7 +32,7 @@ export const GET: RequestHandler = async (event) => {
   }
 
   // Summarise the hard checks into pass/warn/fail counts.
-  const checks = Array.isArray(parsedHealth?.hardChecks) ? (parsedHealth!.hardChecks as Array<{ status?: string }>) : [];
+  const checks = Array.isArray(parsedHealth?.hardChecks) ? (parsedHealth?.hardChecks as Array<{ status?: string }>) : [];
   const checkCounts = { pass: 0, warn: 0, fail: 0 };
   for (const c of checks) {
     if (c.status === 'pass') checkCounts.pass++;

--- a/packages/ui/src/routes/admin/providers/_helpers.ts
+++ b/packages/ui/src/routes/admin/providers/_helpers.ts
@@ -61,6 +61,7 @@ export function parseModels(modelsJson: string) {
 	return parsed
 		.filter((m) => typeof m.id === 'string' && m.id.trim().length > 0)
 		.map((m) => ({
+			// biome-ignore lint/style/noNonNullAssertion: the preceding .filter guarantees m.id is a non-empty string.
 			id: m.id!.trim(),
 			name: typeof m.name === 'string' ? m.name.trim() : '',
 			contextLimit: parseLimit(m.contextLimit),
@@ -91,6 +92,7 @@ export function parseHeaders(headersJson: string): Record<string, string> {
 	return Object.fromEntries(
 		parsed
 			.filter((h) => typeof h.key === 'string' && typeof h.value === 'string')
+			// biome-ignore lint/style/noNonNullAssertion: the preceding .filter guarantees both h.key and h.value are strings.
 			.map((h) => [h.key!.trim(), h.value!.trim()])
 			.filter((e) => e[0].length > 0 && e[1].length > 0)
 	);

--- a/packages/ui/src/routes/admin/versions/+server.ts
+++ b/packages/ui/src/routes/admin/versions/+server.ts
@@ -104,17 +104,17 @@ async function resolveDockerLatestSilent(
     const candidates: string[] = [];
     for (const tag of data.results ?? []) {
       // Stable semver always accepted
-      const plain = tag.name.match(STABLE_SEMVER);
-      if (plain) { candidates.push(plain[1]!); continue; }
+      const plain = tag.name.match(STABLE_SEMVER)?.[1];
+      if (plain) { candidates.push(plain); continue; }
       // Voice variant tags (X.Y.Z-cpu etc.) — extract base version for the voice image
       if (isVoice) {
-        const voice = tag.name.match(VOICE_STABLE);
-        if (voice) { candidates.push(voice[1]!); continue; }
+        const voice = tag.name.match(VOICE_STABLE)?.[1];
+        if (voice) { candidates.push(voice); continue; }
       }
       // Prerelease tags accepted only on the "next" channel
       if (channel === "next") {
-        const pre = tag.name.match(PRERELEASE_SEMVER);
-        if (pre) candidates.push(pre[1]!);
+        const pre = tag.name.match(PRERELEASE_SEMVER)?.[1];
+        if (pre) candidates.push(pre);
       }
     }
     if (candidates.length === 0) return null;

--- a/packages/ui/src/routes/admin/versions/releases/server.vitest.ts
+++ b/packages/ui/src/routes/admin/versions/releases/server.vitest.ts
@@ -55,7 +55,7 @@ describe('GET /admin/versions/releases', () => {
     expect(res.status).toBe(200);
     const body = await res.json() as { releases: { tag: string; hasElectronBuild: boolean }[] };
     expect(body.releases.map((r) => r.tag)).toEqual(['0.12.5']);
-    expect(body.releases[0]!.hasElectronBuild).toBe(true);
+    expect(body.releases[0]?.hasElectronBuild).toBe(true);
   });
 
   test('skips platform releases without Electron assets', async () => {
@@ -80,7 +80,7 @@ describe('GET /admin/versions/releases', () => {
     expect(res.status).toBe(200);
     const body = await res.json() as { releases: { tag: string }[] };
     expect(body.releases).toHaveLength(1);
-    expect(body.releases[0]!.tag).toBe('0.12.5');
+    expect(body.releases[0]?.tag).toBe('0.12.5');
   });
 
   test('returns empty list with error when GitHub API returns an error status', async () => {

--- a/packages/ui/src/routes/advanced/page.svelte.vitest.ts
+++ b/packages/ui/src/routes/advanced/page.svelte.vitest.ts
@@ -129,7 +129,7 @@ describe('/advanced/+page.svelte', () => {
 
     const iframe = page.getByTitle('OpenCode — Advanced Chat');
     await expect.element(iframe).toBeVisible();
-    const src = document.querySelector('iframe[title="OpenCode — Advanced Chat"]')!.getAttribute('src')!;
+    const src = document.querySelector('iframe[title="OpenCode — Advanced Chat"]')?.getAttribute('src');
     // base64('/work') = 'L3dvcms' — the workspace segment must encode the real dir.
     expect(src).toContain('/L3dvcms/session/ses_known');
     // Never the old hardcoded path base64('/work/itlackey/openpalm').
@@ -143,7 +143,7 @@ describe('/advanced/+page.svelte', () => {
 
     const iframe = page.getByTitle('OpenCode — Advanced Chat');
     await expect.element(iframe).toBeVisible();
-    const src = document.querySelector('iframe[title="OpenCode — Advanced Chat"]')!.getAttribute('src')!;
+    const src = document.querySelector('iframe[title="OpenCode — Advanced Chat"]')?.getAttribute('src');
     // No broken /session/ deep link — just the endpoint base.
     expect(src).not.toContain('/session/');
     expect(src).toBe('http://127.0.0.1:3800');

--- a/packages/ui/src/routes/proxy/assistant/[...path]/server.vitest.ts
+++ b/packages/ui/src/routes/proxy/assistant/[...path]/server.vitest.ts
@@ -60,6 +60,7 @@ beforeEach(async () => {
     };
     tick();
   });
+  // biome-ignore lint/style/noNonNullAssertion: sseServer was assigned via createServer directly above; TS drops that narrowing inside this Promise-executor closure.
   await new Promise<void>((resolve) => sseServer!.listen(0, '127.0.0.1', resolve));
   const port = (sseServer.address() as AddressInfo).port;
   sseUrl = `http://127.0.0.1:${port}`;
@@ -108,7 +109,9 @@ describe('proxy/assistant streaming passthrough', () => {
 
     // Read chunks with timestamps so we can confirm they arrive over time
     // rather than as one buffered blob.
-    const reader = res.body!.getReader();
+    const body = res.body;
+    if (!body) throw new Error('response body must be a ReadableStream');
+    const reader = body.getReader();
     const decoder = new TextDecoder();
     const arrivals: { t: number; text: string }[] = [];
     const start = Date.now();

--- a/packages/ui/src/routes/setup/+page.svelte
+++ b/packages/ui/src/routes/setup/+page.svelte
@@ -42,12 +42,8 @@
   {#if s.currentStep === 0 && !s.showDeploy}
     <div style="display:none" aria-hidden="true">
       <section class="step-content step-content--hidden" id="step-0" data-testid="step-system-check">
-        <SystemCheckStep
-          isRerun={s.isRerun}
-          onpass={() => s.handleSystemCheckPass()}
-          onnext={() => s.handleSystemCheckPass()}
-          ongpudetected={() => s.handleGpuDetected()}
-        />
+        <!-- SystemCheckStep reads the setup-state store directly. -->
+        <SystemCheckStep />
       </section>
     </div>
   {/if}

--- a/packages/ui/src/routes/setup/steps/CloudAttachPanel.svelte
+++ b/packages/ui/src/routes/setup/steps/CloudAttachPanel.svelte
@@ -13,33 +13,21 @@
 
   import ProviderOAuthList from './ProviderOAuthList.svelte';
   import Spinner from '$lib/components/common/Spinner.svelte';
-  import type { OpenCodeProvider, AuthMethod, ProviderState } from '$lib/client/types.js';
+  import { setupState } from '$lib/setup/setup-state.svelte.js';
 
-  interface Props {
-    credentialCount?: number;
-    cloudProviders?: string[];
-    opencodeProviders?: OpenCodeProvider[];
-    opencodeAuth?: Record<string, AuthMethod[]>;
-    providerState?: Record<string, ProviderState>;
-    hostImporting?: boolean;
-    verifiedCount?: number;
-    onhostimport?: () => void;
-    onoauthstart?: (id: string, methodIndex: number) => void;
-    onoauthcancel?: (id: string) => void;
-  }
+  // Takes NO props: reads the setup-state store directly (hostImporting /
+  // verifiedCount) and calls its host-import method, mirroring Screen1ModelsStep
+  // / ReviewStep. The nested ProviderOAuthList likewise reads the store.
+  const s = setupState;
 
-  let {
-    credentialCount = 0,
-    cloudProviders = [],
-    opencodeProviders = [],
-    opencodeAuth = {},
-    providerState = {},
-    hostImporting = false,
-    verifiedCount = 0,
-    onhostimport,
-    onoauthstart,
-    onoauthcancel,
-  }: Props = $props();
+  // The wizard always drove these as 0 / [] — the "account already found on this
+  // computer" path is inert in the current flow but kept for behavior parity.
+  const credentialCount = 0;
+  const cloudProviders: string[] = [];
+
+  const hostImporting = $derived(s.hostImporting);
+  const verifiedCount = $derived(s.verifiedCount);
+  const onhostimport = (): void => void s.handleHostImport();
 
   const hasFoundAccount = $derived(credentialCount > 0 || cloudProviders.length > 0);
   const connected = $derived(verifiedCount > 0);
@@ -74,13 +62,7 @@
   {:else}
     <!-- Sign in to a cloud AI service -->
     <p class="lead">Sign in to your AI service:</p>
-    <ProviderOAuthList
-      {opencodeProviders}
-      {opencodeAuth}
-      {providerState}
-      onoauthstart={(id, idx) => onoauthstart?.(id, idx)}
-      onoauthcancel={(id) => onoauthcancel?.(id)}
-    />
+    <ProviderOAuthList />
     {#if hasFoundAccount}
       <button type="button" class="account-link" onclick={() => (signInInstead = false)}>
         Use the account on this computer instead

--- a/packages/ui/src/routes/setup/steps/LocalModelsStatus.svelte
+++ b/packages/ui/src/routes/setup/steps/LocalModelsStatus.svelte
@@ -2,40 +2,22 @@
   /**
    * LocalModelsStatus — shows the local model runtime state for Screen 1.
    *
-   * Props:
-   *   hostProviders      — runtimes already running on the host (ollama / lmstudio / model-runner)
-   *   gpuVramMb          — detected VRAM in MiB (0 = not detected)
-   *   gpuVendor          — 'apple' | 'nvidia' | 'amd' | '' (empty = not detected)
-   *   gpuName            — human-readable GPU name from detection
-   *   ollamaEnabled      — true when in-stack Ollama will be added
-   *   selectedOllamaProfile — Ollama profile id (cuda / rocm / cpu)
-   *   onrecheck          — called when the user clicks Re-check (re-calls GET /api/setup/recommend)
+   * Takes NO props: reads the setup-state store directly (detected host runtimes,
+   * GPU info, in-stack Ollama selection) and calls its recommendation re-check,
+   * mirroring Screen1ModelsStep / ReviewStep.
    */
 
-  interface HostProvider {
-    provider: string;
-    url: string;
-  }
+  import { setupState } from '$lib/setup/setup-state.svelte.js';
 
-  interface Props {
-    hostProviders?: HostProvider[];
-    gpuVramMb?: number;
-    gpuVendor?: string;
-    gpuName?: string;
-    ollamaEnabled?: boolean;
-    selectedOllamaProfile?: string;
-    onrecheck?: () => void;
-  }
+  const s = setupState;
 
-  let {
-    hostProviders = [],
-    gpuVramMb = 0,
-    gpuVendor = '',
-    gpuName = '',
-    ollamaEnabled = false,
-    selectedOllamaProfile = '',
-    onrecheck,
-  }: Props = $props();
+  const hostProviders = $derived(s.detectedHostProviders);
+  const gpuVramMb = $derived(s.detectedGpuVramMb);
+  const gpuVendor = $derived(s.detectedGpuVendor);
+  const gpuName = $derived(s.detectedGpuName);
+  const ollamaEnabled = $derived(s.ollamaEnabled);
+  const selectedOllamaProfile = $derived(s.selectedOllamaProfile);
+  const onrecheck = (): void => void s.fetchAndApplyRecommendation();
 
   const isAppleSilicon = $derived(gpuVendor === 'apple');
   const hasRunningRuntime = $derived(hostProviders.length > 0);

--- a/packages/ui/src/routes/setup/steps/ProviderOAuthList.svelte
+++ b/packages/ui/src/routes/setup/steps/ProviderOAuthList.svelte
@@ -5,33 +5,23 @@
    * Renders a compact vertical list of OAuth-capable providers,
    * filtered through WIZARD_EXCLUDED_PROVIDERS (no Anthropic).
    *
-   * Props:
-   *   opencodeProviders  — full list from /api/setup/recommend
-   *   opencodeAuth       — auth methods per provider id
-   *   providerState      — current verification state per provider id
-   *   onoauthstart       — called when the user clicks "Sign in" for a provider
-   *   onoauthcancel      — called when OAuth poll should be aborted
+   * Takes NO props: reads the setup-state store directly (opencodeProviders /
+   * opencodeAuth / providerState) and calls its OAuth methods
+   * (startOpenCodeOAuth / cancelOAuth), mirroring Screen1ModelsStep / ReviewStep.
    */
 
   import { WIZARD_EXCLUDED_PROVIDERS } from '$lib/client/constants.js';
-  import type { OpenCodeProvider, AuthMethod, ProviderState } from '$lib/client/types.js';
+  import type { ProviderState } from '$lib/client/types.js';
   import Spinner from '$lib/components/common/Spinner.svelte';
+  import { setupState } from '$lib/setup/setup-state.svelte.js';
 
-  interface Props {
-    opencodeProviders: OpenCodeProvider[];
-    opencodeAuth: Record<string, AuthMethod[]>;
-    providerState: Record<string, ProviderState>;
-    onoauthstart: (id: string, methodIndex: number) => void;
-    onoauthcancel: (id: string) => void;
-  }
+  const s = setupState;
 
-  let {
-    opencodeProviders,
-    opencodeAuth,
-    providerState,
-    onoauthstart,
-    onoauthcancel,
-  }: Props = $props();
+  const opencodeProviders = $derived(s.opencodeProviders);
+  const opencodeAuth = $derived(s.opencodeAuth);
+  const providerState = $derived(s.providerState);
+  const onoauthstart = (id: string, methodIndex: number): void => void s.startOpenCodeOAuth(id, methodIndex);
+  const onoauthcancel = (id: string): void => s.cancelOAuth(id);
 
   // Order recognizable consumer providers first; obscure ones fall to the end.
   const RECOGNIZABLE_FIRST = ['openai', 'google', 'github-copilot', 'groq', 'mistral', 'huggingface'];

--- a/packages/ui/src/routes/setup/steps/Screen1ModelsStep.svelte
+++ b/packages/ui/src/routes/setup/steps/Screen1ModelsStep.svelte
@@ -42,13 +42,8 @@
   const systemCheckError = $derived(s.systemCheckPassed ? '' : (s.step0Error || ''));
   const gpuVramMb = $derived(s.detectedGpuVramMb);
   const gpuVendor = $derived(s.detectedGpuVendor);
-  const gpuName = $derived(s.detectedGpuName);
   const hostProviders = $derived(s.detectedHostProviders);
   const opencodeProviders = $derived(s.opencodeProviders);
-  const opencodeAuth = $derived(s.opencodeAuth);
-  const providerState = $derived(s.providerState);
-  const ollamaEnabled = $derived(s.ollamaEnabled);
-  const selectedOllamaProfile = $derived(s.selectedOllamaProfile);
   const hostImporting = $derived(s.hostImporting);
   const verifiedCount = $derived(s.verifiedCount);
   const allowEmptyInstall = $derived(s.allowEmptyInstall);
@@ -57,9 +52,6 @@
   const detectedCloudConn = $derived(s.detectedCloudConn);
 
   const onmodelmodechange = (mode: ModelMode): void => s.handleConnectModeChange(mode);
-  const onhostimport = (): void => void s.handleHostImport();
-  const onoauthstart = (id: string, methodIndex: number): void => void s.startOpenCodeOAuth(id, methodIndex);
-  const onoauthcancel = (id: string): void => s.cancelOAuth(id);
   const onrecheck = (): void => void s.fetchAndApplyRecommendation();
   const onsystemcheckretry = (): void => s.goToStep(0);
   const onallowemptyinstallchange = (v: boolean): void => { s.allowEmptyInstall = v; };
@@ -245,15 +237,7 @@
       <!-- Local AI expansion panel (accordion below local row) -->
       {#if showLocalPanel}
         <div class="s1-local-panel" aria-live="polite">
-          <LocalModelsStatus
-            {hostProviders}
-            {gpuVramMb}
-            {gpuVendor}
-            {gpuName}
-            {ollamaEnabled}
-            {selectedOllamaProfile}
-            {onrecheck}
-          />
+          <LocalModelsStatus />
         </div>
       {/if}
 
@@ -278,18 +262,7 @@
       <!-- Sign-in panel expands inline below the cloud row -->
       {#if showSignInPanel}
         <div class="s1-signin-panel" aria-live="polite">
-          <CloudAttachPanel
-            credentialCount={0}
-            cloudProviders={[]}
-            {opencodeProviders}
-            {opencodeAuth}
-            {providerState}
-            {hostImporting}
-            {verifiedCount}
-            {onhostimport}
-            onoauthstart={(id, idx) => onoauthstart?.(id, idx)}
-            onoauthcancel={(id) => onoauthcancel?.(id)}
-          />
+          <CloudAttachPanel />
         </div>
       {/if}
 

--- a/packages/ui/src/routes/setup/steps/SystemCheckStep.svelte
+++ b/packages/ui/src/routes/setup/steps/SystemCheckStep.svelte
@@ -5,6 +5,7 @@
   import IconConnect from '$lib/components/icons/IconConnect.svelte';
   import { friendlyError, type FriendlyErrorView } from '$lib/client/error-messages.js';
   import Spinner from '$lib/components/common/Spinner.svelte';
+  import { setupState } from '$lib/setup/setup-state.svelte.js';
 
   interface CheckResult {
     ok: boolean;
@@ -43,16 +44,18 @@
 
   const KNOWN_PROVIDERS = new Set(['ollama', 'lmstudio', 'model-runner']);
 
-  interface Props {
-    onnext: () => void;
-    onpass: () => void;
-    ongpudetected?: (gpu: string) => void;
-    /** True when re-running an existing install; suppresses misleading
-     *  port-conflict warnings that just reflect the running stack itself. */
-    isRerun?: boolean;
-  }
+  // Takes NO props: reads the setup-state store directly (isRerun) and calls its
+  // navigation / GPU-detection methods, mirroring Screen1ModelsStep / ReviewStep.
+  // `onnext` and `onpass` both mapped to handleSystemCheckPass at the call site;
+  // `ongpudetected` ignored its gpu argument (the store re-derives it).
+  const s = setupState;
 
-  let { onnext, onpass, ongpudetected, isRerun = false }: Props = $props();
+  const onnext = (): void => s.handleSystemCheckPass();
+  const onpass = (): void => s.handleSystemCheckPass();
+  const ongpudetected = (): void => s.handleGpuDetected();
+  /** True when re-running an existing install; suppresses misleading
+   *  port-conflict warnings that just reflect the running stack itself. */
+  const isRerun = $derived(s.isRerun);
 
   let loading = $state(true);
   let result = $state<SystemCheckResponse | null>(null);
@@ -89,7 +92,7 @@
       const data = await res.json() as SystemCheckResponse;
       result = data;
       if (data.docker.ok && data.compose.ok) onpass();
-      if (data.gpu) ongpudetected?.(data.gpu);
+      if (data.gpu) ongpudetected();
     } catch (err) {
       errorView = friendlyError(err, 'system-check');
       result = null;

--- a/portals/discord/src/index.test.ts
+++ b/portals/discord/src/index.test.ts
@@ -454,13 +454,14 @@ describe("parseCustomCommands", () => {
     }]);
     const commands = parseCustomCommands(json);
     expect(commands.length).toBe(1);
-    const opts = commands[0].options!;
-    expect(opts.length).toBe(4);
-    expect(opts[0].type).toBe(CommandOptionType.STRING);
-    expect(opts[1].type).toBe(CommandOptionType.NUMBER);
-    expect(opts[2].type).toBe(CommandOptionType.BOOLEAN);
+    const opts = commands[0].options;
+    expect(opts).toBeDefined();
+    expect(opts?.length).toBe(4);
+    expect(opts?.[0].type).toBe(CommandOptionType.STRING);
+    expect(opts?.[1].type).toBe(CommandOptionType.NUMBER);
+    expect(opts?.[2].type).toBe(CommandOptionType.BOOLEAN);
     // Invalid type defaults to STRING
-    expect(opts[3].type).toBe(CommandOptionType.STRING);
+    expect(opts?.[3].type).toBe(CommandOptionType.STRING);
   });
 
   it("handles option choices", () => {
@@ -1098,7 +1099,8 @@ describe("command validation edge cases", () => {
     }]);
     const commands = parseCustomCommands(json);
     expect(commands.length).toBe(1);
-    const resolved = resolvePromptTemplate(commands[0].promptTemplate!, { text: "hello", lang: "Spanish" });
+    expect(commands[0].promptTemplate).toBeDefined();
+    const resolved = resolvePromptTemplate(commands[0].promptTemplate ?? "", { text: "hello", lang: "Spanish" });
     expect(resolved).toBe("Translate 'hello' to Spanish");
   });
 });
@@ -1122,7 +1124,7 @@ describe("full command flow", () => {
     expect(cmd).toBeDefined();
     expect(cmd?.promptTemplate).toBeDefined();
 
-    const prompt = resolvePromptTemplate(cmd!.promptTemplate!, { topic: "recursion" });
+    const prompt = resolvePromptTemplate(cmd?.promptTemplate ?? "", { topic: "recursion" });
     expect(prompt).toBe("Explain recursion in simple terms");
   });
 

--- a/portals/slack/src/index.ts
+++ b/portals/slack/src/index.ts
@@ -264,7 +264,8 @@ export default class SlackChannel extends BasePortal {
         : `slack:channel:${event.channel}:user:${event.user}`;
 
     if (inTrackedThread) {
-      this.touchThread(event.channel, event.thread_ts!);
+      // inTrackedThread implies event.thread_ts != null (see above), so threadTs === event.thread_ts here.
+      this.touchThread(event.channel, threadTs);
     }
 
     await this.conversationQueue.runOrQueue(sessionKey, {


### PR DESCRIPTION
## Summary

Follow-up to the code-quality work (#543, #544). Addresses the remaining substantive cleanup, behavior-preserving, with `bun run lint` still at **0 warnings**.

### 1. Non-null assertions properly resolved (rule re-enabled)

`noNonNullAssertion` was previously `off` by policy; this re-enables it (`warn`) and drives all **177** sites to zero — each **addressed per-site**, not silenced:

- Converted to optional chaining / nullish-coalescing / a preceding narrowing guard where that's a genuine, behavior-preserving improvement (e.g. `match(re)?.[1]`, `x?.` in tests already guarded by `expect(x).not.toBeNull()`).
- Kept `x!` with a **specific `biome-ignore` rationale** only where the value is a deliberate, provably-non-null invariant — explicitly **not** rewriting `a!.b`→`a?.b` where a null `a` *should* throw (that would turn a throw into a silent `undefined`). Examples: `process.getuid!()` behind a `platform !== 'win32'` guard; a DB row after `INSERT … ON CONFLICT`; a route present on every matched allowlist entry.

Also drops the deprecated Biome `recommended: true` field (the recommended preset is the default, so rules are unchanged) — clears the last informational notice.

### 2. Setup wizard grandchild prop-drilling folded into the store

`CloudAttachPanel`, `LocalModelsStatus`, `ProviderOAuthList`, and `SystemCheckStep` now read the `setupState` store directly (mirroring `Screen1ModelsStep`/`ReviewStep`) instead of threaded props, dropping the drilled props + now-unused aliases from `Screen1ModelsStep`/`+page.svelte`. `DeployStep` keeps its explicit deploy props (deliberately not folded).

### 3. Stale-docs sweep

Corrected outdated references across `AGENTS.md`, `containers/guardian/README.md`, `docs/technical/foundations.md`, and `docs/portals/community-portals.md` — chiefly the `containers/guardian/src` → `packages/guardian` (`@openpalm/guardian`) source relocation, plus stale file/command citations. Every file path introduced was verified to resolve on disk.

### Deliberately left as-is

- `SERVICE_NAMED_VOLUMES` (lib) stays a hand-maintained literal — the compose files aren't in lib's build tree (they're a runtime skeleton artifact), and the literal is a curated set of *repair-needing* volumes; deriving it would over-repair (behavior change) and add YAML-parsing fragility. Explicit is correct here.
- `noTemplateCurlyInString` stays `off` (documented) — every hit is a test asserting on a literal `${VAR}` compose string; re-enabling would only add ignore-comment noise.
- Cross-package port-constant hoist descoped (CLI/Electron already dedupe locally).

## Testing

All suites green (only the documented pre-existing environmental failures — root-uid ownership tests, one IPv6 guardian bind; sandbox runs as uid 0):

- guardian 190/1 · lib 723/12 · portals+SDK 283/0 · cli 71/1 · electron 75/75 · UI vitest 557 · `svelte-check` 0 errors.
- `bun run lint` → **0 warnings, 0 infos**. Zero behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NDPRjdj7sQejNRahQZdubh)_