### PR TITLE
docs: add UI theming & branding guide + 0.14.0 assessment for #426

### DIFF
--- a/.github/roadmap/0.14.0/assessments/426.md
+++ b/.github/roadmap/0.14.0/assessments/426.md
@@ -6,7 +6,11 @@ injection + `/admin` editor against file targets that no longer exist; rev 2
 corrected the targets after a claim-by-claim audit; rev 3 (maintainer
 direction) replaced the mechanism with a plain operator-edited CSS file; rev 4
 removed the remaining scope that didn't serve that mechanism (name/logo
-override, dynamic asset route, magic-byte/ETag machinery). Principle:
+override, dynamic asset route, magic-byte/ETag machinery); rev 5 modernized
+the foundation — `tokens.css` collapses its duplicated attribute-keyed blocks
+into single `light-dark()` declarations inside a cascade `@layer`, which
+eliminates both cascade constraints (selector matching, link ordering) the
+earlier designs had to document around. Principle:
 `docs/technical/design-intent.md` — "manageable with Docker Compose and a
 file editor."_
 
@@ -20,10 +24,18 @@ file editor."_
   (`:13-23` light / `:29-39` dark); accent `--s-seal` `#98420A`/`#DCC25C`.
   Selector lists — light: `:root, :root[data-theme='light'],
   :root[data-theme='day']`; dark: `:root[data-theme='dark'],
-  :root[data-theme='night']`. Derived tints already `color-mix()` off the
-  anchors, so one anchor override cascades. A stylesheet loaded **after** the
-  bundled CSS with the **same selector lists** wins on document order — no
-  injection machinery needed.
+  :root[data-theme='night']` — the `day`/`night` aliases are dead (nothing
+  ever sets them). Derived tints already `color-mix()` off the anchors, so
+  one anchor override cascades. Rev 5 replaces the dual blocks with single
+  `light-dark()` declarations on `:root` inside `@layer theme-tokens`
+  (scoped to the token declarations only — the `wiz-*` class rules in the
+  same file stay unlayered so their priority vs `app.css` is unchanged).
+  `data-theme` selector consumers outside tokens.css — `app.css` (the
+  color-scheme bridge), `chat/+page.svelte`, `setup/steps/Screen1ModelsStep.svelte`
+  — keep the attribute; only the tokens stop depending on it. The one
+  non-color themed token, `--s-paper-grain` (0.05/0.04, single consumer
+  `chat/+page.svelte:622`), can't use `light-dark()`: collapse to one value
+  or keep a two-line attribute pair.
 - **Modes**: pre-paint script in `app.html:8-37` stamps `data-theme` before
   paint (localStorage `openpalm.theme`); client service
   `theme-state.svelte.ts` flips it live. Both are untouched by this design.
@@ -58,15 +70,22 @@ file editor."_
 
 ## Remaining work
 
-- [ ] **Phase 1 — theme file**: skeleton `packages/skeleton/config/ui/theme.css`
-      (commented anchor template in the two correct selector blocks);
+- [ ] **Phase 1 — tokens modernization**: `tokens.css` → `@layer theme-tokens`
+      + single-block `light-dark()` anchors; drop dead `day`/`night`
+      aliases; resolve `--s-paper-grain` (collapse or two-line pair);
+      update `theme-tokens.test.ts` to parse the `light-dark()` form (same
+      AA assertions on both resolved values); fix the two contrast literals;
+      **default render visually identical in both modes** and mode toggle
+      behavior unchanged.
+- [ ] **Phase 2 — theme file**: skeleton `packages/skeleton/config/ui/theme.css`
+      (one `:root` block, commented `light-dark()` anchor lines);
       `routes/branding/theme.css/+server.ts` (~10 lines: `node:fs` read of
       `${configDir}/ui/theme.css`, `text/css`, `Cache-Control: no-cache`,
-      empty 200 when absent); `<link rel="stylesheet"
-      href="/branding/theme.css" />` in `app.html` **after**
-      `%sveltekit.head%`; `/branding/` pre-auth exemption in hooks; fix the
-      two contrast literals (two-line change).
-- [ ] **Phase 2 — avatar**: parametrize Presence's mark (ensō default /
+      empty 200 when absent); one static `<link rel="stylesheet"
+      href="/branding/theme.css" />` in `app.html` (position immaterial —
+      layers); `/branding/` pre-auth exemption in hooks; route vitest +
+      no-op HTML proof.
+- [ ] **Phase 3 — avatar**: parametrize Presence's mark (ensō default /
       `<img src="/branding/avatar">` when a custom file exists — one
       `existsSync` boolean exposed from the existing root
       `+layout.server.ts`, its payload vitest updated);
@@ -74,7 +93,7 @@ file editor."_
       `avatar.png|webp|gif`, first match served, 404 otherwise); remount
       Presence once at page level (composer dock beside `VoiceStatusStrip`);
       add `Presence.svelte.vitest.ts`.
-- [ ] **Phase 3 — docs**: `docs/theming.md` (drafted on this branch) +
+- [ ] **Phase 4 — docs**: `docs/theming.md` (drafted on this branch) +
       README row (done); add `config/ui/` to the filesystem-contract docs
       (`core-principles.md`, `environment-and-mounts.md`,
       `managing-openpalm.md` directory map); `ui-route-map.md` rows;
@@ -101,26 +120,30 @@ file editor."_
 - Layout vitest: avatar boolean present/absent.
 - No-op proof: without `config/ui/`, rendered HTML is byte-identical except
   the one static link tag (which serves an empty stylesheet).
-- Playwright: an uncommented `--s-seal` in the seeded blocks applies with no
-  flash in **both** modes; login page themed pre-auth; no
-  `securitypolicyviolation` events.
+- Playwright: an uncommented `light-dark()` anchor line applies with no
+  flash in **both** modes, with a bare `:root {}` and regardless of link
+  position; login page themed pre-auth; no `securitypolicyviolation` events.
 - Existing gates stay green: `csp-config`, hooks suites, `theme-tokens`,
   ui-kit svelte-check, `npm run check`. New contract check: template anchor
   list matches `tokens.css`.
 
 ## Dependencies / risks
 
+- **Browser floor (explicit decision, rev 5):** `light-dark()` in
+  `tokens.css` makes Chrome/Edge 123+ / Firefox 120+ / Safari 17.5+ (all
+  mid-2024, Baseline) the floor for the whole console. Acceptable for a
+  self-hosted operator UI in 2026; Electron ships current Chromium. Older
+  browsers render unthemed — recorded so it's a choice, not an accident.
+- `@layer` scope: layer only the token declarations, not the `wiz-*` class
+  rules sharing `tokens.css`, or those rules drop below unlayered `app.css`.
 - Coordinates with #506 (token-vocabulary docs); `ui-design-rubric.md` §4
   wording ("brand orange") can be amended at ship time with maintainer
   sign-off.
-- Freehand CSS outside the seeded blocks loses on specificity — handled by
-  the pre-correct template + a troubleshooting row in docs; not a code
-  problem.
 - Operator CSS is trusted by design (their file, their machine; no network
   write path exists).
 - Presence has no test today — add its vitest before rewiring chrome.
 
 ## Original issue body
 
-Revision 4 (2026-07-20) is maintained on GitHub:
+Revision 5 (2026-07-20) is maintained on GitHub:
 <https://github.com/itlackey/openpalm/issues/426>.

--- a/.github/roadmap/0.14.0/assessments/426.md
+++ b/.github/roadmap/0.14.0/assessments/426.md
@@ -1,0 +1,160 @@
+# Assessment — #426: Enable UI branding override + customizable chat avatar (2D)
+
+_Assessed 2026-07-20 against `main` @ `07890f4` (0.13.0-beta.8). Effort: M–L
+(6 shippable phases). The issue body was rewritten the same day (revision 2)
+from this assessment; every line reference below was verified against the
+working tree, and the load-bearing claims were independently re-verified by a
+second adversarial pass._
+
+## Current state (verified — nothing merged for this issue)
+
+No branding/theming override mechanism exists anywhere:
+
+- No `branding.ts` (or any `*branding*` module) under `packages/lib/src/control-plane/`.
+- No `transformPageChunk` usage anywhere in `packages/` — `hooks.server.ts:259`
+  calls `await resolve(event)` with no options.
+- No custom placeholder in `packages/ui/src/app.html`; no runtime
+  `style.setProperty('--…')` in product code (only test fixtures).
+- No `config/ui/` tree in `packages/skeleton/config/` (currently `akm/`,
+  `assistant/`, `guardian/`, `stack/`).
+
+What the issue builds on has moved since June:
+
+- **Tokens** live in `packages/ui-kit/src/lib/theme/tokens.css` (Stillness
+  `--s-*`; extracted from `app.css` by #555 P5a). Accent anchor `--s-seal`:
+  `#98420A` light (`:18`) / `#DCC25C` dark (`:34`). 11 color anchors per mode
+  (`:13-23` / `:29-39`). Light selector list `:root, :root[data-theme='light'],
+  :root[data-theme='day']`; dark `:root[data-theme='dark'], :root[data-theme='night']`.
+  Derived tints already use `color-mix()` off the anchors (e.g. `tokens.css:313,
+  429-430,439`; `app.css:291,875-876,1214`) — rev 1's "color-mix refactor" is moot.
+- **`/admin` is a dead namespace** (router 404; `hooks.server.admin-404.vitest.ts`;
+  `admin-paths-hygiene.vitest.ts` fails quoted `/admin` literals). Admin pages:
+  `routes/host/+page.svelte` + `host/navigation.ts` TabBar; privileged JSON:
+  `routes/api/host/**` (every route must call `requireCapability` —
+  `guard-hygiene.vitest.ts`); assistant-scoped settings: `routes/api/assistant/**`.
+  The canonical settings GET/PUT exemplar is
+  `routes/api/assistant/persona/+server.ts:38-84` (persona editing has shipped —
+  the "tracked in #22" note in rev 1 is stale).
+- **Capabilities** are the server boundary (`lib/server/features.ts:26-55`):
+  `BASE_CAPABILITIES` for every lane; `HOST_CAPABILITIES` only when
+  `OP_INSIDE_ELECTRON=1` or `OP_ENABLE_ADMIN=1`. The assistant-container lane
+  serves the UI under **Node** (`node "$ui_index"`,
+  `containers/assistant/entrypoint.sh:341`) with admin envs unset and no
+  operator `OP_HOME` — branding must fail open to defaults there. No `Bun.*`
+  APIs are allowed in UI/lib server code (`ui-supervisor.ts:13`).
+- **Root `+layout.server.ts` exists** (returns `serverRuntimeContext`; payload
+  pinned by `layout.server.vitest.ts`).
+- **CSP** (`svelte.config.js`, hash mode, pinned by `csp-config.vitest.ts`):
+  `img-src ['self','data:']` is what blocks remote images;
+  `connect-src`/`frame-src` are `['self','http:','https:']` since Phase 3b;
+  `style-src` includes `'unsafe-inline'` (+ Google Fonts origins). Five hooks
+  vitest suites stub `resolve()`.
+- **Branding sites**: ~12+ across two packages — `chrome/Navbar.svelte:54-58`;
+  six `<title>` tags (`login:48`, `setup:29`, `host:302`, `advanced:241`,
+  `connections:348`, `attention:13`); setup wordmark/mascot/copy
+  (`setup/+page.svelte:66-68,117,212,240`); `attention:18-19`; ui-kit
+  `AuthGate.svelte:34`, `UpdateBanner.svelte:51`, `IconLogo.svelte:9-23`; test
+  pins `e2e/setup-guard.pw.ts:46`, `e2e/chat-footer-responsive.pw.ts:232`,
+  `ChatNavbar.svelte.vitest.ts:105`. ui-kit is presentational-only
+  (`tests/no-app-coupling.test.ts`) — AuthGate branding must arrive via props.
+  No favicon exists at all; `static/logo*.png`, `banner.png`, `fu*.png` are dead
+  (the rendered logo is the inline currentColor `IconLogo` SVG).
+- **Avatar**: `lib/components/chat/Presence.svelte` (359 lines) is a complete
+  state-reactive animated ensō avatar (breathing / listening ripples / 5-bar
+  speaking waveform / processing pulse; `prefers-reduced-motion` block
+  `:349-358`; mark = hardcoded `LOGO` path at `:14`, byte-identical to
+  IconLogo). **Orphaned** — unmounted by the chrome redesign `b94908e`
+  (2026-07-17); zero imports; no colocated test. The streaming assistant reply
+  bypasses `ChatMessage.svelte` (inline `.s-pending` at `chat/+page.svelte:424-437`),
+  and `ChatMessage` is shared with `/advanced` — so a per-message avatar mount
+  is the wrong design; remount Presence once at page level.
+- **Contrast**: `ui-kit/tests/theme-tokens.test.ts` pins WCAG AA for the
+  *default* tokens only; two hardcoded seal-paired ink literals
+  (`tokens.css:158-164` `#1f1d18`, `app.css:1677-1680` `#1a0e00`) will not
+  track an overridden `--s-seal`.
+
+## Remaining work
+
+- [ ] **Phase 1 — lib core**: `packages/lib/src/control-plane/branding.ts`
+      (read/write/validate/serialize/asset-save; hex-only validation; selector
+      lists incl. `day`/`night` aliases) + `paths.ts` + barrel + unit tests;
+      skeleton seed `packages/skeleton/config/ui/branding.json`.
+- [ ] **Phase 2 — contrast-literal refactor**: derive the two seal-paired ink
+      literals; default render byte-identical.
+- [ ] **Phase 3 — injection + swap**: `+layout.server.ts` branding field;
+      `%op.themeStyle%` placeholder **after** `%sveltekit.head%`;
+      `transformPageChunk`; `/branding/[asset]` route (`node:fs`, realpath
+      containment, magic bytes); `<Brand>`/`<Logo>`; AuthGate name prop; title
+      helper; update 3 test pins + 5 hooks-suite resolve stubs +
+      `layout.server.vitest.ts`.
+- [ ] **Phase 4 — settings surface**: `/api/host/ui-config` GET/PUT/POST with
+      new `host:ui-branding` capability; `/host` Appearance tab with per-anchor
+      contrast warnings.
+- [ ] **Phase 5 — avatar**: parametrize Presence's mark (ensō default /
+      `<img src="/branding/…">` swap), remount once at page level (composer
+      dock beside `VoiceStatusStrip`), add `Presence.svelte.vitest.ts`.
+- [ ] **Phase 6 — docs**: `docs/theming.md` guide (drafted on the feature
+      branch) + README row; `api-spec.md`; `ui-route-map.md`;
+      `core-principles.md` + `environment-and-mounts.md` +
+      `managing-openpalm.md` filesystem-contract updates for `config/ui/`;
+      `ui-design-rubric.md` §4 amendment (maintainer sign-off); CHANGELOG.
+
+## Affected files
+
+See "Key files" in the issue body (revision 2) — new: lib `branding.ts` +
+tests, skeleton `config/ui/branding.json`, `routes/branding/[asset]/+server.ts`,
+`routes/api/host/ui-config/+server.ts`, `Brand.svelte`/`Logo.svelte`,
+`Presence.svelte.vitest.ts`, `docs/theming.md`; edits: `paths.ts`, lib barrel,
+`hooks.server.ts`, `app.html`, root `+layout.server.ts`, `features.ts`,
+`host/+page.svelte` + `host/navigation.ts`, `tokens.css` + `app.css`
+(two literals), `Navbar.svelte`, ui-kit `AuthGate.svelte`, six route titles,
+`chat/+page.svelte`, `Presence.svelte`, three test pins.
+
+## Test strategy
+
+- Lib unit tests: CSS-injection rejection (`red;}body{…`, `url(…)`,
+  `</style><script>`, `#fff`, 8-digit hex), traversal rejection,
+  only-changed-tokens emission, both selector lists, defaults-on-absent,
+  magic-byte sniffing (PNG/GIF/WebP accept; SVG/JPEG reject), size cap.
+- UI vitest: asset route (allowlist/containment/fallback), ui-config endpoint
+  (capability + admin + origin), layout payload, hooks transform no-op when
+  config absent (HTML snapshot), placeholder-after-head assertion.
+- Existing gates that must stay green: `guard-hygiene`, `admin-paths-hygiene`,
+  `csp-config`, five hooks suites, `theme-tokens.test.ts`, `ui-kit` svelte-check,
+  `packages/ui` `npm run check`.
+- Playwright: `securitypolicyviolation` listener on default render + uploaded
+  GIF avatar; override wins in both light and dark (the specificity pitfall);
+  e2e title pins.
+
+## Dependencies
+
+- Coordinates with **#506** (documenting the shared `wiz-*`/token vocabulary)
+  — do not duplicate its docs work.
+- `ui-design-rubric.md` §4 wording change needs maintainer approval (rubric is
+  the #439 gate).
+- Electron shell branding + desktop-notification titles are a follow-up issue
+  (outside the served UI).
+
+## Risks
+
+1. **Cascade specificity**: a bare `:root{}` light override loses to the
+   bundled `:root[data-theme='light']` block — must emit the full selector
+   lists and inject after `%sveltekit.head%` (unit-tested).
+2. **CSP regression**: adding any style hash/nonce voids `'unsafe-inline'`
+   and breaks Svelte transitions + the injected block. Rule: never add style
+   hashes.
+3. **Operator-broken contrast**: overrides bypass the AA test suite —
+   mitigated by the advisory contrast warnings, the literal refactor, and
+   docs.
+4. **Lane divergence**: container-served lane has no operator `OP_HOME`;
+   branding must fail open to defaults and the write surface is host-only by
+   design.
+5. **Untested revival**: Presence.svelte has no test today; add the colocated
+   vitest before wiring it into chrome.
+
+## Original issue body
+
+Revision 2 (2026-07-20) is maintained on GitHub:
+<https://github.com/itlackey/openpalm/issues/426>. The revision replaced the
+June 3 body after a full claim-by-claim audit; the "Corrections at a glance"
+table in the issue records every rev 1 → rev 2 change with evidence.

--- a/.github/roadmap/0.14.0/assessments/426.md
+++ b/.github/roadmap/0.14.0/assessments/426.md
@@ -1,165 +1,126 @@
-# Assessment — #426: Enable UI branding override + customizable chat avatar (2D)
+# Assessment — #426: UI theme override (editable CSS file) + chat avatar (2D)
 
-_Assessed 2026-07-20 against `main` @ `07890f4` (0.13.0-beta.8). Effort: S–M
-(5 shippable phases). Design history: the issue body was rewritten twice on
-2026-07-20 — revision 2 corrected the June body's stale file targets after a
-claim-by-claim audit (findings preserved below); revision 3, by maintainer
-direction, replaced rev 2's mechanism (JSON palette schema → serialized
-inline style + admin editor UI) with a **plain operator-editable CSS file and
-file/env conventions — no admin editor, no write API, no serializer**. This
-matches `docs/technical/design-intent.md`: "manageable with Docker Compose
-and a file editor."_
+_Assessed 2026-07-20 against `main` @ `07890f4` (0.13.0-beta.8). Effort: S.
+Design history: rev 1 (June) proposed a JSON palette + serialized inline-style
+injection + `/admin` editor against file targets that no longer exist; rev 2
+corrected the targets after a claim-by-claim audit; rev 3 (maintainer
+direction) replaced the mechanism with a plain operator-edited CSS file; rev 4
+removed the remaining scope that didn't serve that mechanism (name/logo
+override, dynamic asset route, magic-byte/ETag machinery). Principle:
+`docs/technical/design-intent.md` — "manageable with Docker Compose and a
+file editor."_
 
 ## Current state (verified — nothing merged for this issue)
 
