### PR TITLE
Fix concurrent forced reload clobbering in-flight activation

### DIFF
--- a/packages/ui/src/lib/endpoints-state.svelte.ts
+++ b/packages/ui/src/lib/endpoints-state.svelte.ts
@@ -154,15 +154,10 @@ class ConnectionsService {
         store.getActiveId(),
       ]);
       if (activationSeq !== this.activationSeq) return;
-      const restoredActiveId = await this.restoreActiveId(store, connections, storedActiveId);
-      if (activationSeq !== this.activationSeq) return;
+      // Refreshing the endpoint list, marking loaded, and kicking discovery are
+      // always safe under a concurrent activation and must run unconditionally
+      // so a reload still surfaces added/removed connections.
       this.endpoints = connections.map(toView);
-      this.activeId = restoredActiveId ?? '';
-      // Keep the transport's active connection in sync (no $effect).
-      const activeConnection = connections.find((c) => c.id === this.activeId) ?? null;
-      setActiveConnection(activeConnection);
-      this.publishedActiveId = this.activeId;
-      this.publishedConnection = activeConnection;
       this.loaded = true;
       if (!this.discoveryStarted) {
         this.discoveryStarted = true;
@@ -173,6 +168,28 @@ class ConnectionsService {
         // rejects — failures are swallowed inside it).
         this.discoverySettled = this.discoverLocal();
       }
+      // #576: an in-flight activation is the sole authority on the active
+      // selection. The activationSeq guard above only catches an activation
+      // that bumped the seq DURING this load; an activation already in flight
+      // when we captured the seq performed its single bump earlier, so the seq
+      // is unchanged and both seq checks pass. pendingActivation — set the
+      // instant an activation starts — is the signal the seq guard is blind to.
+      // Gating BEFORE restoreActiveId also suppresses its self-heal store write,
+      // which would otherwise race the activation's own write on the shared
+      // activeWrites queue.
+      if (this.pendingActivation) return;
+      const restoredActiveId = await this.restoreActiveId(store, connections, storedActiveId);
+      if (activationSeq !== this.activationSeq) return;
+      // Re-check immediately before the synchronous publish, with NO await
+      // between this gate and the writes, so an activation that started during
+      // the restoreActiveId await above still wins.
+      if (this.pendingActivation) return;
+      this.activeId = restoredActiveId ?? '';
+      // Keep the transport's active connection in sync (no $effect).
+      const activeConnection = connections.find((c) => c.id === this.activeId) ?? null;
+      setActiveConnection(activeConnection);
+      this.publishedActiveId = this.activeId;
+      this.publishedConnection = activeConnection;
     } catch (e) {
       const err = e as { message?: string; status?: number };
       this.error = err.message ?? 'Failed to load connections';
@@ -212,13 +229,18 @@ class ConnectionsService {
         store.list(),
         store.getActiveId(),
       ]);
-      if (activationSeq !== this.activationSeq) {
-        this.endpoints = connections.map(toView);
-        return;
-      }
+      // Always refresh the endpoint list — a newly discovered connection must
+      // surface even when a concurrent activation owns the active selection.
+      this.endpoints = connections.map(toView);
+      if (activationSeq !== this.activationSeq) return;
+      // #576: same reasoning as _load — an in-flight activation is the sole
+      // authority on the active selection, and pendingActivation catches the
+      // already-in-flight case the seq guard cannot. Gating before
+      // restoreActiveId also suppresses its self-heal store write.
+      if (this.pendingActivation) return;
       const restoredActiveId = await this.restoreActiveId(store, connections, storedActiveId);
       if (activationSeq !== this.activationSeq) return;
-      this.endpoints = connections.map(toView);
+      if (this.pendingActivation) return;
       this.activeId = restoredActiveId ?? '';
       const activeConnection = connections.find((c) => c.id === this.activeId) ?? null;
       setActiveConnection(activeConnection);
