### PR TITLE
ci: reclaim runner disk space in quality-gates job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,27 @@ jobs:
         with:
           fetch-depth: 0
 
+      # This job builds three Docker images (the assistant image alone bakes a
+      # multi-GB tool node_modules — see containers/assistant/Dockerfile) and
+      # then boots them with volumes whose entrypoints install more tools at
+      # runtime. That footprint has outgrown the stock ubuntu-latest runner:
+      # run 29520797034 hit "Free space left: 0 MB" mid-smoke and the guardian
+      # died on ENOSPC installing opencode. Reclaim the big preinstalled
+      # bundles this job never uses (~20+ GB) before the heavy steps.
+      - name: Free runner disk space
+        run: |
+          set -euo pipefail
+          echo "Disk before cleanup:"; df -h /
+          sudo rm -rf \
+            /usr/local/lib/android \
+            /usr/share/dotnet \
+            /opt/ghc \
+            /usr/local/.ghcup \
+            /opt/hostedtoolcache/CodeQL \
+            /usr/share/swift
+          sudo docker image prune -af >/dev/null
+          echo "Disk after cleanup:"; df -h /
+
       - name: Scan for leaked API keys
         # CI has no real secrets, so varlock scan has nothing to resolve.
         # Use grep patterns on the PR diff for provider-specific key formats.
@@ -135,6 +156,17 @@ jobs:
         run: |
           source scripts/rootless-smoke-fixture.sh
           smoke_build_images assistant guardian portal
+
+      # The assistant image's intermediate build stages (toolbuild's ~3.5 GB
+      # npm tree, the model bundle) stay behind as BuildKit cache after the
+      # :dev images are tagged — dead weight that roughly doubles the build's
+      # disk cost while the smokes below need room for container volumes.
+      # Pruning build cache never touches tagged images.
+      - name: Drop Docker build cache before smokes
+        run: |
+          set -euo pipefail
+          docker builder prune -af >/dev/null
+          df -h /
 
       - name: Rootless ownership smoke (assistant+guardian)
         env:


### PR DESCRIPTION
## Why

CI is red on main: run [29520797034](https://github.com/itlackey/openpalm/actions/runs/29520797034) (merge of #567) failed in the **Quality gates** job with `Free space left: 0 MB` on the runner. The guardian container died on `ENOSPC: copying file bin/opencode` during its runtime tool install, never became healthy, and the rootless ownership smoke failed.

This is not a regression from #567 — that PR touched only UI/lib code, docs, and version bumps (no Dockerfiles or compose files). The quality-gates job has simply outgrown the stock `ubuntu-latest` runner's disk: it builds three Docker images (the assistant image bakes a ~3.5 GB tool `node_modules`, which its intermediate build stage duplicates in BuildKit cache), plus workspace deps, then boots smoke stacks whose volumes install more tools at runtime.

## What

Two steps added to the quality-gates job, both logging `df -h` so future disk-headroom regressions are visible in the job output:

- **Free runner disk space** (right after checkout): deletes preinstalled bundles the job never uses (Android SDK, dotnet, ghc/ghcup, CodeQL, swift) and prunes the runner's preloaded Docker images — reclaims roughly 20+ GB.
- **Drop Docker build cache before smokes** (after the `:dev` images are built): `docker builder prune -af` discards the intermediate build stages, which are dead weight once the images are tagged. Pruning build cache never touches tagged images.

## Verification

- `ci.yml` YAML validated locally.
- The real verification is this PR's own CI run — the failing step ("Rootless ownership smoke (assistant+guardian)") runs on `pull_request`, now with the reclaimed headroom, and the new `df -h` output shows the margins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S4X2xsDxC5aMrm9tYp9VH1

---
_Generated by [Claude Code](https://claude.ai/code/session_01S4X2xsDxC5aMrm9tYp9VH1)_