-No branding/theming override mechanism exists anywhere:
-
-- No branding module under `packages/lib/src/control-plane/`; no custom
-  placeholder in `packages/ui/src/app.html`; no runtime
-  `style.setProperty('--…')` in product code (only test fixtures).
-- No `config/ui/` tree in `packages/skeleton/config/` (currently `akm/`,
-  `assistant/`, `guardian/`, `stack/`).
-
-What the feature builds on (all re-verified, key facts):
-
-- **Tokens** live in `packages/ui-kit/src/lib/theme/tokens.css` (Stillness
-  `--s-*`; extracted from `app.css` by #555 P5a). Accent anchor `--s-seal`:
-  `#98420A` light (`:18`) / `#DCC25C` dark (`:34`). 11 color anchors per mode
-  (`:13-23` / `:29-39`). Light selector list `:root, :root[data-theme='light'],
-  :root[data-theme='day']`; dark `:root[data-theme='dark'], :root[data-theme='night']`.
-  Derived tints already use `color-mix()` off the anchors — overriding one
-  anchor cascades. The historical `--color-primary*` / `#ff9d00` targets never
-  existed in the web UI (`#ff9d00` is the assistant TUI theme only, now at
-  `packages/skeleton/system/assistant/themes/openpalm.json`).
-- **Mode switching**: pre-paint script in `app.html:8-37` (localStorage
-  `openpalm.theme`) stamps `data-theme` before paint; client service
-  `theme-state.svelte.ts` flips it live. A theme stylesheet loaded after the
-  bundled CSS with the same selector lists wins on document order — no
-  hooks/injection machinery needed.
-- **Serving lanes**: the UI is adapter-node and runs under **Node** in the
-  assistant-container lane (`node "$ui_index"`,
-  `containers/assistant/entrypoint.sh:341`, admin envs unset, no operator
-  `OP_HOME`) and Electron lane — "no Bun.* APIs" (`ui-supervisor.ts:13`).
-  Absent theme/assets must fail open to defaults. `stack.env` values are
-  already promoted into `process.env` at startup (`hooks.server.ts`
-  `loadProcessEnv` → `readStackRuntimeEnv`) — an `OP_UI_BRAND_NAME` env needs
-  no new plumbing. Env-var display-name branding has precedent
-  (`SLACK_BOT_NAME`, #491 D4).
-- **Root `+layout.server.ts` exists** (returns `serverRuntimeContext`; payload
-  pinned by `layout.server.vitest.ts`) — branding data extends it.
-- **CSP** (`svelte.config.js`, hash mode, pinned by `csp-config.vitest.ts`):
-  a same-origin `<link>` stylesheet is covered by `style-src 'self'` — the
-  CSS-file design needs no CSP change and does not depend on
-  `'unsafe-inline'`. `img-src ['self','data:']` blocks remote images.
-- **Branding sites**: ~12+ across two packages — `chrome/Navbar.svelte:54-58`;
-  six `<title>` tags (`login:48`, `setup:29`, `host:302`, `advanced:241`,
-  `connections:348`, `attention:13`); setup wordmark/mascot/copy
-  (`setup/+page.svelte:66-68,117,212,240`); `attention:18-19`; ui-kit
-  `AuthGate.svelte:34`, `UpdateBanner.svelte:51`, `IconLogo.svelte:9-23`; test
-  pins `e2e/setup-guard.pw.ts:46`, `e2e/chat-footer-responsive.pw.ts:232`,
-  `ChatNavbar.svelte.vitest.ts:105`. ui-kit is presentational-only
-  (`tests/no-app-coupling.test.ts`) — AuthGate branding arrives via props.
-  No favicon exists; `static/logo*.png`, `banner.png`, `fu*.png` are dead
-  assets (the rendered logo is the inline currentColor `IconLogo` SVG).
+- No theming/branding override mechanism exists: no branding module in lib,
+  no custom placeholder in `app.html`, no runtime `setProperty` in product
+  code, no `config/ui/` in `packages/skeleton/config/`.
+- **Tokens**: `packages/ui-kit/src/lib/theme/tokens.css` (Stillness `--s-*`,
+  extracted from `app.css` by #555 P5a). 11 color anchors per mode
+  (`:13-23` light / `:29-39` dark); accent `--s-seal` `#98420A`/`#DCC25C`.
+  Selector lists — light: `:root, :root[data-theme='light'],
+  :root[data-theme='day']`; dark: `:root[data-theme='dark'],
+  :root[data-theme='night']`. Derived tints already `color-mix()` off the
+  anchors, so one anchor override cascades. A stylesheet loaded **after** the
+  bundled CSS with the **same selector lists** wins on document order — no
+  injection machinery needed.
+- **Modes**: pre-paint script in `app.html:8-37` stamps `data-theme` before
+  paint (localStorage `openpalm.theme`); client service
+  `theme-state.svelte.ts` flips it live. Both are untouched by this design.
+- **Lanes**: the UI runs under Node in the assistant-container lane
+  (`node "$ui_index"`, `containers/assistant/entrypoint.sh:341`, no operator
+  `OP_HOME`) and Electron ("no Bun.* APIs", `ui-supervisor.ts:13`) — the
+  theme route must return an empty stylesheet when the file is absent.
+- **CSP**: a same-origin `<link>` stylesheet is covered by the existing
+  `style-src 'self'` (`svelte.config.js`, pinned by `csp-config.vitest.ts`)
+  — zero CSP changes, no reliance on `'unsafe-inline'`.
+- **Seeding**: `applyHomeSeed` copies `packages/skeleton/config/` user trees
+  once with `skipExisting` (`ui-assets.ts:137-178`) — a skeleton
+  `config/ui/theme.css` is seeded-once for free. Serving the UI is
+  contractually read-only w.r.t. `OP_HOME` (`hooks.server.ts:41-44`).
 - **Avatar**: `lib/components/chat/Presence.svelte` (359 lines) is a complete
   state-reactive animated ensō avatar (breathing / listening ripples / 5-bar
   speaking waveform / processing pulse; `prefers-reduced-motion` block
-  `:349-358`; mark = hardcoded `LOGO` path at `:14`, byte-identical to
-  IconLogo). **Orphaned** — unmounted by chrome redesign `b94908e`
-  (2026-07-17); zero imports; no colocated test. The streaming assistant reply
-  bypasses `ChatMessage.svelte` (inline `.s-pending`,
-  `chat/+page.svelte:424-437`) and `ChatMessage` is shared with `/advanced` —
-  remount Presence once at page level, never per-message.
-- **Contrast**: `ui-kit/tests/theme-tokens.test.ts` pins WCAG AA for the
-  *default* tokens only; two hardcoded seal-paired ink literals
-  (`tokens.css:158-164` `#1f1d18`, `app.css:1677-1680` `#1a0e00`) will not
-  track an overridden `--s-seal`.
-- **Dead namespace**: `/admin/*` is a router 404; `admin-paths-hygiene.vitest.ts`
-  fails quoted `/admin` literals. (Rev 3 adds no settings surface, so this is
-  now only a historical trap to avoid.)
+  `:349-358`; mark = hardcoded `LOGO` path at `:14`). **Orphaned** since
+  chrome redesign `b94908e` (2026-07-17); zero imports; no colocated test.
+  The streaming assistant reply bypasses `ChatMessage.svelte` (inline
+  `.s-pending`, `chat/+page.svelte:424-437`) and `ChatMessage` is shared with
+  `/advanced` — mount Presence once at page level, never per-message. Driving
+  state exists: `chat.sending`, `chat.pendingAssistantText`,
+  `voiceState.status`.
+- **Contrast**: `ui-kit/tests/theme-tokens.test.ts` pins WCAG AA for default
+  tokens only. Two hardcoded seal-paired ink literals will not track an
+  overridden `--s-seal`: `tokens.css:158-164` (`#1f1d18`) and
+  `app.css:1677-1680` (`#1a0e00`).
+- **Auth gating**: hooks redirect unauthenticated document requests to
+  `/login` — `/branding/*` needs the same style of exemption as `/health`
+  so the login page themes.
 
 ## Remaining work
 
-- [ ] **Phase 1 — seed + serve**: skeleton `packages/skeleton/config/ui/theme.css`
-      (commented anchor template in the correct light/dark selector blocks;
-      seeded once via `applyHomeSeed` `skipExisting`); asset route
-      `routes/branding/[asset]/+server.ts` serving `theme.css` (text/css;
-      empty 200 when absent) and conventional raster assets (`node:fs`
-      streaming, realpath containment, magic-byte PNG/GIF/WebP, ≤ 1 MB,
-      ETag + `no-cache`); `<link rel="stylesheet" href="/branding/theme.css">`
-      in `app.html` **after** `%sveltekit.head%`; `/branding/*` exempt from
-      landing/auth gating (login page must theme); prove absent-file render is
-      byte-identical.
-- [ ] **Phase 2 — contrast-literal refactor**: derive the two seal-paired ink
-      literals; default render unchanged; `theme-tokens.test.ts` green.
-- [ ] **Phase 3 — name/logo swap**: `OP_UI_BRAND_NAME` (stack.env) →
-      `+layout.server.ts` branding field (+ update its vitest) →
-      `<Brand>`/`<Logo>` components, AuthGate name prop, title helper across
-      the six routes; conventional logo files (`logo.*` / `logo-dark.*`)
-      with IconLogo fallback; update 3 test pins.
-- [ ] **Phase 4 — avatar**: parametrize Presence's mark (ensō default /
-      `<img src="/branding/avatar.*">` when the conventional file exists),
-      remount once at page level (composer dock beside `VoiceStatusStrip`),
+- [ ] **Phase 1 — theme file**: skeleton `packages/skeleton/config/ui/theme.css`
+      (commented anchor template in the two correct selector blocks);
+      `routes/branding/theme.css/+server.ts` (~10 lines: `node:fs` read of
+      `${configDir}/ui/theme.css`, `text/css`, `Cache-Control: no-cache`,
+      empty 200 when absent); `<link rel="stylesheet"
+      href="/branding/theme.css" />` in `app.html` **after**
+      `%sveltekit.head%`; `/branding/` pre-auth exemption in hooks; fix the
+      two contrast literals (two-line change).
+- [ ] **Phase 2 — avatar**: parametrize Presence's mark (ensō default /
+      `<img src="/branding/avatar">` when a custom file exists — one
+      `existsSync` boolean exposed from the existing root
+      `+layout.server.ts`, its payload vitest updated);
+      `routes/branding/avatar/+server.ts` (~15 lines: fixed names
+      `avatar.png|webp|gif`, first match served, 404 otherwise); remount
+      Presence once at page level (composer dock beside `VoiceStatusStrip`);
       add `Presence.svelte.vitest.ts`.
-- [ ] **Phase 5 — docs**: `docs/theming.md` (drafted on the feature branch) +
-      README row; `ui-route-map.md` (`/branding/[asset]`);
-      `core-principles.md` + `environment-and-mounts.md` +
-      `managing-openpalm.md` filesystem-contract updates for `config/ui/`;
-      `ui-design-rubric.md` §4 amendment (maintainer sign-off); CHANGELOG.
+- [ ] **Phase 3 — docs**: `docs/theming.md` (drafted on this branch) +
+      README row (done); add `config/ui/` to the filesystem-contract docs
+      (`core-principles.md`, `environment-and-mounts.md`,
+      `managing-openpalm.md` directory map); `ui-route-map.md` rows;
+      CHANGELOG `[Unreleased]`.
 
-## Affected files
+## Descoped (rev 4, with justification)
 
-New: `packages/skeleton/config/ui/theme.css`;
-`packages/ui/src/routes/branding/[asset]/+server.ts` (+ vitest);
-`packages/ui/src/lib/components/Brand.svelte` + `Logo.svelte`;
-`Presence.svelte.vitest.ts`; `docs/theming.md`.
-Edit: `packages/ui/src/app.html` (link tag); `hooks.server.ts` (gate
-exemption only); root `+layout.server.ts` (+ vitest);
-`packages/ui-kit/src/lib/theme/tokens.css` + `packages/ui/src/app.css`
-(two literals); `chrome/Navbar.svelte`; ui-kit `AuthGate.svelte` (name
-prop); six route titles; `chat/+page.svelte` (Presence remount);
-`chat/Presence.svelte` (parametrized mark); three test pins; small lib
-helper for asset lookup/containment if shared with the route.
+- **Product name + logo override** (`OP_UI_BRAND_NAME`, `<Brand>`/`<Logo>`,
+  title helper, AuthGate prop, three test-pin updates): a rename feature,
+  not a theming feature — it alone accounted for most of rev 3's file churn.
+  Follow-up issue if ever wanted. (The ~12-site hardcoded-brand inventory
+  from the rev 2 audit is preserved in git history of this file.)
+- **Dynamic `[asset]` route + traversal containment + magic-byte sniffing +
+  size caps + ETag**: two literal routes with no user-controlled path
+  segment have nothing to defend; files are operator-owned local config
+  served same-origin with the existing global `nosniff` (SEC-3).
+- **Admin editor UI / write API / capability / Appearance tab**: removed in
+  rev 3; the UI only reads.
 
 ## Test strategy
 
-- Route vitest: containment (`..`/absolute/separators rejected), magic-byte
-  accept/reject (PNG/GIF/WebP yes; SVG/JPEG no), size cap, empty-theme 200,
-  content types, pre-auth reachability.
-- Layout vitest: branding payload (name env set/unset, logo file
-  present/absent).
-- HTML snapshot: no `config/ui/` ⇒ byte-identical output (link tag present
-  but stylesheet empty).
-- Playwright: theme override applies with no flash in light AND dark
-  (values inside the seeded selector blocks); login page themed pre-auth;
-  `securitypolicyviolation` listener clean; e2e title pins.
-- Existing gates stay green: `csp-config`, hooks suites (unchanged resolve
-  usage), `theme-tokens.test.ts`, ui-kit svelte-check, `npm run check`.
-- New contract check: seeded template's anchor list matches `tokens.css`.
+- Route vitests: theme route (file present / absent-empty-200 / content
+  type), avatar route (each extension, 404 when absent).
+- Layout vitest: avatar boolean present/absent.
+- No-op proof: without `config/ui/`, rendered HTML is byte-identical except
+  the one static link tag (which serves an empty stylesheet).
+- Playwright: an uncommented `--s-seal` in the seeded blocks applies with no
+  flash in **both** modes; login page themed pre-auth; no
+  `securitypolicyviolation` events.
+- Existing gates stay green: `csp-config`, hooks suites, `theme-tokens`,
+  ui-kit svelte-check, `npm run check`. New contract check: template anchor
+  list matches `tokens.css`.
 
-## Dependencies
+## Dependencies / risks
 