@@ -228,6 +250,11 @@ class ConnectionsService {
       // until a manual switch. Same veto guard as activate().
       if (this.activeId === added.id && !activationBlockReason()) {
         await emitConnectionActivated(added.id);
+        // The handoff await split the active-state sequence: re-check both
+        // guards before the trailing publish so an activation that started
+        // during the emit still wins.
+        if (activationSeq !== this.activationSeq) return;
+        if (this.pendingActivation) return;
       }
       this.publishedActiveId = this.activeId;
       this.publishedConnection = activeConnection;

--- a/packages/ui/src/lib/endpoints-state.svelte.ts
+++ b/packages/ui/src/lib/endpoints-state.svelte.ts
@@ -84,13 +84,23 @@ class ConnectionsService {
 		promise: Promise<void>;
 	} | null = null;
 
+  /**
+   * The active id a load should resolve to: the stored one when it still names
+   * a listed connection, otherwise the first connection (or null when the list
+   * is empty). Pure — no persistence — so a caller can decide whether a
+   * concurrent activation would be disturbed BEFORE any self-heal write runs.
+   */
+  private intendedActiveId(connections: Connection[], storedActiveId: string | null): string | null {
+    const activeExists = connections.some((connection) => connection.id === storedActiveId);
+    return activeExists ? storedActiveId : (connections[0]?.id ?? null);
+  }
+
   private async restoreActiveId(
     store: ConnectionStore,
     connections: Connection[],
     storedActiveId: string | null
   ): Promise<string | null> {
-    const activeExists = connections.some((connection) => connection.id === storedActiveId);
-    const restoredActiveId = activeExists ? storedActiveId : (connections[0]?.id ?? null);
+    const restoredActiveId = this.intendedActiveId(connections, storedActiveId);
     if (restoredActiveId !== storedActiveId) {
       await this.queueActiveWrite(() =>
         restoredActiveId ? store.setActive(restoredActiveId) : store.clearActive()
@@ -168,28 +178,40 @@ class ConnectionsService {
         // rejects — failures are swallowed inside it).
         this.discoverySettled = this.discoverLocal();
       }
-      // #576: an in-flight activation is the sole authority on the active
-      // selection. The activationSeq guard above only catches an activation
-      // that bumped the seq DURING this load; an activation already in flight
-      // when we captured the seq performed its single bump earlier, so the seq
-      // is unchanged and both seq checks pass. pendingActivation — set the
-      // instant an activation starts — is the signal the seq guard is blind to.
-      // Gating BEFORE restoreActiveId also suppresses its self-heal store write,
-      // which would otherwise race the activation's own write on the shared
-      // activeWrites queue.
-      if (this.pendingActivation) return;
-      const restoredActiveId = await this.restoreActiveId(store, connections, storedActiveId);
+      // #576: an in-flight activation is the sole authority on WHICH connection
+      // is selected. The activationSeq guard above only catches an activation
+      // that bumped the seq DURING this load; one already in flight when we
+      // captured the seq bumped it earlier, so the seq is unchanged and both
+      // seq checks pass. pendingActivation — set the instant an activation
+      // starts — is the signal the seq guard is blind to.
+      //
+      // Suppress the load ONLY when it would switch the selection to a DIFFERENT
+      // id than the activation is establishing (the clobber), and with it
+      // restoreActiveId's self-heal write, which would otherwise race the
+      // activation's own write on the shared activeWrites queue. A load that
+      // resolves to the SAME id is not a selection change: it still refreshes
+      // the transport snapshot below, so an edit to the active connection
+      // reaches direct requests without waiting for the next reload.
+      const restoredActiveId = this.intendedActiveId(connections, storedActiveId);
+      if (this.pendingActivation && this.pendingActivation.id !== restoredActiveId) return;
+      await this.restoreActiveId(store, connections, storedActiveId);
       if (activationSeq !== this.activationSeq) return;
-      // Re-check immediately before the synchronous publish, with NO await
-      // between this gate and the writes, so an activation that started during
-      // the restoreActiveId await above still wins.
-      if (this.pendingActivation) return;
-      this.activeId = restoredActiveId ?? '';
-      // Keep the transport's active connection in sync (no $effect).
-      const activeConnection = connections.find((c) => c.id === this.activeId) ?? null;
+      // Re-check immediately before the synchronous writes, with NO await
+      // between the gate and the writes, so an activation that started (or
+      // retargeted) during the restoreActiveId await above still wins.
+      if (this.pendingActivation && this.pendingActivation.id !== restoredActiveId) return;
+      // Keep the transport's active connection in sync (no $effect). This runs
+      // even under a same-id activation so record edits are picked up.
+      const activeConnection = connections.find((c) => c.id === restoredActiveId) ?? null;
       setActiveConnection(activeConnection);
-      this.publishedActiveId = this.activeId;
-      this.publishedConnection = activeConnection;
+      if (!this.pendingActivation) {
+        // Only take ownership of the selection + rollback anchor when no
+        // activation is in flight; otherwise the activation owns activeId and
+        // the publishedActiveId/publishedConnection it would roll back to.
+        this.activeId = restoredActiveId ?? '';
+        this.publishedActiveId = this.activeId;
+        this.publishedConnection = activeConnection;
+      }
     } catch (e) {
       const err = e as { message?: string; status?: number };
       this.error = err.message ?? 'Failed to load connections';
@@ -233,17 +255,24 @@ class ConnectionsService {
       // surface even when a concurrent activation owns the active selection.
       this.endpoints = connections.map(toView);
       if (activationSeq !== this.activationSeq) return;
-      // #576: same reasoning as _load — an in-flight activation is the sole
-      // authority on the active selection, and pendingActivation catches the
-      // already-in-flight case the seq guard cannot. Gating before
+      // #576: same reasoning as _load — suppress only when this discovery would
+      // change the in-flight activation's selection; a same-id refresh may still
+      // update the transport snapshot. pendingActivation catches the
+      // already-in-flight case the seq guard cannot, and gating before
       // restoreActiveId also suppresses its self-heal store write.
-      if (this.pendingActivation) return;
-      const restoredActiveId = await this.restoreActiveId(store, connections, storedActiveId);
+      const restoredActiveId = this.intendedActiveId(connections, storedActiveId);
+      if (this.pendingActivation && this.pendingActivation.id !== restoredActiveId) return;
+      await this.restoreActiveId(store, connections, storedActiveId);
       if (activationSeq !== this.activationSeq) return;
-      if (this.pendingActivation) return;
-      this.activeId = restoredActiveId ?? '';
-      const activeConnection = connections.find((c) => c.id === this.activeId) ?? null;
+      if (this.pendingActivation && this.pendingActivation.id !== restoredActiveId) return;
+      const activeConnection = connections.find((c) => c.id === restoredActiveId) ?? null;
       setActiveConnection(activeConnection);
+      if (this.pendingActivation) {
+        // A same-id activation owns the selection and its own handoff; the
+        // transport snapshot is refreshed, so leave the rest to it.
+        return;
+      }
+      this.activeId = restoredActiveId ?? '';
       // When the discovered entry just became the effective active connection
       // (a previously empty list), complete the activation handoff so the
       // chat store loads its sessions instead of staying on "not reachable"

--- a/packages/ui/src/lib/endpoints-state.svelte.vitest.ts
+++ b/packages/ui/src/lib/endpoints-state.svelte.vitest.ts
@@ -305,6 +305,66 @@ describe('overlapping activation', () => {
 		expect(setActiveConnection).toHaveBeenLastCalledWith(records[1]);
 	});
 
+	test('a concurrent forced reload cannot clobber an already in-flight activation', async () => {
+		storedActiveId = 'alpha';
+		const service = await freshService();
+		await service.load(true);
+		expect(service.activeId).toBe('alpha');
+		setActiveConnection.mockClear();
+
+		let releaseActivate: (() => void) | undefined;
+		fakeStore.setActive.mockImplementationOnce(
+			(id: string) =>
+				new Promise<void>((resolve) => {
+					releaseActivate = () => {
+						storedActiveId = id;
+						resolve();
+					};
+				})
+		);
+
+		// Start the activation FIRST and park it on its held setActive write.
+		// This bumps activationSeq -> 1, sets activeId='beta', sets
+		// pendingActivation, and enqueues the held setActive('beta').
+		const activation = service.activate('beta');
+		while (!releaseActivate) await Promise.resolve();
+
+		// The activation owns the selection in memory, but its store write is
+		// still parked, so storage still reads the stale 'alpha'.
+		expect(service.activeId).toBe('beta');
+		expect(storedActiveId).toBe('alpha');
+
+		// A forced reload races in while the activation is STILL parked. It sees
+		// the stale stored 'alpha' and captures seq=1 (the activation already did
+		// its single ++ before this load captured it), so both seq re-checks pass
+		// 1===1. Without the pendingActivation gate it republishes the stale
+		// 'alpha', clobbering the in-flight activation. Do NOT release/await the
+		// activation first — that would clear pendingActivation and mask the bug.
+		await service.load(true);
+
+		// Capture the discriminators WHILE the activation is still in flight, but
+		// do not assert yet: releasing/awaiting the activation below must run
+		// unconditionally so a red (unfixed) run fails on a clean assertion
+		// instead of hanging on the still-parked activation promise.
+		const activeIdDuringActivation = service.activeId;
+		const endpointsAfterReload = service.endpoints.map((endpoint) => endpoint.id);
+
+		releaseActivate();
+		await activation;
+
+		// The fix-vs-unfixed discriminator: the in-flight activation must remain
+		// the sole authority on active selection. RED without the fix (the reload
+		// republishes the stale 'alpha' over the just-activated 'beta').
+		expect(activeIdDuringActivation).toBe('beta');
+		// The reload must still refresh the endpoint list unconditionally, even
+		// while its active-state publish is suppressed by the gate.
+		expect(endpointsAfterReload).toEqual(['alpha', 'beta', 'gamma']);
+		// Memory, transport, and storage all agree on the activated connection.
+		expect(service.activeId).toBe('beta');
+		expect(storedActiveId).toBe('beta');
+		expect(setActiveConnection).toHaveBeenLastCalledWith(records[1]);
+	});
+
 	test('a failing superseding activation rolls back to the last published connection', async () => {
 		storedActiveId = 'alpha';
 		const service = await freshService();

--- a/packages/ui/src/lib/endpoints-state.svelte.vitest.ts
+++ b/packages/ui/src/lib/endpoints-state.svelte.vitest.ts
@@ -365,6 +365,53 @@ describe('overlapping activation', () => {
 		expect(setActiveConnection).toHaveBeenLastCalledWith(records[1]);
 	});
 
+	test('a same-id reload during an in-flight activation refreshes the connection record', async () => {
+		storedActiveId = 'alpha';
+		const service = await freshService();
+		await service.load(true);
+
+		// Put an activation in flight and hold it on its handoff so activeId and
+		// storedActiveId are already 'beta' while it awaits — the window in which
+		// the user can edit the connection being activated.
+		let releaseHandoff: (() => void) | undefined;
+		emitConnectionActivated.mockImplementationOnce(
+			() =>
+				new Promise<void>((resolve) => {
+					releaseHandoff = resolve;
+				})
+		);
+		const activation = service.activate('beta');
+		while (!releaseHandoff) await Promise.resolve();
+		expect(service.activeId).toBe('beta');
+		expect(storedActiveId).toBe('beta');
+		setActiveConnection.mockClear();
+
+		// The active connection (beta) is edited; the settings save path reloads.
+		const editedBeta: Connection = {
+			...connection('beta'),
+			baseUrl: 'https://beta-edited.example'
+		};
+		fakeStore.list.mockResolvedValueOnce([records[0], editedBeta, records[2]]);
+		await service.load(true);
+
+		// Capture before releasing so a regression fails on a clean assertion
+		// rather than hanging on the still-parked activation.
+		const transportAfterReload = setActiveConnection.mock.calls.at(-1)?.[0];
+		const activeIdAfterReload = service.activeId;
+		const betaUrlAfterReload = service.endpoints.find((endpoint) => endpoint.id === 'beta')?.url;
+
+		releaseHandoff();
+		await activation;
+
+		// A same-id reload must not change the selection, but MUST refresh the
+		// transport snapshot so direct requests pick up the edited record.
+		expect(activeIdAfterReload).toBe('beta');
+		expect(transportAfterReload).toEqual(editedBeta);
+		expect(betaUrlAfterReload).toBe('https://beta-edited.example');
+		expect(service.activeId).toBe('beta');
+		expect(storedActiveId).toBe('beta');
+	});
+
 	test('a failing superseding activation rolls back to the last published connection', async () => {
 		storedActiveId = 'alpha';
 		const service = await freshService();


### PR DESCRIPTION
## Summary
Fixes a race condition where a forced reload could overwrite an in-flight activation's selection with stale data from storage. The issue occurs when a reload captures the same `activationSeq` as an already-in-flight activation, causing both the seq guard and the reload logic to proceed, resulting in the stale active connection being republished.

## Key Changes
- **Added `pendingActivation` gate**: Introduced a second guard in `_load()` and `_discover()` methods that checks if an activation is already in flight. This catches activations that started before the reload captured the seq, which the seq guard alone cannot detect.
- **Unconditional endpoint refresh**: Moved endpoint list updates outside the activation guards so that newly discovered/removed connections surface even when a concurrent activation owns the active selection.
- **Deferred active-state restoration**: Moved `restoreActiveId()` and active connection publishing to after the `pendingActivation` checks, preventing the reload from overwriting in-flight selections.
- **Double-check before publish**: Added a second `pendingActivation` check immediately before synchronous active-state writes (with no awaits in between) to catch activations that start during async operations.
- **Added comprehensive test**: New test case `a concurrent forced reload cannot clobber an already in-flight activation` validates the fix by parking an activation mid-flight and racing a forced reload against it.

## Implementation Details
- The `pendingActivation` flag is set the instant an activation starts and cleared when it completes, providing a reliable signal of in-flight activations that the seq-based guard cannot detect.
- The fix maintains the invariant that an in-flight activation is the sole authority on active selection, while still allowing reloads to refresh the endpoint list unconditionally.
- Multiple guard checks are strategically placed to handle different timing windows where activations could start (before/during/after async operations).

https://claude.ai/code/session_01BGs4NpsvnwzETYFgJbixXH