-- Coordinates with **#506** (documenting the shared `wiz-*`/token
-  vocabulary) — don't duplicate.
-- `ui-design-rubric.md` §4 wording change needs maintainer approval.
-- Electron shell branding + desktop-notification titles: follow-up issue.
-
-## Risks
-
-1. **Freehand CSS outside the seeded blocks** silently loses to the built-in
-   mode blocks (specificity) — mitigated by the pre-correct template and a
-   troubleshooting row in `docs/theming.md`; not a code problem.
-2. **Operator CSS is trusted by design** — same trust level as every other
-   file in user-owned `config/`; there is no network write path to it (no
-   API), which is a smaller attack surface than rev 2's admin editor.
-3. **Pre-auth exemption for `/branding/*`** must serve only theme.css +
-   allowlisted raster assets (containment + magic bytes) — nothing else.
-4. **Upgrade drift**: operators theming beyond the 11 anchors may break on
-   upgrade — docs state the anchor contract as the supported surface.
-5. **Untested revival**: Presence.svelte has no test today; add the
-   colocated vitest before wiring it into chrome.
+- Coordinates with #506 (token-vocabulary docs); `ui-design-rubric.md` §4
+  wording ("brand orange") can be amended at ship time with maintainer
+  sign-off.
+- Freehand CSS outside the seeded blocks loses on specificity — handled by
+  the pre-correct template + a troubleshooting row in docs; not a code
+  problem.
+- Operator CSS is trusted by design (their file, their machine; no network
+  write path exists).
+- Presence has no test today — add its vitest before rewiring chrome.
 
 ## Original issue body
 
-Revision 3 (2026-07-20) is maintained on GitHub:
+Revision 4 (2026-07-20) is maintained on GitHub:
 <https://github.com/itlackey/openpalm/issues/426>.

--- a/.github/roadmap/0.14.0/assessments/426.md
+++ b/.github/roadmap/0.14.0/assessments/426.md
@@ -1,54 +1,56 @@
 # Assessment — #426: Enable UI branding override + customizable chat avatar (2D)
 
-_Assessed 2026-07-20 against `main` @ `07890f4` (0.13.0-beta.8). Effort: M–L
-(6 shippable phases). The issue body was rewritten the same day (revision 2)
-from this assessment; every line reference below was verified against the
-working tree, and the load-bearing claims were independently re-verified by a
-second adversarial pass._
+_Assessed 2026-07-20 against `main` @ `07890f4` (0.13.0-beta.8). Effort: S–M
+(5 shippable phases). Design history: the issue body was rewritten twice on
+2026-07-20 — revision 2 corrected the June body's stale file targets after a
+claim-by-claim audit (findings preserved below); revision 3, by maintainer
+direction, replaced rev 2's mechanism (JSON palette schema → serialized
+inline style + admin editor UI) with a **plain operator-editable CSS file and
+file/env conventions — no admin editor, no write API, no serializer**. This
+matches `docs/technical/design-intent.md`: "manageable with Docker Compose
+and a file editor."_
 
 ## Current state (verified — nothing merged for this issue)
 
 No branding/theming override mechanism exists anywhere:
 
-- No `branding.ts` (or any `*branding*` module) under `packages/lib/src/control-plane/`.
-- No `transformPageChunk` usage anywhere in `packages/` — `hooks.server.ts:259`
-  calls `await resolve(event)` with no options.
-- No custom placeholder in `packages/ui/src/app.html`; no runtime
+- No branding module under `packages/lib/src/control-plane/`; no custom
+  placeholder in `packages/ui/src/app.html`; no runtime
   `style.setProperty('--…')` in product code (only test fixtures).
 - No `config/ui/` tree in `packages/skeleton/config/` (currently `akm/`,
   `assistant/`, `guardian/`, `stack/`).
 
-What the issue builds on has moved since June:
+What the feature builds on (all re-verified, key facts):
 
 - **Tokens** live in `packages/ui-kit/src/lib/theme/tokens.css` (Stillness
   `--s-*`; extracted from `app.css` by #555 P5a). Accent anchor `--s-seal`:
   `#98420A` light (`:18`) / `#DCC25C` dark (`:34`). 11 color anchors per mode
   (`:13-23` / `:29-39`). Light selector list `:root, :root[data-theme='light'],
   :root[data-theme='day']`; dark `:root[data-theme='dark'], :root[data-theme='night']`.
-  Derived tints already use `color-mix()` off the anchors (e.g. `tokens.css:313,
-  429-430,439`; `app.css:291,875-876,1214`) — rev 1's "color-mix refactor" is moot.
-- **`/admin` is a dead namespace** (router 404; `hooks.server.admin-404.vitest.ts`;
-  `admin-paths-hygiene.vitest.ts` fails quoted `/admin` literals). Admin pages:
-  `routes/host/+page.svelte` + `host/navigation.ts` TabBar; privileged JSON:
-  `routes/api/host/**` (every route must call `requireCapability` —
-  `guard-hygiene.vitest.ts`); assistant-scoped settings: `routes/api/assistant/**`.
-  The canonical settings GET/PUT exemplar is
-  `routes/api/assistant/persona/+server.ts:38-84` (persona editing has shipped —
-  the "tracked in #22" note in rev 1 is stale).
-- **Capabilities** are the server boundary (`lib/server/features.ts:26-55`):
-  `BASE_CAPABILITIES` for every lane; `HOST_CAPABILITIES` only when
-  `OP_INSIDE_ELECTRON=1` or `OP_ENABLE_ADMIN=1`. The assistant-container lane
-  serves the UI under **Node** (`node "$ui_index"`,
-  `containers/assistant/entrypoint.sh:341`) with admin envs unset and no
-  operator `OP_HOME` — branding must fail open to defaults there. No `Bun.*`
-  APIs are allowed in UI/lib server code (`ui-supervisor.ts:13`).
+  Derived tints already use `color-mix()` off the anchors — overriding one
+  anchor cascades. The historical `--color-primary*` / `#ff9d00` targets never
+  existed in the web UI (`#ff9d00` is the assistant TUI theme only, now at
+  `packages/skeleton/system/assistant/themes/openpalm.json`).
+- **Mode switching**: pre-paint script in `app.html:8-37` (localStorage
+  `openpalm.theme`) stamps `data-theme` before paint; client service
+  `theme-state.svelte.ts` flips it live. A theme stylesheet loaded after the
+  bundled CSS with the same selector lists wins on document order — no
+  hooks/injection machinery needed.
+- **Serving lanes**: the UI is adapter-node and runs under **Node** in the
+  assistant-container lane (`node "$ui_index"`,
+  `containers/assistant/entrypoint.sh:341`, admin envs unset, no operator
+  `OP_HOME`) and Electron lane — "no Bun.* APIs" (`ui-supervisor.ts:13`).
+  Absent theme/assets must fail open to defaults. `stack.env` values are
+  already promoted into `process.env` at startup (`hooks.server.ts`
+  `loadProcessEnv` → `readStackRuntimeEnv`) — an `OP_UI_BRAND_NAME` env needs
+  no new plumbing. Env-var display-name branding has precedent
+  (`SLACK_BOT_NAME`, #491 D4).
 - **Root `+layout.server.ts` exists** (returns `serverRuntimeContext`; payload
-  pinned by `layout.server.vitest.ts`).
+  pinned by `layout.server.vitest.ts`) — branding data extends it.
 - **CSP** (`svelte.config.js`, hash mode, pinned by `csp-config.vitest.ts`):
-  `img-src ['self','data:']` is what blocks remote images;
-  `connect-src`/`frame-src` are `['self','http:','https:']` since Phase 3b;
-  `style-src` includes `'unsafe-inline'` (+ Google Fonts origins). Five hooks
-  vitest suites stub `resolve()`.
+  a same-origin `<link>` stylesheet is covered by `style-src 'self'` — the
+  CSS-file design needs no CSP change and does not depend on
+  `'unsafe-inline'`. `img-src ['self','data:']` blocks remote images.
 - **Branding sites**: ~12+ across two packages — `chrome/Navbar.svelte:54-58`;
   six `<title>` tags (`login:48`, `setup:29`, `host:302`, `advanced:241`,
   `connections:348`, `attention:13`); setup wordmark/mascot/copy
@@ -56,105 +58,108 @@ What the issue builds on has moved since June:
   `AuthGate.svelte:34`, `UpdateBanner.svelte:51`, `IconLogo.svelte:9-23`; test
   pins `e2e/setup-guard.pw.ts:46`, `e2e/chat-footer-responsive.pw.ts:232`,
   `ChatNavbar.svelte.vitest.ts:105`. ui-kit is presentational-only
-  (`tests/no-app-coupling.test.ts`) — AuthGate branding must arrive via props.
-  No favicon exists at all; `static/logo*.png`, `banner.png`, `fu*.png` are dead
-  (the rendered logo is the inline currentColor `IconLogo` SVG).
+  (`tests/no-app-coupling.test.ts`) — AuthGate branding arrives via props.
+  No favicon exists; `static/logo*.png`, `banner.png`, `fu*.png` are dead
+  assets (the rendered logo is the inline currentColor `IconLogo` SVG).
 - **Avatar**: `lib/components/chat/Presence.svelte` (359 lines) is a complete
   state-reactive animated ensō avatar (breathing / listening ripples / 5-bar
   speaking waveform / processing pulse; `prefers-reduced-motion` block
   `:349-358`; mark = hardcoded `LOGO` path at `:14`, byte-identical to
-  IconLogo). **Orphaned** — unmounted by the chrome redesign `b94908e`
+  IconLogo). **Orphaned** — unmounted by chrome redesign `b94908e`
   (2026-07-17); zero imports; no colocated test. The streaming assistant reply
-  bypasses `ChatMessage.svelte` (inline `.s-pending` at `chat/+page.svelte:424-437`),
-  and `ChatMessage` is shared with `/advanced` — so a per-message avatar mount
-  is the wrong design; remount Presence once at page level.
+  bypasses `ChatMessage.svelte` (inline `.s-pending`,
+  `chat/+page.svelte:424-437`) and `ChatMessage` is shared with `/advanced` —
+  remount Presence once at page level, never per-message.
 - **Contrast**: `ui-kit/tests/theme-tokens.test.ts` pins WCAG AA for the
   *default* tokens only; two hardcoded seal-paired ink literals
   (`tokens.css:158-164` `#1f1d18`, `app.css:1677-1680` `#1a0e00`) will not
   track an overridden `--s-seal`.
+- **Dead namespace**: `/admin/*` is a router 404; `admin-paths-hygiene.vitest.ts`
+  fails quoted `/admin` literals. (Rev 3 adds no settings surface, so this is
+  now only a historical trap to avoid.)
 
 ## Remaining work
 
-- [ ] **Phase 1 — lib core**: `packages/lib/src/control-plane/branding.ts`
-      (read/write/validate/serialize/asset-save; hex-only validation; selector
-      lists incl. `day`/`night` aliases) + `paths.ts` + barrel + unit tests;
-      skeleton seed `packages/skeleton/config/ui/branding.json`.
+- [ ] **Phase 1 — seed + serve**: skeleton `packages/skeleton/config/ui/theme.css`
+      (commented anchor template in the correct light/dark selector blocks;
+      seeded once via `applyHomeSeed` `skipExisting`); asset route
+      `routes/branding/[asset]/+server.ts` serving `theme.css` (text/css;
+      empty 200 when absent) and conventional raster assets (`node:fs`
+      streaming, realpath containment, magic-byte PNG/GIF/WebP, ≤ 1 MB,
+      ETag + `no-cache`); `<link rel="stylesheet" href="/branding/theme.css">`
+      in `app.html` **after** `%sveltekit.head%`; `/branding/*` exempt from
+      landing/auth gating (login page must theme); prove absent-file render is
+      byte-identical.
 - [ ] **Phase 2 — contrast-literal refactor**: derive the two seal-paired ink
-      literals; default render byte-identical.
-- [ ] **Phase 3 — injection + swap**: `+layout.server.ts` branding field;
-      `%op.themeStyle%` placeholder **after** `%sveltekit.head%`;
-      `transformPageChunk`; `/branding/[asset]` route (`node:fs`, realpath
-      containment, magic bytes); `<Brand>`/`<Logo>`; AuthGate name prop; title
-      helper; update 3 test pins + 5 hooks-suite resolve stubs +
-      `layout.server.vitest.ts`.
-- [ ] **Phase 4 — settings surface**: `/api/host/ui-config` GET/PUT/POST with
-      new `host:ui-branding` capability; `/host` Appearance tab with per-anchor
-      contrast warnings.
-- [ ] **Phase 5 — avatar**: parametrize Presence's mark (ensō default /
-      `<img src="/branding/…">` swap), remount once at page level (composer
-      dock beside `VoiceStatusStrip`), add `Presence.svelte.vitest.ts`.
-- [ ] **Phase 6 — docs**: `docs/theming.md` guide (drafted on the feature
-      branch) + README row; `api-spec.md`; `ui-route-map.md`;
+      literals; default render unchanged; `theme-tokens.test.ts` green.
+- [ ] **Phase 3 — name/logo swap**: `OP_UI_BRAND_NAME` (stack.env) →
+      `+layout.server.ts` branding field (+ update its vitest) →
+      `<Brand>`/`<Logo>` components, AuthGate name prop, title helper across
+      the six routes; conventional logo files (`logo.*` / `logo-dark.*`)
+      with IconLogo fallback; update 3 test pins.
+- [ ] **Phase 4 — avatar**: parametrize Presence's mark (ensō default /
+      `<img src="/branding/avatar.*">` when the conventional file exists),
+      remount once at page level (composer dock beside `VoiceStatusStrip`),
+      add `Presence.svelte.vitest.ts`.
+- [ ] **Phase 5 — docs**: `docs/theming.md` (drafted on the feature branch) +
+      README row; `ui-route-map.md` (`/branding/[asset]`);
       `core-principles.md` + `environment-and-mounts.md` +
       `managing-openpalm.md` filesystem-contract updates for `config/ui/`;
       `ui-design-rubric.md` §4 amendment (maintainer sign-off); CHANGELOG.
 
 ## Affected files
 
-See "Key files" in the issue body (revision 2) — new: lib `branding.ts` +
-tests, skeleton `config/ui/branding.json`, `routes/branding/[asset]/+server.ts`,
-`routes/api/host/ui-config/+server.ts`, `Brand.svelte`/`Logo.svelte`,
-`Presence.svelte.vitest.ts`, `docs/theming.md`; edits: `paths.ts`, lib barrel,
-`hooks.server.ts`, `app.html`, root `+layout.server.ts`, `features.ts`,
-`host/+page.svelte` + `host/navigation.ts`, `tokens.css` + `app.css`
-(two literals), `Navbar.svelte`, ui-kit `AuthGate.svelte`, six route titles,
-`chat/+page.svelte`, `Presence.svelte`, three test pins.
+New: `packages/skeleton/config/ui/theme.css`;
+`packages/ui/src/routes/branding/[asset]/+server.ts` (+ vitest);
+`packages/ui/src/lib/components/Brand.svelte` + `Logo.svelte`;
+`Presence.svelte.vitest.ts`; `docs/theming.md`.
+Edit: `packages/ui/src/app.html` (link tag); `hooks.server.ts` (gate
+exemption only); root `+layout.server.ts` (+ vitest);
+`packages/ui-kit/src/lib/theme/tokens.css` + `packages/ui/src/app.css`
+(two literals); `chrome/Navbar.svelte`; ui-kit `AuthGate.svelte` (name
+prop); six route titles; `chat/+page.svelte` (Presence remount);
+`chat/Presence.svelte` (parametrized mark); three test pins; small lib
+helper for asset lookup/containment if shared with the route.
 
 ## Test strategy
 
-- Lib unit tests: CSS-injection rejection (`red;}body{…`, `url(…)`,
-  `</style><script>`, `#fff`, 8-digit hex), traversal rejection,
-  only-changed-tokens emission, both selector lists, defaults-on-absent,
-  magic-byte sniffing (PNG/GIF/WebP accept; SVG/JPEG reject), size cap.
-- UI vitest: asset route (allowlist/containment/fallback), ui-config endpoint
-  (capability + admin + origin), layout payload, hooks transform no-op when
-  config absent (HTML snapshot), placeholder-after-head assertion.
-- Existing gates that must stay green: `guard-hygiene`, `admin-paths-hygiene`,
-  `csp-config`, five hooks suites, `theme-tokens.test.ts`, `ui-kit` svelte-check,
-  `packages/ui` `npm run check`.
-- Playwright: `securitypolicyviolation` listener on default render + uploaded
-  GIF avatar; override wins in both light and dark (the specificity pitfall);
-  e2e title pins.
+- Route vitest: containment (`..`/absolute/separators rejected), magic-byte
+  accept/reject (PNG/GIF/WebP yes; SVG/JPEG no), size cap, empty-theme 200,
+  content types, pre-auth reachability.
+- Layout vitest: branding payload (name env set/unset, logo file
+  present/absent).
+- HTML snapshot: no `config/ui/` ⇒ byte-identical output (link tag present
+  but stylesheet empty).
+- Playwright: theme override applies with no flash in light AND dark
+  (values inside the seeded selector blocks); login page themed pre-auth;
+  `securitypolicyviolation` listener clean; e2e title pins.
+- Existing gates stay green: `csp-config`, hooks suites (unchanged resolve
+  usage), `theme-tokens.test.ts`, ui-kit svelte-check, `npm run check`.
+- New contract check: seeded template's anchor list matches `tokens.css`.
 
 ## Dependencies
 
-- Coordinates with **#506** (documenting the shared `wiz-*`/token vocabulary)
-  — do not duplicate its docs work.
-- `ui-design-rubric.md` §4 wording change needs maintainer approval (rubric is
-  the #439 gate).
-- Electron shell branding + desktop-notification titles are a follow-up issue
-  (outside the served UI).
+- Coordinates with **#506** (documenting the shared `wiz-*`/token
+  vocabulary) — don't duplicate.
+- `ui-design-rubric.md` §4 wording change needs maintainer approval.
+- Electron shell branding + desktop-notification titles: follow-up issue.
 
 ## Risks
 
-1. **Cascade specificity**: a bare `:root{}` light override loses to the
-   bundled `:root[data-theme='light']` block — must emit the full selector
-   lists and inject after `%sveltekit.head%` (unit-tested).
-2. **CSP regression**: adding any style hash/nonce voids `'unsafe-inline'`
-   and breaks Svelte transitions + the injected block. Rule: never add style
-   hashes.
-3. **Operator-broken contrast**: overrides bypass the AA test suite —
-   mitigated by the advisory contrast warnings, the literal refactor, and
-   docs.
-4. **Lane divergence**: container-served lane has no operator `OP_HOME`;
-   branding must fail open to defaults and the write surface is host-only by
-   design.
-5. **Untested revival**: Presence.svelte has no test today; add the colocated
-   vitest before wiring it into chrome.
+1. **Freehand CSS outside the seeded blocks** silently loses to the built-in
+   mode blocks (specificity) — mitigated by the pre-correct template and a
+   troubleshooting row in `docs/theming.md`; not a code problem.
+2. **Operator CSS is trusted by design** — same trust level as every other
+   file in user-owned `config/`; there is no network write path to it (no
+   API), which is a smaller attack surface than rev 2's admin editor.
+3. **Pre-auth exemption for `/branding/*`** must serve only theme.css +
+   allowlisted raster assets (containment + magic bytes) — nothing else.
+4. **Upgrade drift**: operators theming beyond the 11 anchors may break on
+   upgrade — docs state the anchor contract as the supported surface.
+5. **Untested revival**: Presence.svelte has no test today; add the
+   colocated vitest before wiring it into chrome.
 
 ## Original issue body
 
-Revision 2 (2026-07-20) is maintained on GitHub:
-<https://github.com/itlackey/openpalm/issues/426>. The revision replaced the
-June 3 body after a full claim-by-claim audit; the "Corrections at a glance"
-table in the issue records every rev 1 → rev 2 change with evidence.
+Revision 3 (2026-07-20) is maintained on GitHub:
+<https://github.com/itlackey/openpalm/issues/426>.

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,6 +17,7 @@ Repo layout convention:
 | [manual-compose-runbook.md](operations/manual-compose-runbook.md) | Step-by-step manual host configuration (no scripts) |
 | [how-it-works.md](how-it-works.md) | Architecture overview and data flow |
 | [managing-openpalm.md](managing-openpalm.md) | Configuration, portals, secrets, access control, automations |
+| [theming.md](theming.md) | UI theming & branding — Stillness tokens today, operator theme/avatar overrides (0.14.0, #426) |
 | [discord-setup.md](portals/discord-setup.md) | Discord bot setup — create app, install portal addon, invite bot |
 | [slack-setup.md](portals/slack-setup.md) | Slack bot setup — create app, install portal addon, configure Socket Mode |
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,7 +17,7 @@ Repo layout convention:
 | [manual-compose-runbook.md](operations/manual-compose-runbook.md) | Step-by-step manual host configuration (no scripts) |
 | [how-it-works.md](how-it-works.md) | Architecture overview and data flow |
 | [managing-openpalm.md](managing-openpalm.md) | Configuration, portals, secrets, access control, automations |
-| [theming.md](theming.md) | UI theming & branding — Stillness tokens today; edit `config/ui/theme.css` to re-theme (0.14.0, #426) |
+| [theming.md](theming.md) | UI theming — Stillness tokens today; edit `config/ui/theme.css` to re-theme (0.14.0, #426) |
 | [discord-setup.md](portals/discord-setup.md) | Discord bot setup — create app, install portal addon, invite bot |
 | [slack-setup.md](portals/slack-setup.md) | Slack bot setup — create app, install portal addon, configure Socket Mode |
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -54,6 +54,7 @@ Repo layout convention:
 | [code-quality-principles.md](technical/code-quality-principles.md) | All code |
 | [bunjs-rules.md](technical/bunjs-rules.md) | Guardian and portal-side Bun services |
 | [sveltekit-rules.md](technical/sveltekit-rules.md) | Admin UI (`packages/ui/`) |
+| [ui-styling-unification.md](technical/ui-styling-unification.md) | UI styling — verified drift inventory + refactor plan to the unified token/component system (`packages/ui/`, `packages/ui-kit/`) |
 
 ## Release notes
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,7 +17,7 @@ Repo layout convention:
 | [manual-compose-runbook.md](operations/manual-compose-runbook.md) | Step-by-step manual host configuration (no scripts) |
 | [how-it-works.md](how-it-works.md) | Architecture overview and data flow |
 | [managing-openpalm.md](managing-openpalm.md) | Configuration, portals, secrets, access control, automations |
-| [theming.md](theming.md) | UI theming & branding — Stillness tokens today, operator theme/avatar overrides (0.14.0, #426) |
+| [theming.md](theming.md) | UI theming & branding — Stillness tokens today; edit `config/ui/theme.css` to re-theme (0.14.0, #426) |
 | [discord-setup.md](portals/discord-setup.md) | Discord bot setup — create app, install portal addon, invite bot |
 | [slack-setup.md](portals/slack-setup.md) | Slack bot setup — create app, install portal addon, configure Socket Mode |
 

--- a/docs/technical/ui-styling-unification.md
+++ b/docs/technical/ui-styling-unification.md
@@ -1,0 +1,360 @@
+# UI Styling Unification — drift inventory & refactor plan
+
+> **Status: plan (2026-07-20).** Written against `main` @ `07890f4`
+> (0.13.0-beta.8). Companion to issue #426 (rev 5), which establishes the
+> theming foundation (`light-dark()` + `@layer` tokens, operator
+> `theme.css`). This document inventories every place the app drifts from
+> that architecture and lays out the refactor to one unified styling system.
+>
+> **Provenance:** produced by a 7-surface parallel code sweep (setup wizard,
+> host dashboard, settings/voice, chat, entry surfaces, ui-kit, global CSS),
+> each surface independently re-verified by an adversarial pass that opened
+> every cited file/line, plus manual spot-checks. 119 findings were filed;
+> 117 confirmed, 2 refuted on citation accuracy (premises noted below), and
+> 9 additional items surfaced by the verifiers. Citation corrections from
+> verification are folded into this document.
+
+---
+
+## 1. The target architecture
+
+One styling system, four layers:
+
+1. **Tokens** — `packages/ui-kit/src/lib/theme/tokens.css` is the single
+   source of truth: 11 color anchors per mode (migrating to single
+   `light-dark()` declarations inside `@layer theme-tokens`, #426 phase 1),
+   plus type (`--s-type-*`), fonts (`--s-font-*`), spacing (`--s-sp-*`,
+   4px grid), motion (`--s-t-*`, `--s-ease*`), and layout tokens.
+2. **Derivation** — every tint/wash/hover derives from an anchor via
+   `color-mix()` (or `filter: brightness()`); no raw palette literals in
+   component styles, ever. This is what makes operator theming work: one
+   `--s-seal` override must reach every accent surface.
+3. **Shared components & utilities** — presentational components live once
+   in `@openpalm/ui-kit`; genuinely global utility classes (`.btn*`,
+   `.badge*`, `.feedback*`, form primitives) are defined once and consumed
+   everywhere; pages never re-implement them.
+4. **Scoped component styles** — everything page/component-specific lives in
+   that component's own `<style>` block, consuming layers 1–3.
+   `app.css` holds only global concerns (reset, base, scrollbars, shared
+   utilities).
+
+Conventions: no `[data-theme]` selectors in components (mode-dependence
+belongs in tokens); `prefers-reduced-motion` covers every loop/entrance
+animation; Svelte 5 runes with `$effect` treated as a bug unless justified;
+no `{@html}` with non-static content.
+
+## 2. State of the system (verified)
+
+| Surface | Health | Dominant drift |
+|---|---|---|
+| Entry (login/attention/layout/app.html) | **Clean** | app.html theme-color literals + dead font load |
+| Settings/voice (connections, voice, device chrome) | Good | 2 contrast literals; `.alert`/`.btn-danger`/pill-toggle duplicates; `border-radius: 2px` ×13 |
+| Host dashboard (~20 admin/akm components) | Good | 3 hand-rolled white-on-seal checkboxes; underline input copied ~8×; badge concept reinvented ×5; an 8-property `!important` fight |
+| ui-kit | Good | Drawer scrim literal; wiz-* px/font scales parallel to tokens; 3 components depend on app.css globals |
+| Chat (chat/advanced routes + 15 components) | Fair | `.s-moon` `[data-theme]` branch; nav heights 64/112/144px copied ×4 files; `0.75/0.875rem` and `120ms` literals pervasive; 5 duplicated mini-patterns |
+| Setup wizard (10 step components) | **Poor** | 9 invented-hue washes incl. one rgb triplet pasted ×3 files; 2 hand-rolled RadioRow clones; third on-seal literal; only surface with zero reduced-motion handling |
+| Global CSS (`app.css`, 1704 lines) | **Poor** | ~500–600 lines confirmed-dead wizard CSS; ~350 lines live-but-misplaced; ~250-line unconsumed "Universal Form System" |
+
+Also verified: **`--nav-height` and the four `--toggle-*` tokens have zero
+consumers anywhere** (components hardcode the same values); the `.wiz-*`
+vocabulary is ~⅓ dead (14 of 39 selectors never referenced); `$effect`
+appears exactly once (root `+layout.svelte`, with an inline justification —
+compliant); no inline `style=` carries colors anywhere.
+
+## 3. Decisions
+
+- **D1 — on-accent text is `var(--s-paper)`.** `app.css`'s `.btn-primary`
+  already does this (`color: var(--s-paper); background: var(--s-seal)`),
+  and it self-adjusts in both modes and under operator overrides. The four
+  hardcoded on-seal literals (`#1f1d18`, `#1a0e00` ×2, `white`) and the
+  three white-on-moss checkmarks all become `var(--s-paper)`. (A dedicated
+  `--s-on-seal` token can come later if contrast tuning demands it.)
+- **D2 — status semantics always use status anchors.** Error/warning/success
+  UI uses `--s-error`/`--s-warning`/`--s-moss` — never `--s-seal` standing
+  in for danger (fixes the `.alert` family, local `.btn-danger` shadow, the
+  rgb(242,92,92) triad, `.deploy-bar-fill` ambers, `.s1-badge-recommended`).
+- **D3 — the global `s-*` form primitives become canonical (interim).**
+  `app.css`'s "Universal Form System" (`.s-input`, `.s-check`, `.s-toggle`,
+  …) is built, correct (paper-colored checkmark, token-based), and matches
+  the recipes hand-copied across ~11 host/settings files — adopt it and
+  delete the copies, rather than deleting it. Long-term these fold into
+  ui-kit components (D6). Rename the chat page's colliding decorative
+  `.s-field`/`.s-error-msg` classes so names mean one thing.
+- **D4 — new tokens** (all values already de-facto standards in the code):
+
+  | Token | Value | Replaces |
+  |---|---|---|
+  | `--s-radius-sm` | `2px` | ~24 hand-typed instances (ui-kit ×11, settings ×13) |
+  | `--s-radius-card` | `10px` | card corners across chat/host |
+  | `--s-radius-chip` | `8px` | chip/small-card corners |
+  | `--s-radius-pill` | `999px` | pill shapes (`99px` today) |
+  | `--s-tap-min` | `44px` | a11y hit-target: `44px` and `2.75rem` (same value) hand-typed ~25× |
+  | `--nav-height-conversation`(+`-tablet`,`-mobile`) | `64/112/144px` | copied across 4 files |
+  | `--tabbar-height` | *measure first* | `/host` hardcodes `36px`, but TabBar actually renders ≥44px rows — fix the stale math, then tokenize |
+  | `--overlay-bg` (redefine) | `light-dark()`-aware scrim | today a dead raw-rgba token; Drawer/ToolStrip hand-roll their own scrims |
+
+  Scrim note: do **not** derive the scrim from `--s-ink` (dark-mode ink is
+  light — the scrim would wash white); define it per-mode via `light-dark()`
+  or mix from `black`.
+- **D5 — one micro-transition duration.** The untokenized `120ms` (×6 files)
+  and `150ms` (×15+ declarations) both collapse to `var(--s-t-instant)`
+  (.15s) with `var(--s-ease)`; no new token unless design wants two speeds.
+- **D6 — ui-kit becomes self-contained (end-state).** `Panel`, `FormField`,
+  and `SecretSelect` render classes that exist only in `app.css` (the
+  `no-app-coupling` test can't see CSS-class coupling — it only scans import
+  specifiers). End-state: the shared utility layer (`.btn*`, `.badge*`,
+  `.feedback*`, form primitives) moves into ui-kit so its components render
+  correctly for any consumer. Interim: keep the documented bridge, extend it
+  to SecretSelect (currently undocumented).
+- **D7 — fonts.** The token fonts **do** load — `app.css:1` @imports Poor
+  Story + Iosevka Charon Mono, and Google Fonts serves both (verified live
+  2026-07-20; an earlier sweep claim that they never load was wrong).
+  `app.html:38-43`'s Source Sans 3 + IBM Plex Mono stylesheet is consumed by
+  **nothing** (verified) — delete the link, keep the preconnects (they
+  benefit the app.css import). Follow-up (white-label/offline story): move
+  the @import to a `<link>` and/or self-host.
+- **D8 — theme-color metas.** Sync app.html's `#161c22`/`#f9fafb`/`#ffffff`
+  constants to the actual `--s-paper` values and pin them with a contract
+  test against `tokens.css`; runtime/build-time generation is overkill.
+
+## 4. Refactor tracks
+
+### Track A — fix what breaks theming (do first)
+
+These are the places an operator's `--s-*` override silently fails.
+All verified at the cited lines.
+
+| # | Where | Problem → fix |
+|---|---|---|
+| A1 | `tokens.css:158-164`, `app.css:1677-1680`, `setup/steps/CloudAttachPanel.svelte:124`, `connections/+page.svelte:891-894` | Four on-seal text literals (`#1f1d18`, `#1a0e00` ×2, `white`) → `var(--s-paper)` (D1) |
+| A2 | `admin/automations/TaskDrawer.svelte:434-454`, `admin/secrets/SecretsTab.svelte:204-224`, `admin/assistant/AssistantTab.svelte:220-240` | Three hand-rolled checkboxes draw a `white` checkmark on `--s-seal` → adopt `.s-check` (checkmark already `var(--s-paper)`); SecretsTab's is a smaller variant — scale or accept the size change |
+| A3 | `setup/steps/Screen1ModelsStep.svelte:365-377` | White check on `--s-moss` → `var(--s-paper)` |
+| A4 | `Screen1ModelsStep.svelte:294-297`, `NetworkAccessStep.svelte:248-257`, `ReviewStep.svelte:291-300` | Invented `rgb(242,92,92)` danger red pasted across three files (mixed with seal borders) → one recipe: `color-mix(in srgb, var(--s-error) 12%, transparent)` + `--s-error` text/border (D2) |
+| A5 | `Screen1ModelsStep.svelte:496-512` | Amber badge with hex/rgba pairs inside `:global(.dark)` (dead — no `.dark` class exists) + `[data-theme]` branches → `var(--s-warning)` + `color-mix` wash; delete both branches |
+| A6 | `Screen1ModelsStep.svelte:514-525`; `Screen2ExtrasStep.svelte:282-284`, `:64` | Invented violet/blue washes + a non-brand `#3b82f6` mic-icon stroke → seal-wash recipe (`color-mix(in srgb, var(--s-seal) 8%, transparent)`) and `var(--s-seal)`/`var(--s-ink-2)` strokes (Discord/Slack brand glyph colors stay) |
+| A7 | `Screen2ExtrasStep.svelte:312-358` | Hand-rolled toggle: `#fff` thumb + re-derived track colors at 42×24 while the four `--toggle-*` tokens (36×20) have zero consumers → wire onto the tokens + new `--toggle-thumb`, or delete the tokens; pick one |
+| A8 | `chat/+page.svelte:606-615` | `.s-moon` branches on `[data-theme='dark'/'night']` with hand-picked rgba glows → per-mode token (`light-dark()`), component stays mode-agnostic |
+| A9 | `chat/ToolLog.svelte:282,291` | `var(--s-radius-sm, 4px)` / `var(--s-bg-hover, rgba(127,127,127,.08))` — neither token exists; always resolves to the literal → real tokens (D4) or direct `color-mix` |
+| A10 | `chat/ToolStrip.svelte:196`; `ui-kit Drawer.svelte:119`; `tokens.css:96` | Two hand-rolled scrims (one duplicating `--overlay-bg`'s value, one inlining light-ink rgba) + a dead raw-rgba token → one `light-dark()`-aware `--overlay-bg`, consumed by both (D4 scrim note) |
+| A11 | `admin/overview/OperationOutput.svelte:61-62` | Permanently dark terminal (`#e4e8f0`/`#1e2330`) → LogsTab's token recipe (`color-mix(in srgb, var(--s-ink) 3%, var(--s-paper))` + `var(--s-ink-2)`) |
+| A12 | `app.css:807,955,1668` | White/grey-alpha hover washes assume a dark surface → `color-mix(in srgb, var(--s-ink) N%, transparent)` |
+| A13 | `app.css:1472,1478` | `.deploy-bar-fill` `.ready`/`.stopped` hardcode `#ffb020`/`#d97706` beside token-correct siblings → `var(--s-warning)` / `var(--s-error)` (D2) |
+| A14 | `connections/+page.svelte:849-852` | Leftover blue `rgba(37,99,235,.08)` focus glow beside a seal border → `color-mix(in srgb, var(--s-seal) 8%, transparent)` |
+| A15 | `connections/+page.svelte:793-808` + `voice/VoiceClientSettings.svelte:575-581`; `connections/+page.svelte:986-993` | `.alert` family and local `.btn-danger` use seal-as-error (and shadow the global `--s-error`-backed `.btn-danger` under the same name) → adopt global `.feedback--error/--warning` and global `.btn-danger` (D2) |
+| A16 | `UpdatesTab.svelte:488-497`, `VoiceClientSettings.svelte:511` | Dead `var()` fallbacks (`var(--s-moss, #16a34a)` etc.) — anchors are always defined → drop the fallbacks |
+| A17 | `app.html:6,11-12,24-27` | theme-color metas diverge from `--s-paper` → sync + contract-test (D8) |
+
+### Track B — delete dead CSS (~700+ lines, zero visual change)
+
+All confirmed zero-consumer by grep, twice:
+
+- `app.css` orphaned wizard vocabulary (superseded by per-step scoped
+  classes): `.provider-grid/-group*` (998-1035), `.auth-row`/`.auth-btn*`
+  (1037-1122, keep only the `.step-actions .btn:focus` fragment),
+  `.ollama-mode-*` (1124-1174), `.model-group*`/`.model-filter*`
+  (1176-1261), `.review-card`/`.review-row*` (1263-1345, keep
+  `.deploy-svc-status`), `.options-section*`/`.toggle-grid`/`.channel-cred*`
+  (1612-1641), `.nav-info` (in 971-996), dead names in the prose-cap
+  selector (`.section-subtitle`, `.panel-description`, `.engine-desc`,
+  781-788), `.auth-method-*` dead halves (92-115, incl. undefined
+  `var(--transition-fast)`).
+- `tokens.css:343-503`: the dead third of `wiz-*` (14 selectors: ledger,
+  stamp, local-cta, add-toggle, section-label families).
+- `chat/ChatInput.svelte:236`: `animation: s-ripple …` references a keyframe
+  that exists nowhere — delete (or reinstate the keyframe deliberately).
+- `ui-kit MetricTile.svelte:101`: dead `border` declaration overridden 3
+  lines later.
+- Decide-and-act (not blind deletes): `setup/ProgressBar.svelte` (orphaned
+  component whose ~100 lines of app.css rules are still shipped) and the
+  "Universal Form System" (D3 says adopt, not delete).
+
+### Track C — relocate misplaced CSS (app.css → owners)
+
+- `.deploy-*`/`.done-*`/`.service-list*` (~260 lines, 1347-1610) →
+  `DeployStep.svelte` (which currently defines only 3 of the ~30 classes it
+  renders).
+- `.prog-*` (907-969, 1643-1681) → `ProgressBar.svelte` (after the Track B
+  decision).
+- `.rerun-banner`/`.rerun-back-link` (869-887), `.step-content` (890-900) →
+  `routes/setup/+page.svelte`.
+- `.setup-page` + `wizard-fade-in` (852-867) → a shared wizard-shell partial
+  (two consumers: setup + attention).
+- `.step-actions` (971-…) → the same shared partial.
+
+### Track D — consolidate duplicated patterns
+
+New/extended ui-kit components (each replaces 2+ verified hand-rolled copies):
+
+| Component | Replaces |
+|---|---|
+| `RadioRow` (extend: icon slot, multi-line sub, detail panel, unavailable state) | `Screen1ModelsStep` `.s1-choice-row` (402-474), `NetworkAccessStep` `.network-option-row` (149-197 — an exact recipe match) |
+| `SegmentedControl` (pill toggle) | `connections` `.theme-options` (764-791), `ModeSwitch` (52-86 — identical recipe); DeviceSettingsNav's underline tabs stay a distinct pattern |
+| `NavTrigger` (icon + eyebrow/value + dot + caret) | `EndpointSwitcher` (41-146), `SessionPicker` (49-155) |
+| `ContextCard` | byte-identical copies in `ChatActivity` (132-151) and `ChatNavbar` (196-215) |
+| `ActionCard`/`ActionButton` | `PermissionCard` (64-144) and `QuestionCard` (103-218) `s-action-*` families |
+| `EmptyState` (exists — adopt + fix collisions) | `ContainersEmptyState` hand-roll; `SessionList` `.state-card`; `EndpointList`/`ChatActivity` `.empty-state`; rename `UpdatesTab`'s third same-named variant |
+| Dismiss button (IconButton variant) | `Toast` (106-119) and `UpdateBanner` (96-106) hand-rolled ×'s |
+| Tool detail row partial | `ToolLog` (413-434) vs `ToolStrip` (280-303) |
+| `.code-chip` utility | `AutomationsTab` (558-564), `AddonsTab` (566-572), `HostImportModal` (126-133) |
+| `.sr-only` (define once) | near-identical copies in `AuthGate` (191-201) and `Toast` (127-137) |
+
+Class-adoption consolidations (no new components):
+
+- **Underline input:** adopt global `.s-input/--narrow` at the ~7 sites
+  copying the recipe (`BehaviorSection:128-142`,
+  `AkmHealthReportSection:154-168`, `EmbeddingSection:124-138`,
+  `ImproveProfileDrawer:165-177`, `AgentProfileDrawer:62-73`,
+  `AssistantTab:210-211`, `AddonsTab:599-610`) — kills the 8-property
+  `!important` fight in `AssistantTab:217`. (`LlmProfileDrawer:99-106` uses
+  the same class name for a *different* boxed recipe — rename or align.)
+- **Badges:** consolidate on global `.badge*` — local redefinitions in
+  `AutomationsTab:496-517`, `ProfileRow:72-89`, `AgentProfilesSection:84-95`;
+  parallel inventions `.stream-badge` (`ActivityTab:473-476`),
+  `.s-tile-badge` (`MetricTile:93-111`), `.creds-tag`.
+- **Chat bubble unification:** the streaming bubble's `:global(.you-words)/
+  (.master-words)` in `chat/+page.svelte:660-706` diverges from
+  `ChatMessage.svelte:202-238` (1.6rem/300/color-mix border vs
+  whisper-token/400/`--s-line`) — one recipe, one place. (Coordinate with
+  #426's Presence remount, same file region.)
+- **`Brand`-adjacent chrome:** `.msg-copy` vs `.code-copy` in
+  `ChatMessage.svelte:322-380` → one copy-button class.
+- **`VoiceProfileSelector`:** stop shadowing global `.field-hint`
+  (84-92 vs `app.css:300-303`) — one canonical definition + a warning
+  modifier if generally useful.
+
+### Track E — tokenize repeated literals
+
+With D4/D5 tokens in place, mechanical sweeps (all sites verified):
+
+- **`var(--nav-height)`** (today: zero consumers): `Navbar:94,99,106`,
+  `TabBar:201`, `EndpointSwitcher:47`, `SessionPicker:55`,
+  `DeviceSettingsNav:63`, `host/+page.svelte:388` (fix the `36px` half per
+  D4 first).
+- **`--nav-height-conversation*`**: `Navbar:165,169,181,197`,
+  `ChatNavbar:263,270,280,293,298`, `chat/+page.svelte:632,926,984,990`,
+  `advanced/+page.svelte:343,488,492`.
+- **Type tokens**: `0.75rem`→`--s-type-mark-sm`, `0.875rem`→`--s-type-deed`
+  across `SessionList` (×8), `EndpointList` (×6), `ChatNavbar:214,248`,
+  `EndpointSwitcher:106,124`, `SessionPicker:116,134`, `ChatActivity:150`,
+  `chat/+page.svelte:953-964`, `ModeSwitch:73`, `app.css:938,1666`;
+  `TaskDrawer:530`'s `10px` (under the 12px floor) → `--s-type-mark`. Odd
+  sizes to reconcile: `ChatNavbar:174` (`0.8125rem`), `Toast:114` (`18px`),
+  `UpdateBanner:101` (`1.1rem`), `Drawer:157` (`1.25rem`).
+- **Motion**: `150ms`→`--s-t-instant` (`Screen1ModelsStep` ×5,
+  `Screen2ExtrasStep`, `ReviewStep` ×3, `TaskDrawer:531`, `tokens.css:154,
+  484`); `120ms`→`--s-t-instant` per D5 (`EndpointSwitcher:56`,
+  `SessionPicker:64,96`, `ToolStrip:174,261`, `VoiceControl:315,340`,
+  `VoiceStatusStrip:124`); `0.12s`→same (`MetricTile:55`,
+  `AkmHealthCard:62`, `ConfigureShortcuts:59`); `0.2s`→`--s-t-quick`
+  (`app.css:140` — the `.btn` rule, 55 consuming files);
+  `cubic-bezier(0.4,0,0.2,1)` literals → `var(--s-ease)`.
+- **Radius**: `2px`/`8px`/`10px`/`99px` → the D4 tokens (ui-kit ×11 sites,
+  settings ×13, `SessionList` ×10 and siblings).
+- **Tap target**: `44px`/`2.75rem` → `--s-tap-min` (~25 sites across host
+  akm sections, ProvidersPanel, connections, voice, chrome; exact citations
+  in the host/settings sweeps — the settings-surface line numbers need
+  re-derivation during implementation, see §7).
+- **wiz-* internal hygiene** (`tokens.css`): px spacing on the grid →
+  `--s-sp-*`; the parallel 12–16px font scale → `--s-type-*`; survives only
+  for selectors still alive after Track B.
+- **Spacing**: `Toast:76`, `PasswordInput:51`, `AuthGate:91,107,137,151,180`,
+  `UpdateBanner:70-71` (`1px`→`--s-hair`), `app.css:127,186,193` (`.btn`
+  paddings — snap to grid or document the touch-target exception),
+  `attention/+page.svelte:49` (`3rem` one-offs — accept or extend scale).
+
+### Track F — app.html & fonts
+
+Per D7/D8: delete the Source Sans 3/IBM Plex Mono stylesheet link; keep
+preconnects; sync + contract-test the theme-color constants; optional
+follow-up to move the token-font @import to a `<link>` or self-host.
+
+### Track G — motion/reduced-motion gaps
+
+- `Screen1ModelsStep:330-351` — `s1shimmer` infinite loop, and the setup
+  surface has **no** reduced-motion handling at all → add the standard
+  media block.
+- `app.css:894` — `.step-content` entrance animation unguarded → guard (or
+  it moves with Track C and gains the guard there).
+- `ChatInput` dead ripple → Track B.
+
+### Track H — guardrails (make drift impossible, not just fixed)
+
+1. **`styling-hygiene.vitest.ts`** (repo already runs source-scanning
+   hygiene suites — `guard-hygiene`, `admin-paths-hygiene`,
+   `chrome-untangle-hygiene`; this is the same idiom): scan every component
+   `<style>` block and `app.css` for (a) raw hex/`rgb()`/`hsl()` outside an
+   explicit allowlist (tokens.css token blocks, SVG filter internals,
+   third-party brand glyphs listed by file:line), (b) `[data-theme` in
+   component styles, (c) `var(--s-…, fallback)` where the token is one of
+   the always-defined anchors, (d) references to undefined `--s-*`/custom
+   tokens (catches `--s-radius-2`, `--s-bg-hover`, `--transition-fast`
+   -class bugs). New literals then fail CI with the file:line and the rule.
+2. **Rewrite `ui-kit/tests/theme-tokens.test.ts` for `light-dark()`** —
+   **this is a hard blocker for #426 phase 1**: the suite regexes the
+   literal selector lists (`:root[data-theme='light'], :root[data-theme='day']`,
+   lines 16-21) and its `parseColor()` (32-55) reads only `#hex`/`rgba()`,
+   so the migration makes every test throw. The rewrite parses
+   `light-dark(a, b)` pairs and asserts the same WCAG ratios on both
+   resolved values.
+3. **Template contract check** (from #426): the seeded operator
+   `theme.css` template's anchor list must match `tokens.css`.
+4. **ui-kit CSS-class coupling**: extend or complement
+   `no-app-coupling.test.ts` to flag ui-kit components rendering classes not
+   defined within ui-kit (catches the Panel/FormField/SecretSelect bridge
+   regressing further) — enforce once D6's migration lands.
+
+## 5. Sequencing
+
+Each phase is independently shippable; every phase ends with the
+existing gates green plus screenshot comparison (rubric §10) proving the
+default render unchanged (except where a fix corrects an actual bug, e.g.
+A12's invisible hover washes on light paper).
+
+1. **Phase 0 — guardrails + tokens** (S): Track H test (baseline allowlist =
+   today's violations, ratcheted down as tracks land); D4 token additions;
+   theme-tokens.test rewrite prepared.
+2. **Phase 1 — Track A** (M): the ~17 breaks-theming clusters. This is what
+   makes operator theming *correct*, and it's a prerequisite for
+   #426 acceptance ("one anchor override re-tints everything").
+3. **Phase 2 — #426 phase 1 lands** (`light-dark()` + `@layer` + test
+   rewrite), coordinated with this plan's Phase 0/1.
+4. **Phase 3 — Tracks B + C** (M): delete ~700 lines, relocate ~350;
+   `app.css` drops from 1704 lines to roughly its true global core.
+5. **Phase 4 — Tracks E + F + G** (M): mechanical tokenization sweeps behind
+   the hygiene test's ratchet.
+6. **Phase 5 — Track D** (L, incremental): component consolidation, one
+   pattern at a time; each extraction is its own reviewable change.
+7. **Phase 6 — D6** (L): move the shared utility layer into ui-kit;
+   Panel/FormField/SecretSelect become self-contained; enable H4.
+
+## 6. What this buys
+
+- **Theme-ability**: after Phase 1–2, an operator `theme.css` override of
+  any anchor reaches every surface — no stranded literals, no
+  `[data-theme]` branches, no seal-as-error lies.
+- **Consistency**: one badge, one input, one radio row, one empty state, one
+  scrim — the same UI concept can no longer silently diverge per page
+  (rubric §6 becomes enforceable).
+- **Maintainability**: `app.css` shrinks ~60%; every remaining rule has an
+  owner; new literals fail CI instead of accreting.
+
+## 7. Verification notes & known citation corrections
+
+- Two findings were refuted on citation accuracy and need line re-derivation
+  before use (premises verified sound): the settings-surface `44px`
+  inventory (most cited lines pointed at script/markup, not the CSS; the
+  token gap itself is real) and ~5 of 23 line cites in the ui-kit wiz-*
+  spacing finding (off-by-one/already-tokenized lines; 18 verified).
+- Verifier corrections folded in above: TabBar's real height ≥44px (not
+  36px); SecretsTab checkbox is a smaller variant; `LlmProfileDrawer`'s
+  `.control-input` is a different recipe under the same name; Drawer scrim
+  must not mix from `--s-ink`; `ChatNavbar:174` is `0.8125rem` (not
+  0.75rem); the two `.sr-only` copies differ by one property; ~25-26 wiz-*
+  selectors are live (not ~19), 14 confirmed dead.
+- One inter-agent contradiction resolved by live check (2026-07-20): Google
+  Fonts serves both token families (incl. `Iosevka Charon Mono` v1), so the
+  fonts *do* load via `app.css:1`; only the app.html Source Sans 3/IBM Plex
+  Mono load is dead.
+- Full per-finding evidence (quoted code, line-verified verdicts, verifier
+  notes) lives in the sweep transcripts; this document is the distilled,
+  corrected inventory.

--- a/docs/technical/ui-styling-unification.md
+++ b/docs/technical/ui-styling-unification.md
@@ -323,7 +323,11 @@ A12's invisible hover washes on light paper).
 5. **Phase 4 — Tracks E + F + G** (M): mechanical tokenization sweeps behind
    the hygiene test's ratchet.
 6. **Phase 5 — Track D** (L, incremental): component consolidation, one
-   pattern at a time; each extraction is its own reviewable change.
+   pattern at a time; each extraction is its own reviewable change. The
+   normal-mode slice of this track (wizard RadioRow/toggle adoption, the
+   connections restyle, chat empty state) is owned by **#506** (rev 2),
+   which folds each file's Track A fixes into the same pass — don't
+   double-schedule those surfaces here.
 7. **Phase 6 — D6** (L): move the shared utility layer into ui-kit;
    Panel/FormField/SecretSelect become self-contained; enable H4.
 

--- a/docs/technical/ui-styling-unification.md
+++ b/docs/technical/ui-styling-unification.md
@@ -324,10 +324,13 @@ A12's invisible hover washes on light paper).
    the hygiene test's ratchet.
 6. **Phase 5 — Track D** (L, incremental): component consolidation, one
    pattern at a time; each extraction is its own reviewable change. The
-   normal-mode slice of this track (wizard RadioRow/toggle adoption, the
-   connections restyle, chat empty state) is owned by **#506** (rev 2),
-   which folds each file's Track A fixes into the same pass — don't
-   double-schedule those surfaces here.
+   *design* dimension of this track is owned by **#506** (rev 3: unify the
+   entire UI on a single chat-first Stillness language): for each pattern
+   it picks the winning design (chat-first, best-of-breed absorbed from
+   wizard/host/settings), refines it once in ui-kit, adopts it across all
+   surfaces, and deletes the losers — folding each file's Track A fixes
+   into the same pass. This plan stays the mechanical-correctness layer;
+   don't double-schedule the same surfaces here.
 7. **Phase 6 — D6** (L): move the shared utility layer into ui-kit;
    Panel/FormField/SecretSelect become self-contained; enable H4.
 

--- a/docs/theming.md
+++ b/docs/theming.md
@@ -167,6 +167,10 @@ only, ≤ 1 MB.
 
 ## For contributors
 
+- The UI is converging on a single chat-first Stillness design language
+  (#506): per-pattern design decisions (which implementation won, what was
+  absorbed from other surfaces, what was deleted) are logged in this
+  section as they're made.
 - Token changes land in `packages/ui-kit`; keep `theme-tokens.test.ts` and
   `svelte-check` green.
 - Consume `var(--s-*)` anchors or `color-mix()` tints — never hardcode a

--- a/docs/theming.md
+++ b/docs/theming.md
@@ -1,14 +1,14 @@
 # Theming & Branding the OpenPalm UI
 
 > **Status:** the "Today" sections describe the current UI (0.13.x). The
-> "Creating and applying a theme" workflow ships with the branding override
-> feature planned for **0.14.0 (#426)** — the schema below is the design of
-> record for that issue and may evolve until it ships.
+> `theme.css` workflow ships with the branding feature planned for
+> **0.14.0 (#426)** — it is the design of record for that issue.
 
 OpenPalm's operator console (chat + host dashboard) is styled by a single
-design-token system called **Stillness**. Every color, font, spacing step, and
-motion curve in the UI resolves to a CSS custom property, so theming is a
-matter of overriding a small set of token values — not editing components.
+design-token system called **Stillness**. Every color in the UI resolves to a
+CSS custom property, so theming is overriding a handful of token values in a
+plain CSS file — no build step, no JSON schema, no admin screens. You edit a
+file; the UI re-themes.
 
 ---
 
@@ -20,8 +20,7 @@ The token vocabulary is defined once, in the shared UI kit:
 
 - `packages/ui-kit/src/lib/theme/tokens.css` — the Stillness `--s-*` tokens
   (colors, type scale, spacing, motion) plus the `wiz-*` wizard vocabulary.
-- `packages/ui/src/app.css` imports it (`@import '@openpalm/ui-kit/theme/tokens.css'`)
-  and keeps only app-level layout/utility CSS.
+- `packages/ui/src/app.css` imports it and keeps only app-level layout CSS.
 
 Components never hardcode palette colors; they consume `var(--s-…)`. Derived
 tints (hover washes, subtle backgrounds, borders) are computed with
@@ -34,7 +33,7 @@ of its tints automatically.
   the preference in `localStorage` under `openpalm.theme`.
 - A blocking pre-paint script in `app.html` resolves the preference before
   first paint and stamps `data-theme="light"` or `data-theme="dark"` on
-  `<html>` — so there is no flash of the wrong mode.
+  `<html>` — no flash of the wrong mode.
 - Token blocks are keyed to that attribute:
   - light: `:root, :root[data-theme='light'], :root[data-theme='day']`
   - dark: `:root[data-theme='dark'], :root[data-theme='night']`
@@ -44,24 +43,23 @@ of its tints automatically.
 Eleven color tokens per mode define the entire palette. These are the values
 a theme overrides:
 
-| Anchor | Token | Role | Light default | Dark default |
-|---|---|---|---|---|
-| `paper` | `--s-paper` | Page background | `#E5E1D5` | `#15181B` |
-| `paperDeep` | `--s-paper-deep` | Recessed surfaces (asides, wells) | `#D9D5C8` | `#0F1214` |
-| `ink` | `--s-ink` | Primary text | `#26292B` | `#DAD6C9` |
-| `ink2` | `--s-ink-2` | Secondary text | `#575B59` | `#989B91` |
-| `ink3` | `--s-ink-3` | Tertiary text, labels | `#5D5C56` | `#85887F` |
-| `seal` | `--s-seal` | **Brand accent** — primary actions, active states | `#98420A` | `#DCC25C` |
-| `moss` | `--s-moss` | Success / positive | `#555C42` | `#8FA08C` |
-| `error` | `--s-error` | Errors / destructive | `#AB301F` | `#D95F4E` |
-| `warning` | `--s-warning` | Caution | `#835D08` | `#E0B85A` |
-| `line` | `--s-line` | Borders, dividers | `#6F6D66` | `#73766E` |
-| `lineSoft` | `--s-line-soft` | Subtle borders | `#79756C` | `#666961` |
+| Token | Role | Light default | Dark default |
+|---|---|---|---|
+| `--s-paper` | Page background | `#E5E1D5` | `#15181B` |
+| `--s-paper-deep` | Recessed surfaces (asides, wells) | `#D9D5C8` | `#0F1214` |
+| `--s-ink` | Primary text | `#26292B` | `#DAD6C9` |
+| `--s-ink-2` | Secondary text | `#575B59` | `#989B91` |
+| `--s-ink-3` | Tertiary text, labels | `#5D5C56` | `#85887F` |
+| `--s-seal` | **Brand accent** — primary actions, active states | `#98420A` | `#DCC25C` |
+| `--s-moss` | Success / positive | `#555C42` | `#8FA08C` |
+| `--s-error` | Errors / destructive | `#AB301F` | `#D95F4E` |
+| `--s-warning` | Caution | `#835D08` | `#E0B85A` |
+| `--s-line` | Borders, dividers | `#6F6D66` | `#73766E` |
+| `--s-line-soft` | Subtle borders | `#79756C` | `#666961` |
 
 There are deliberately **no hover/subtle/border variants** to override: those
-are derived from the anchors via `color-mix()` (e.g. an 8% seal wash for
-accent backgrounds), so a single `seal` change re-tints every accent surface
-in the UI.
+derive from the anchors via `color-mix()` (e.g. an 8% seal wash for accent
+backgrounds), so a single `--s-seal` change re-tints every accent surface.
 
 ### Guardrails
 
@@ -70,185 +68,161 @@ WCAG AA: 4.5:1 for text tokens on both papers, 3:1 for border tokens, plus
 type-size floors and the 4px spacing grid. If you change the **default** theme
 in source, keep that suite green (`cd packages/ui-kit && bun test`).
 
-### Changing the default theme today (source builds)
-
-Until the 0.14.0 runtime override ships, retheming means editing source:
-
-1. Edit the anchor values in `packages/ui-kit/src/lib/theme/tokens.css`
-   (both the light and dark blocks).
-2. Run `cd packages/ui-kit && bun test && bun run check` — the contrast suite
-   tells you immediately if a value breaks AA.
-3. Rebuild the UI (`bun run ui:build`).
-
 ---
 
 ## Creating and applying a theme (0.14.0, #426)
 
-Once the branding override ships, themes are a single operator-owned JSON
-file — no rebuild, no source edits.
+Every install seeds an editable theme file:
 
-### The theme file
+```
+~/.openpalm/config/ui/theme.css
+```
 
-`~/.openpalm/config/ui/branding.json` (seeded with defaults on install;
-user-owned — lifecycle never overwrites it):
+It is user-owned — lifecycle never overwrites it — and it is loaded by every
+page **after** the built-in stylesheet, so anything you set there wins. The
+file ships with the full anchor list commented out, in the correct light/dark
+blocks, so applying a theme is: open the file, uncomment, change values, save,
+reload the browser. No restart, no rebuild.
 
-```jsonc
-{
-  "version": 1,
-  "name": null,                            // string → replaces "OpenPalm" everywhere; null → default
-  "logo": { "light": null, "dark": null }, // filenames under config/ui/assets/; null → built-in logo
-  "palette": {
-    "light": {},                           // any subset of the 11 anchors, hex only
-    "dark": {}
-  },
-  "avatar": null                           // filename under config/ui/assets/; null → animated ensō
+### The seeded template
+
+```css
+/* OpenPalm UI theme — edit freely; this file is yours.
+   Uncomment a token to override it. Keep values inside these two blocks:
+   the selectors must match the built-in theme's blocks so your values
+   apply in the right mode. Full docs: docs/theming.md */
+
+:root,
+:root[data-theme='light'],
+:root[data-theme='day'] {
+  /* --s-paper:      #E5E1D5; */
+  /* --s-paper-deep: #D9D5C8; */
+  /* --s-ink:        #26292B; */
+  /* --s-ink-2:      #575B59; */
+  /* --s-ink-3:      #5D5C56; */
+  /* --s-seal:       #98420A; */
+  /* --s-moss:       #555C42; */
+  /* --s-error:      #AB301F; */
+  /* --s-warning:    #835D08; */
+  /* --s-line:       #6F6D66; */
+  /* --s-line-soft:  #79756C; */
+}
+
+:root[data-theme='dark'],
+:root[data-theme='night'] {
+  /* --s-paper:      #15181B; */
+  /* --s-paper-deep: #0F1214; */
+  /* --s-ink:        #DAD6C9; */
+  /* --s-ink-2:      #989B91; */
+  /* --s-ink-3:      #85887F; */
+  /* --s-seal:       #DCC25C; */
+  /* --s-moss:       #8FA08C; */
+  /* --s-error:      #D95F4E; */
+  /* --s-warning:    #E0B85A; */
+  /* --s-line:       #73766E; */
+  /* --s-line-soft:  #666961; */
 }
 ```
 
-Rules:
+### Walkthrough: re-color the brand accent
 
-- Palette keys are the camelCase anchor names from the table above
-  (`paper`, `paperDeep`, `ink`, `ink2`, `ink3`, `seal`, `moss`, `error`,
-  `warning`, `line`, `lineSoft`).
-- Values must be 6-digit hex (`#RRGGBB`). Anything else — shorthand hex,
-  `rgb()`/`oklch()`, CSS keywords, or anything containing punctuation — is
-  rejected and the default is used for that key. This is a security boundary
-  (the values are emitted into a style block), not a formatting preference.
-- Every key is optional. Override one anchor or all eleven; light and dark
-  are independent.
-- Unknown keys are ignored (forward-compatible) and logged.
+Uncomment `--s-seal` in both blocks and change the values:
 
-### Walkthrough: a minimal brand re-color
+```css
+:root,
+:root[data-theme='light'],
+:root[data-theme='day'] {
+  --s-seal: #1D5C8F;
+}
 
-Change only the accent, in both modes:
-
-```jsonc
-{
-  "version": 1,
-  "palette": {
-    "light": { "seal": "#1D5C8F" },
-    "dark":  { "seal": "#7FB4DC" }
-  }
+:root[data-theme='dark'],
+:root[data-theme='night'] {
+  --s-seal: #7FB4DC;
 }
 ```
 
-Save the file and reload the UI — the server picks up edits within a few
-seconds (no restart). Buttons, active tabs, focus rings, the speaking
-waveform, and every accent wash re-tint, because they all derive from
-`--s-seal`.
+Save and reload. Buttons, active tabs, focus rings, the speaking waveform,
+and every accent wash re-tint — they all derive from `--s-seal`.
 
-### Walkthrough: a full theme
+### Beyond the anchors
 
-A complete "slate & amber" theme:
-
-```jsonc
-{
-  "version": 1,
-  "name": "Ops Console",
-  "palette": {
-    "light": {
-      "paper": "#ECEEF1", "paperDeep": "#DFE3E8",
-      "ink": "#1F2429", "ink2": "#4C555E", "ink3": "#5D6772",
-      "seal": "#B26A00", "moss": "#3E6B4F",
-      "error": "#A8321F", "warning": "#8A6400",
-      "line": "#6C737A", "lineSoft": "#7E858C"
-    },
-    "dark": {
-      "paper": "#14171A", "paperDeep": "#0E1114",
-      "ink": "#D7DBDF", "ink2": "#97A0A8", "ink3": "#828B93",
-      "seal": "#E8A94E", "moss": "#8CAB94",
-      "error": "#D96A55", "warning": "#D9B45C",
-      "line": "#6E767D", "lineSoft": "#61686F"
-    }
-  }
-}
-```
+The file is real CSS on your own machine — you *can* override any token
+(fonts, spacing, motion) or write arbitrary rules. The 11 color anchors are
+the supported surface: they are stable across releases and everything derives
+from them. Anything beyond the anchors may break on upgrade as internal
+selectors and tokens evolve — keep a backup and expect to maintain it.
 
 ### Contrast: your responsibility once you override
 
 The shipped defaults are WCAG AA-verified; your overrides bypass those tests.
 Keep these pairs readable:
 
-- `ink` / `ink2` / `ink3` against **both** `paper` and `paperDeep` — ≥ 4.5:1.
-- `seal`, `moss`, `error`, `warning` against both papers — ≥ 4.5:1 (they are
-  used as text/icon colors, not just fills).
-- `line` against both papers — ≥ 3:1.
+- `--s-ink` / `-2` / `-3` against **both** papers — ≥ 4.5:1.
+- `--s-seal`, `--s-moss`, `--s-error`, `--s-warning` against both papers —
+  ≥ 4.5:1 (they are used as text/icon colors, not just fills).
+- `--s-line` against both papers — ≥ 3:1.
 
-The Appearance settings tab shows a contrast warning per anchor as you edit;
-any WCAG checker (e.g. WebAIM's) works for offline authoring. Dark-mode tip:
-don't use pure `#000000`/`#FFFFFF` — keep at least one intermediate surface
-(`paperDeep`) distinct from `paper`.
+Any WCAG checker (e.g. WebAIM's) works. Dark-mode tip: don't use pure
+`#000000`/`#FFFFFF` — keep `--s-paper-deep` visibly distinct from `--s-paper`.
 
-### Logo
+### Product name and logo
 
-Drop raster files into `~/.openpalm/config/ui/assets/` and name them:
-
-```jsonc
-{ "logo": { "light": "logo.png", "dark": "logo-dark.png" } }
-```
-
-- Formats: PNG, GIF, WebP. ≤ 1 MB. **No SVG uploads** (XSS surface) and no
-  remote URLs — files are served same-origin from your config directory.
-- Why a light/dark pair: the built-in logo is an inline SVG that inherits the
-  text color and adapts to the mode automatically; a raster file cannot, so
-  you supply one per mode (either may be omitted to keep the built-in mark).
-- Missing or invalid files fall back to the built-in logo — a typo never
-  breaks the UI.
+- **Name**: set `OP_UI_BRAND_NAME` in `~/.openpalm/knowledge/env/stack.env`
+  to replace the "OpenPalm" strings (navbar, login, setup, page titles).
+  Unset → default.
+- **Logo**: drop raster files into `~/.openpalm/config/ui/assets/` using the
+  conventional names `logo.png` and `logo-dark.png` (`.webp`/`.gif` also
+  accepted). If present they replace the built-in mark in the matching mode;
+  absent files fall back to the built-in inline SVG (which follows your theme
+  colors automatically — a raster logo cannot, which is why there is a
+  per-mode pair).
+- Formats: PNG, GIF, WebP only, ≤ 1 MB. No SVG files (they can carry active
+  content) and no remote URLs — assets are served same-origin from your
+  config directory.
 
 ### Chat avatar
 
 The chat surface ships with an animated **ensō presence mark** as the
-assistant avatar. It is state-reactive:
+assistant avatar. It is state-reactive — idle breathing, a pulsing bloom
+while the assistant is thinking, inward ripples while listening, a five-bar
+waveform while speaking — and it draws with the theme's ink/seal tokens, so
+your palette re-colors it automatically. `prefers-reduced-motion` stills
+every loop.
 
-- **idle** — slow breathing
-- **thinking** (assistant is working) — dimmed mark with a pulsing accent bloom
-- **listening** (voice input) — ripples gathering inward
-- **speaking** (voice output) — a five-bar waveform
+To replace it with your own image, drop `avatar.png` (or `.webp`/`.gif`)
+into `~/.openpalm/config/ui/assets/`. Animated GIF/WebP plays as-is; the
+state-driven motion classes still apply gentle scale/opacity treatment, and
+reduced-motion is honored. Delete the file to return to the ensō.
 
-It uses the brand mark and the theme's `ink`/`seal` tokens, so palette
-overrides re-color it automatically. `prefers-reduced-motion` stills every
-loop.
-
-To replace it with your own image:
-
-```jsonc
-{ "avatar": "avatar.webp" }
-```
-
-Same rules as logos (PNG/GIF/WebP under `config/ui/assets/`, ≤ 1 MB). An
-animated GIF/WebP plays as-is; the state-driven motion classes still apply
-gentle scale/opacity treatment around it, and reduced-motion is honored.
-Set `"avatar": null` to return to the ensō.
-
-### Applying and troubleshooting
+### Troubleshooting
 
 | Symptom | Cause / fix |
 |---|---|
-| Nothing changed after editing the file | JSON syntax error — check the server log; the file is parsed fail-closed (invalid file ⇒ defaults). Validate with `jq . branding.json` |
-| One color ignored, others applied | That value failed the `#RRGGBB` check (shorthand hex and `oklch()` are not accepted) |
-| Logo/avatar not showing | Filename in JSON must exactly match a file in `config/ui/assets/`; only PNG/GIF/WebP are served; check size ≤ 1 MB |
-| Colors flash on load | Should never happen — the override is injected server-side before paint. If you see a flash, file a bug |
-| Theme works in light mode but not dark | The two modes are independent — add the anchor under `palette.dark` too |
+| Nothing changed after editing | Hard-reload the browser (the theme file is served with revalidation, but the tab may hold a cached copy); check the file is at `config/ui/theme.css` |
+| Override works in light mode but not dark | The two blocks are independent — set the token inside the dark block too |
+| Override ignored entirely | Values placed outside the two selector blocks (e.g. a bare `:root { }`) lose to the built-in mode blocks — keep overrides inside the seeded selectors |
+| Logo/avatar not showing | Check the conventional filename (`logo.png`, `logo-dark.png`, `avatar.png`/`.webp`/`.gif`), the location (`config/ui/assets/`), format (PNG/GIF/WebP), and size ≤ 1 MB |
+| UI broken after aggressive custom CSS | Delete or empty `theme.css` — the UI always renders correctly without it |
 
-### What branding.json does *not* theme
+### What theme.css does *not* control
 
 - The **assistant terminal (TUI) theme** — that's OpenCode's own theme file,
   managed at `~/.openpalm/system/assistant/themes/openpalm.json`
   (lifecycle-overwritten; separate system).
 - The Electron shell (splash screen, tray icon) and desktop notification
   titles — tracked separately.
-- Fonts, spacing, motion — the Stillness type/spacing/motion tokens are not
-  operator-overridable (bounded palette by design).
 
 ---
 
 ## For contributors
 
-- Token changes land in `packages/ui-kit` (raw-source package, no build step);
-  keep `theme-tokens.test.ts` and `svelte-check` green.
+- Token changes land in `packages/ui-kit` (raw-source package, no build
+  step); keep `theme-tokens.test.ts` and `svelte-check` green.
 - New components must consume `var(--s-*)` anchors or `color-mix()` tints of
   them — never hardcode a palette literal (hardcoded contrast-paired literals
   break operator overrides silently).
+- The seeded template above must stay in sync with the anchor list in
+  `tokens.css` — the token contract test covers both.
 - The UI design rubric (`docs/technical/ui-design-rubric.md`) remains the
-  approval gate for visual changes; note that "brand accent" is
+  approval gate for visual changes; note that the brand accent is
   operator-overridable once #426 ships.

--- a/docs/theming.md
+++ b/docs/theming.md
@@ -1,14 +1,13 @@
-# Theming & Branding the OpenPalm UI
+# Theming the OpenPalm UI
 
 > **Status:** the "Today" sections describe the current UI (0.13.x). The
-> `theme.css` workflow ships with the branding feature planned for
-> **0.14.0 (#426)** — it is the design of record for that issue.
+> `theme.css` workflow ships with **0.14.0 (#426)**.
 
-OpenPalm's operator console (chat + host dashboard) is styled by a single
-design-token system called **Stillness**. Every color in the UI resolves to a
-CSS custom property, so theming is overriding a handful of token values in a
-plain CSS file — no build step, no JSON schema, no admin screens. You edit a
-file; the UI re-themes.
+OpenPalm's operator console is styled by a single design-token system called
+**Stillness**. Every color in the UI resolves to a CSS custom property, so
+theming is overriding a handful of token values in a plain CSS file. You edit
+a file; the UI re-themes. There is no theme schema, no build step, and no
+settings screen.
 
 ---
 
@@ -16,10 +15,8 @@ file; the UI re-themes.
 
 ### Where the tokens live
 
-The token vocabulary is defined once, in the shared UI kit:
-
 - `packages/ui-kit/src/lib/theme/tokens.css` — the Stillness `--s-*` tokens
-  (colors, type scale, spacing, motion) plus the `wiz-*` wizard vocabulary.
+  (colors, type scale, spacing, motion).
 - `packages/ui/src/app.css` imports it and keeps only app-level layout CSS.
 
 Components never hardcode palette colors; they consume `var(--s-…)`. Derived
@@ -29,44 +26,42 @@ of its tints automatically.
 
 ### Light / dark / system modes
 
-- The mode toggle (in the navbar) cycles **system → light → dark** and stores
-  the preference in `localStorage` under `openpalm.theme`.
-- A blocking pre-paint script in `app.html` resolves the preference before
-  first paint and stamps `data-theme="light"` or `data-theme="dark"` on
-  `<html>` — no flash of the wrong mode.
+- The mode toggle cycles **system → light → dark** and stores the preference
+  in `localStorage` under `openpalm.theme`.
+- A blocking pre-paint script in `app.html` stamps `data-theme="light"` or
+  `data-theme="dark"` on `<html>` before first paint — no flash.
 - Token blocks are keyed to that attribute:
   - light: `:root, :root[data-theme='light'], :root[data-theme='day']`
   - dark: `:root[data-theme='dark'], :root[data-theme='night']`
 
 ### The color anchors
 
-Eleven color tokens per mode define the entire palette. These are the values
-a theme overrides:
+Eleven color tokens per mode define the entire palette:
 
 | Token | Role | Light default | Dark default |
 |---|---|---|---|
 | `--s-paper` | Page background | `#E5E1D5` | `#15181B` |
-| `--s-paper-deep` | Recessed surfaces (asides, wells) | `#D9D5C8` | `#0F1214` |
+| `--s-paper-deep` | Recessed surfaces | `#D9D5C8` | `#0F1214` |
 | `--s-ink` | Primary text | `#26292B` | `#DAD6C9` |
 | `--s-ink-2` | Secondary text | `#575B59` | `#989B91` |
 | `--s-ink-3` | Tertiary text, labels | `#5D5C56` | `#85887F` |
-| `--s-seal` | **Brand accent** — primary actions, active states | `#98420A` | `#DCC25C` |
+| `--s-seal` | **Brand accent** | `#98420A` | `#DCC25C` |
 | `--s-moss` | Success / positive | `#555C42` | `#8FA08C` |
 | `--s-error` | Errors / destructive | `#AB301F` | `#D95F4E` |
 | `--s-warning` | Caution | `#835D08` | `#E0B85A` |
 | `--s-line` | Borders, dividers | `#6F6D66` | `#73766E` |
 | `--s-line-soft` | Subtle borders | `#79756C` | `#666961` |
 
-There are deliberately **no hover/subtle/border variants** to override: those
-derive from the anchors via `color-mix()` (e.g. an 8% seal wash for accent
-backgrounds), so a single `--s-seal` change re-tints every accent surface.
+There are deliberately no hover/subtle/border variants: those derive from the
+anchors via `color-mix()`, so a single `--s-seal` change re-tints every accent
+surface.
 
 ### Guardrails
 
 `packages/ui-kit/tests/theme-tokens.test.ts` pins the default palette to
-WCAG AA: 4.5:1 for text tokens on both papers, 3:1 for border tokens, plus
-type-size floors and the 4px spacing grid. If you change the **default** theme
-in source, keep that suite green (`cd packages/ui-kit && bun test`).
+WCAG AA (4.5:1 text, 3:1 borders, type floors, 4px spacing grid). If you
+change the **default** theme in source, keep it green
+(`cd packages/ui-kit && bun test`).
 
 ---
 
@@ -78,19 +73,17 @@ Every install seeds an editable theme file:
 ~/.openpalm/config/ui/theme.css
 ```
 
-It is user-owned — lifecycle never overwrites it — and it is loaded by every
-page **after** the built-in stylesheet, so anything you set there wins. The
-file ships with the full anchor list commented out, in the correct light/dark
-blocks, so applying a theme is: open the file, uncomment, change values, save,
-reload the browser. No restart, no rebuild.
+It is yours — lifecycle never overwrites it — and it loads after the built-in
+stylesheet on every page, so anything you set there wins. It ships with the
+full anchor list commented out, in the correct light/dark blocks. Applying a
+theme is: open the file, uncomment, change values, save, reload the browser.
 
 ### The seeded template
 
 ```css
-/* OpenPalm UI theme — edit freely; this file is yours.
-   Uncomment a token to override it. Keep values inside these two blocks:
-   the selectors must match the built-in theme's blocks so your values
-   apply in the right mode. Full docs: docs/theming.md */
+/* OpenPalm UI theme — this file is yours; edit freely.
+   Uncomment a token to override it. Keep overrides inside these two
+   blocks so they apply in the right mode. Docs: docs/theming.md */
 
 :root,
 :root[data-theme='light'],
@@ -124,9 +117,7 @@ reload the browser. No restart, no rebuild.
 }
 ```
 
-### Walkthrough: re-color the brand accent
-
-Uncomment `--s-seal` in both blocks and change the values:
+### Example: re-color the brand accent
 
 ```css
 :root,
@@ -146,83 +137,54 @@ and every accent wash re-tint — they all derive from `--s-seal`.
 
 ### Beyond the anchors
 
-The file is real CSS on your own machine — you *can* override any token
-(fonts, spacing, motion) or write arbitrary rules. The 11 color anchors are
-the supported surface: they are stable across releases and everything derives
-from them. Anything beyond the anchors may break on upgrade as internal
-selectors and tokens evolve — keep a backup and expect to maintain it.
+The file is real CSS — you *can* override any token or write arbitrary
+rules. The 11 anchors are the supported, upgrade-stable surface; anything
+beyond them may break as internal selectors evolve.
 
-### Contrast: your responsibility once you override
+### Contrast
 
-The shipped defaults are WCAG AA-verified; your overrides bypass those tests.
-Keep these pairs readable:
-
-- `--s-ink` / `-2` / `-3` against **both** papers — ≥ 4.5:1.
-- `--s-seal`, `--s-moss`, `--s-error`, `--s-warning` against both papers —
-  ≥ 4.5:1 (they are used as text/icon colors, not just fills).
-- `--s-line` against both papers — ≥ 3:1.
-
-Any WCAG checker (e.g. WebAIM's) works. Dark-mode tip: don't use pure
-`#000000`/`#FFFFFF` — keep `--s-paper-deep` visibly distinct from `--s-paper`.
-
-### Product name and logo
-
-- **Name**: set `OP_UI_BRAND_NAME` in `~/.openpalm/knowledge/env/stack.env`
-  to replace the "OpenPalm" strings (navbar, login, setup, page titles).
-  Unset → default.
-- **Logo**: drop raster files into `~/.openpalm/config/ui/assets/` using the
-  conventional names `logo.png` and `logo-dark.png` (`.webp`/`.gif` also
-  accepted). If present they replace the built-in mark in the matching mode;
-  absent files fall back to the built-in inline SVG (which follows your theme
-  colors automatically — a raster logo cannot, which is why there is a
-  per-mode pair).
-- Formats: PNG, GIF, WebP only, ≤ 1 MB. No SVG files (they can carry active
-  content) and no remote URLs — assets are served same-origin from your
-  config directory.
+The shipped defaults are WCAG AA-verified; your overrides bypass those
+tests. Keep `--s-ink`/`-2`/`-3` and the four status colors at ≥ 4.5:1
+against both papers, and `--s-line` at ≥ 3:1. Any WCAG checker (e.g.
+WebAIM's) works.
 
 ### Chat avatar
 
-The chat surface ships with an animated **ensō presence mark** as the
-assistant avatar. It is state-reactive — idle breathing, a pulsing bloom
-while the assistant is thinking, inward ripples while listening, a five-bar
-waveform while speaking — and it draws with the theme's ink/seal tokens, so
-your palette re-colors it automatically. `prefers-reduced-motion` stills
+The chat surface ships with an animated **ensō presence mark** — idle
+breathing, a pulsing bloom while thinking, ripples while listening, a
+waveform while speaking. It draws with the theme's ink/seal tokens, so your
+palette re-colors it automatically, and `prefers-reduced-motion` stills
 every loop.
 
-To replace it with your own image, drop `avatar.png` (or `.webp`/`.gif`)
-into `~/.openpalm/config/ui/assets/`. Animated GIF/WebP plays as-is; the
-state-driven motion classes still apply gentle scale/opacity treatment, and
-reduced-motion is honored. Delete the file to return to the ensō.
+To replace it, drop **`avatar.png`** (or `avatar.webp` / `avatar.gif`) into
+`~/.openpalm/config/ui/assets/`. Animated WebP/GIF plays as-is; reduced
+motion is honored. Delete the file to return to the ensō. Raster formats
+only, ≤ 1 MB.
 
 ### Troubleshooting
 
 | Symptom | Cause / fix |
 |---|---|
-| Nothing changed after editing | Hard-reload the browser (the theme file is served with revalidation, but the tab may hold a cached copy); check the file is at `config/ui/theme.css` |
-| Override works in light mode but not dark | The two blocks are independent — set the token inside the dark block too |
-| Override ignored entirely | Values placed outside the two selector blocks (e.g. a bare `:root { }`) lose to the built-in mode blocks — keep overrides inside the seeded selectors |
-| Logo/avatar not showing | Check the conventional filename (`logo.png`, `logo-dark.png`, `avatar.png`/`.webp`/`.gif`), the location (`config/ui/assets/`), format (PNG/GIF/WebP), and size ≤ 1 MB |
+| Nothing changed after editing | Hard-reload the browser; check the file is at `config/ui/theme.css` |
+| Works in light mode but not dark | The two blocks are independent — set the token in the dark block too |
+| Override ignored entirely | Values outside the two selector blocks (e.g. a bare `:root { }`) lose to the built-in mode blocks — keep overrides inside the seeded selectors |
+| Avatar not showing | Filename must be exactly `avatar.png`/`avatar.webp`/`avatar.gif` in `config/ui/assets/` |
 | UI broken after aggressive custom CSS | Delete or empty `theme.css` — the UI always renders correctly without it |
 
 ### What theme.css does *not* control
 
-- The **assistant terminal (TUI) theme** — that's OpenCode's own theme file,
-  managed at `~/.openpalm/system/assistant/themes/openpalm.json`
-  (lifecycle-overwritten; separate system).
-- The Electron shell (splash screen, tray icon) and desktop notification
-  titles — tracked separately.
+- Product name and logo — out of scope for #426 (follow-up if needed).
+- The **assistant terminal (TUI) theme** — OpenCode's own file, managed at
+  `~/.openpalm/system/assistant/themes/openpalm.json`.
+- The Electron shell (splash/tray) and desktop notifications.
 
 ---
 
 ## For contributors
 
-- Token changes land in `packages/ui-kit` (raw-source package, no build
-  step); keep `theme-tokens.test.ts` and `svelte-check` green.
-- New components must consume `var(--s-*)` anchors or `color-mix()` tints of
-  them — never hardcode a palette literal (hardcoded contrast-paired literals
-  break operator overrides silently).
-- The seeded template above must stay in sync with the anchor list in
-  `tokens.css` — the token contract test covers both.
-- The UI design rubric (`docs/technical/ui-design-rubric.md`) remains the
-  approval gate for visual changes; note that the brand accent is
-  operator-overridable once #426 ships.
+- Token changes land in `packages/ui-kit`; keep `theme-tokens.test.ts` and
+  `svelte-check` green.
+- Consume `var(--s-*)` anchors or `color-mix()` tints — never hardcode a
+  palette literal (hardcoded contrast-paired literals break operator
+  overrides silently).
+- The seeded template must stay in sync with the anchor list in `tokens.css`.

--- a/docs/theming.md
+++ b/docs/theming.md
@@ -30,9 +30,14 @@ of its tints automatically.
   in `localStorage` under `openpalm.theme`.
 - A blocking pre-paint script in `app.html` stamps `data-theme="light"` or
   `data-theme="dark"` on `<html>` before first paint — no flash.
-- Token blocks are keyed to that attribute:
-  - light: `:root, :root[data-theme='light'], :root[data-theme='day']`
-  - dark: `:root[data-theme='dark'], :root[data-theme='night']`
+- Token blocks are currently keyed to that attribute (light:
+  `:root, :root[data-theme='light'], :root[data-theme='day']`; dark:
+  `:root[data-theme='dark'], :root[data-theme='night']`). Phase 1 of #426
+  collapses this duplication: the anchors become single
+  `light-dark(lightValue, darkValue)` declarations on `:root` inside a
+  cascade `@layer`, resolved by `color-scheme` (which the pre-paint script
+  already sets). The `data-theme` attribute remains for the few non-token
+  selectors that use it.
 
 ### The color anchors
 
@@ -73,67 +78,47 @@ Every install seeds an editable theme file:
 ~/.openpalm/config/ui/theme.css
 ```
 
-It is yours — lifecycle never overwrites it — and it loads after the built-in
-stylesheet on every page, so anything you set there wins. It ships with the
-full anchor list commented out, in the correct light/dark blocks. Applying a
-theme is: open the file, uncomment, change values, save, reload the browser.
+It is yours — lifecycle never overwrites it — and because the built-in
+tokens live in a cascade `@layer`, anything you set here wins, regardless of
+selector or ordering. Each anchor takes both modes in one line via
+`light-dark(lightValue, darkValue)`. Applying a theme is: open the file,
+uncomment, change values, save, reload the browser.
 
 ### The seeded template
 
 ```css
 /* OpenPalm UI theme — this file is yours; edit freely.
-   Uncomment a token to override it. Keep overrides inside these two
-   blocks so they apply in the right mode. Docs: docs/theming.md */
+   Uncomment a token to override it. light-dark(a, b) sets the light
+   and dark mode values in one line; a plain single value applies to
+   both modes. Docs: docs/theming.md */
 
-:root,
-:root[data-theme='light'],
-:root[data-theme='day'] {
-  /* --s-paper:      #E5E1D5; */
-  /* --s-paper-deep: #D9D5C8; */
-  /* --s-ink:        #26292B; */
-  /* --s-ink-2:      #575B59; */
-  /* --s-ink-3:      #5D5C56; */
-  /* --s-seal:       #98420A; */
-  /* --s-moss:       #555C42; */
-  /* --s-error:      #AB301F; */
-  /* --s-warning:    #835D08; */
-  /* --s-line:       #6F6D66; */
-  /* --s-line-soft:  #79756C; */
-}
-
-:root[data-theme='dark'],
-:root[data-theme='night'] {
-  /* --s-paper:      #15181B; */
-  /* --s-paper-deep: #0F1214; */
-  /* --s-ink:        #DAD6C9; */
-  /* --s-ink-2:      #989B91; */
-  /* --s-ink-3:      #85887F; */
-  /* --s-seal:       #DCC25C; */
-  /* --s-moss:       #8FA08C; */
-  /* --s-error:      #D95F4E; */
-  /* --s-warning:    #E0B85A; */
-  /* --s-line:       #73766E; */
-  /* --s-line-soft:  #666961; */
+:root {
+  /* --s-paper:      light-dark(#E5E1D5, #15181B); */
+  /* --s-paper-deep: light-dark(#D9D5C8, #0F1214); */
+  /* --s-ink:        light-dark(#26292B, #DAD6C9); */
+  /* --s-ink-2:      light-dark(#575B59, #989B91); */
+  /* --s-ink-3:      light-dark(#5D5C56, #85887F); */
+  /* --s-seal:       light-dark(#98420A, #DCC25C); */
+  /* --s-moss:       light-dark(#555C42, #8FA08C); */
+  /* --s-error:      light-dark(#AB301F, #D95F4E); */
+  /* --s-warning:    light-dark(#835D08, #E0B85A); */
+  /* --s-line:       light-dark(#6F6D66, #73766E); */
+  /* --s-line-soft:  light-dark(#79756C, #666961); */
 }
 ```
 
 ### Example: re-color the brand accent
 
 ```css
-:root,
-:root[data-theme='light'],
-:root[data-theme='day'] {
-  --s-seal: #1D5C8F;
-}
-
-:root[data-theme='dark'],
-:root[data-theme='night'] {
-  --s-seal: #7FB4DC;
+:root {
+  --s-seal: light-dark(#1D5C8F, #7FB4DC);
 }
 ```
 
 Save and reload. Buttons, active tabs, focus rings, the speaking waveform,
-and every accent wash re-tint — they all derive from `--s-seal`.
+and every accent wash re-tint in both modes — they all derive from
+`--s-seal`. Any CSS color syntax works (`oklch()`, named colors, …); use a
+single value instead of `light-dark()` to apply it to both modes.
 
 ### Beyond the anchors
 
@@ -166,8 +151,8 @@ only, ≤ 1 MB.
 | Symptom | Cause / fix |
 |---|---|
 | Nothing changed after editing | Hard-reload the browser; check the file is at `config/ui/theme.css` |
-| Works in light mode but not dark | The two blocks are independent — set the token in the dark block too |
-| Override ignored entirely | Values outside the two selector blocks (e.g. a bare `:root { }`) lose to the built-in mode blocks — keep overrides inside the seeded selectors |
+| Works in light mode but not dark | You set a single value where you wanted a pair — use `light-dark(lightValue, darkValue)` |
+| Colors broken everywhere | Very old browser: the console requires `light-dark()` support (Chrome/Edge 123+, Firefox 120+, Safari 17.5+, all mid-2024) |
 | Avatar not showing | Filename must be exactly `avatar.png`/`avatar.webp`/`avatar.gif` in `config/ui/assets/` |
 | UI broken after aggressive custom CSS | Delete or empty `theme.css` — the UI always renders correctly without it |
 

--- a/docs/theming.md
+++ b/docs/theming.md
@@ -1,0 +1,254 @@
+# Theming & Branding the OpenPalm UI
+
+> **Status:** the "Today" sections describe the current UI (0.13.x). The
+> "Creating and applying a theme" workflow ships with the branding override
+> feature planned for **0.14.0 (#426)** — the schema below is the design of
+> record for that issue and may evolve until it ships.
+
+OpenPalm's operator console (chat + host dashboard) is styled by a single
+design-token system called **Stillness**. Every color, font, spacing step, and
+motion curve in the UI resolves to a CSS custom property, so theming is a
+matter of overriding a small set of token values — not editing components.
+
+---
+
+## How theming works today
+
+### Where the tokens live
+
+The token vocabulary is defined once, in the shared UI kit:
+
+- `packages/ui-kit/src/lib/theme/tokens.css` — the Stillness `--s-*` tokens
+  (colors, type scale, spacing, motion) plus the `wiz-*` wizard vocabulary.
+- `packages/ui/src/app.css` imports it (`@import '@openpalm/ui-kit/theme/tokens.css'`)
+  and keeps only app-level layout/utility CSS.
+
+Components never hardcode palette colors; they consume `var(--s-…)`. Derived
+tints (hover washes, subtle backgrounds, borders) are computed with
+`color-mix()` from the anchor tokens, so changing one anchor cascades to all
+of its tints automatically.
+
+### Light / dark / system modes
+
+- The mode toggle (in the navbar) cycles **system → light → dark** and stores
+  the preference in `localStorage` under `openpalm.theme`.
+- A blocking pre-paint script in `app.html` resolves the preference before
+  first paint and stamps `data-theme="light"` or `data-theme="dark"` on
+  `<html>` — so there is no flash of the wrong mode.
+- Token blocks are keyed to that attribute:
+  - light: `:root, :root[data-theme='light'], :root[data-theme='day']`
+  - dark: `:root[data-theme='dark'], :root[data-theme='night']`
+
+### The color anchors
+
+Eleven color tokens per mode define the entire palette. These are the values
+a theme overrides:
+
+| Anchor | Token | Role | Light default | Dark default |
+|---|---|---|---|---|
+| `paper` | `--s-paper` | Page background | `#E5E1D5` | `#15181B` |
+| `paperDeep` | `--s-paper-deep` | Recessed surfaces (asides, wells) | `#D9D5C8` | `#0F1214` |
+| `ink` | `--s-ink` | Primary text | `#26292B` | `#DAD6C9` |
+| `ink2` | `--s-ink-2` | Secondary text | `#575B59` | `#989B91` |
+| `ink3` | `--s-ink-3` | Tertiary text, labels | `#5D5C56` | `#85887F` |
+| `seal` | `--s-seal` | **Brand accent** — primary actions, active states | `#98420A` | `#DCC25C` |
+| `moss` | `--s-moss` | Success / positive | `#555C42` | `#8FA08C` |
+| `error` | `--s-error` | Errors / destructive | `#AB301F` | `#D95F4E` |
+| `warning` | `--s-warning` | Caution | `#835D08` | `#E0B85A` |
+| `line` | `--s-line` | Borders, dividers | `#6F6D66` | `#73766E` |
+| `lineSoft` | `--s-line-soft` | Subtle borders | `#79756C` | `#666961` |
+
+There are deliberately **no hover/subtle/border variants** to override: those
+are derived from the anchors via `color-mix()` (e.g. an 8% seal wash for
+accent backgrounds), so a single `seal` change re-tints every accent surface
+in the UI.
+
+### Guardrails
+
+`packages/ui-kit/tests/theme-tokens.test.ts` pins the default palette to
+WCAG AA: 4.5:1 for text tokens on both papers, 3:1 for border tokens, plus
+type-size floors and the 4px spacing grid. If you change the **default** theme
+in source, keep that suite green (`cd packages/ui-kit && bun test`).
+
+### Changing the default theme today (source builds)
+
+Until the 0.14.0 runtime override ships, retheming means editing source:
+
+1. Edit the anchor values in `packages/ui-kit/src/lib/theme/tokens.css`
+   (both the light and dark blocks).
+2. Run `cd packages/ui-kit && bun test && bun run check` — the contrast suite
+   tells you immediately if a value breaks AA.
+3. Rebuild the UI (`bun run ui:build`).
+
+---
+
+## Creating and applying a theme (0.14.0, #426)
+
+Once the branding override ships, themes are a single operator-owned JSON
+file — no rebuild, no source edits.
+
+### The theme file
+
+`~/.openpalm/config/ui/branding.json` (seeded with defaults on install;
+user-owned — lifecycle never overwrites it):
+
+```jsonc
+{
+  "version": 1,
+  "name": null,                            // string → replaces "OpenPalm" everywhere; null → default
+  "logo": { "light": null, "dark": null }, // filenames under config/ui/assets/; null → built-in logo
+  "palette": {
+    "light": {},                           // any subset of the 11 anchors, hex only
+    "dark": {}
+  },
+  "avatar": null                           // filename under config/ui/assets/; null → animated ensō
+}
+```
+
+Rules:
+
+- Palette keys are the camelCase anchor names from the table above
+  (`paper`, `paperDeep`, `ink`, `ink2`, `ink3`, `seal`, `moss`, `error`,
+  `warning`, `line`, `lineSoft`).
+- Values must be 6-digit hex (`#RRGGBB`). Anything else — shorthand hex,
+  `rgb()`/`oklch()`, CSS keywords, or anything containing punctuation — is
+  rejected and the default is used for that key. This is a security boundary
+  (the values are emitted into a style block), not a formatting preference.
+- Every key is optional. Override one anchor or all eleven; light and dark
+  are independent.
+- Unknown keys are ignored (forward-compatible) and logged.
+
+### Walkthrough: a minimal brand re-color
+
+Change only the accent, in both modes:
+
+```jsonc
+{
+  "version": 1,
+  "palette": {
+    "light": { "seal": "#1D5C8F" },
+    "dark":  { "seal": "#7FB4DC" }
+  }
+}
+```
+
+Save the file and reload the UI — the server picks up edits within a few
+seconds (no restart). Buttons, active tabs, focus rings, the speaking
+waveform, and every accent wash re-tint, because they all derive from
+`--s-seal`.
+
+### Walkthrough: a full theme
+
+A complete "slate & amber" theme:
+
+```jsonc
+{
+  "version": 1,
+  "name": "Ops Console",
+  "palette": {
+    "light": {
+      "paper": "#ECEEF1", "paperDeep": "#DFE3E8",
+      "ink": "#1F2429", "ink2": "#4C555E", "ink3": "#5D6772",
+      "seal": "#B26A00", "moss": "#3E6B4F",
+      "error": "#A8321F", "warning": "#8A6400",
+      "line": "#6C737A", "lineSoft": "#7E858C"
+    },
+    "dark": {
+      "paper": "#14171A", "paperDeep": "#0E1114",
+      "ink": "#D7DBDF", "ink2": "#97A0A8", "ink3": "#828B93",
+      "seal": "#E8A94E", "moss": "#8CAB94",
+      "error": "#D96A55", "warning": "#D9B45C",
+      "line": "#6E767D", "lineSoft": "#61686F"
+    }
+  }
+}
+```
+
+### Contrast: your responsibility once you override
+
+The shipped defaults are WCAG AA-verified; your overrides bypass those tests.
+Keep these pairs readable:
+
+- `ink` / `ink2` / `ink3` against **both** `paper` and `paperDeep` — ≥ 4.5:1.
+- `seal`, `moss`, `error`, `warning` against both papers — ≥ 4.5:1 (they are
+  used as text/icon colors, not just fills).
+- `line` against both papers — ≥ 3:1.
+
+The Appearance settings tab shows a contrast warning per anchor as you edit;
+any WCAG checker (e.g. WebAIM's) works for offline authoring. Dark-mode tip:
+don't use pure `#000000`/`#FFFFFF` — keep at least one intermediate surface
+(`paperDeep`) distinct from `paper`.
+
+### Logo
+
+Drop raster files into `~/.openpalm/config/ui/assets/` and name them:
+
+```jsonc
+{ "logo": { "light": "logo.png", "dark": "logo-dark.png" } }
+```
+
+- Formats: PNG, GIF, WebP. ≤ 1 MB. **No SVG uploads** (XSS surface) and no
+  remote URLs — files are served same-origin from your config directory.
+- Why a light/dark pair: the built-in logo is an inline SVG that inherits the
+  text color and adapts to the mode automatically; a raster file cannot, so
+  you supply one per mode (either may be omitted to keep the built-in mark).
+- Missing or invalid files fall back to the built-in logo — a typo never
+  breaks the UI.
+
+### Chat avatar
+
+The chat surface ships with an animated **ensō presence mark** as the
+assistant avatar. It is state-reactive:
+
+- **idle** — slow breathing
+- **thinking** (assistant is working) — dimmed mark with a pulsing accent bloom
+- **listening** (voice input) — ripples gathering inward
+- **speaking** (voice output) — a five-bar waveform
+
+It uses the brand mark and the theme's `ink`/`seal` tokens, so palette
+overrides re-color it automatically. `prefers-reduced-motion` stills every
+loop.
+
+To replace it with your own image:
+
+```jsonc
+{ "avatar": "avatar.webp" }
+```
+
+Same rules as logos (PNG/GIF/WebP under `config/ui/assets/`, ≤ 1 MB). An
+animated GIF/WebP plays as-is; the state-driven motion classes still apply
+gentle scale/opacity treatment around it, and reduced-motion is honored.
+Set `"avatar": null` to return to the ensō.
+
+### Applying and troubleshooting
+
+| Symptom | Cause / fix |
+|---|---|
+| Nothing changed after editing the file | JSON syntax error — check the server log; the file is parsed fail-closed (invalid file ⇒ defaults). Validate with `jq . branding.json` |
+| One color ignored, others applied | That value failed the `#RRGGBB` check (shorthand hex and `oklch()` are not accepted) |
+| Logo/avatar not showing | Filename in JSON must exactly match a file in `config/ui/assets/`; only PNG/GIF/WebP are served; check size ≤ 1 MB |
+| Colors flash on load | Should never happen — the override is injected server-side before paint. If you see a flash, file a bug |
+| Theme works in light mode but not dark | The two modes are independent — add the anchor under `palette.dark` too |
+
+### What branding.json does *not* theme
+
+- The **assistant terminal (TUI) theme** — that's OpenCode's own theme file,
+  managed at `~/.openpalm/system/assistant/themes/openpalm.json`
+  (lifecycle-overwritten; separate system).
+- The Electron shell (splash screen, tray icon) and desktop notification
+  titles — tracked separately.
+- Fonts, spacing, motion — the Stillness type/spacing/motion tokens are not
+  operator-overridable (bounded palette by design).
+
+---
+
+## For contributors
+
+- Token changes land in `packages/ui-kit` (raw-source package, no build step);
+  keep `theme-tokens.test.ts` and `svelte-check` green.
+- New components must consume `var(--s-*)` anchors or `color-mix()` tints of
+  them — never hardcode a palette literal (hardcoded contrast-paired literals
+  break operator overrides silently).
+- The UI design rubric (`docs/technical/ui-design-rubric.md`) remains the
+  approval gate for visual changes; note that "brand accent" is
+  operator-overridable once #426 ships.


### PR DESCRIPTION
- docs/theming.md: operator guide — how Stillness theming works today (ui-kit tokens, modes, anchors, contrast guardrails) and how to create and apply themes/logo/chat-avatar overrides once #426 ships, with worked examples and troubleshooting; indexed in docs/README.md.
- .github/roadmap/0.14.0/assessments/426.md: verified current-state assessment backing the issue #426 revision-2 rewrite (token system now in ui-kit, /admin namespace dead, Presence.svelte orphaned avatar, capability/lane model, CSP drift, cascade-specificity risk).


Claude-Session: https://claude.ai/code/session_01E1QNWEE995CY4o7BnqNKkF