### PR TITLE
fix: deploy addons on enable, and stop importing the host's akm config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,33 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **Enabling an addon now deploys it.** The toggle was asymmetric: disable
+  stopped the addon's services through compose, enable only wrote
+  `OP_ENABLED_ADDONS` and returned. The compose profile went active with
+  nothing behind it, and the container appeared only at the next unrelated
+  lifecycle action — enabling paperclip left it permanently "enabled" and
+  never running. Voice escaped this solely because it routes to its own
+  bring-up engine. Enable is an apply now: it brings the addon's services up,
+  answers `202` while they start (a first image pull is minutes), and holds
+  the admin lock until the up settles. Gated on an actual change, so a no-op
+  re-enable does not recreate a healthy container; a failed up is logged and
+  leaves the addon enabled to retry from Containers.
+- **Host AKM sharing no longer imports the host's akm config.** Enabling it
+  merged the host's `engines`/`defaults`/`improve.strategies`/`embedding` from
+  `~/.config/akm/config.json` into `config/akm/config.json` — the file
+  bind-mounted at the assistant's `/etc/akm`. The host and the assistant image
+  are independent installs on independent upgrade cycles, so a host running a
+  newer akm wrote keys the container's CLI could not parse: every `akm`
+  invocation in the assistant failed with `INVALID_CONFIG_FILE`, and the UI
+  reported AKM metrics as unavailable with nothing pointing at the cause. The
+  shared stash **directory** is the whole of host sharing; enable is the
+  `OP_HOST_AKM_STASH` flip alone, and the `/host-stash` bundle is still
+  written once at install.
+- **Stale `OP_TOOL_*_VERSION` rows are swept from `stack.env`.** Tool
+  management moved to a per-container `package.json` in June 2026 and nothing
+  has read them since, but they persisted beside the live `OP_*_VERSION` image
+  tags — reading as the knob that pins the assistant's akm, so an operator
+  debugging a version skew would edit one and see nothing happen.
 - **Root installs work instead of silently producing an unwritable stack.**
   `resolveOperatorIds` refused to return root: when neither `OP_HOME`'s owner
   nor the process was a non-root user it returned `null`, so `OP_UID`/`OP_GID`

--- a/packages/lib/src/control-plane/akm-sources.test.ts
+++ b/packages/lib/src/control-plane/akm-sources.test.ts
@@ -5,14 +5,12 @@ import { join } from "node:path";
 import {
   HOST_SOURCE_NAME,
   addHostStashToOpenpalmConfig,
-  importHostProfiles,
 } from "./akm-sources.js";
 import type { ControlPlaneState } from "./types.js";
 
 let root = "";
 let state: ControlPlaneState;
 let opConfigPath = "";
-let hostConfigPath = "";
 
 function readJson(p: string): Record<string, unknown> {
   return JSON.parse(readFileSync(p, "utf-8"));
@@ -24,7 +22,6 @@ beforeEach(() => {
   mkdirSync(join(configDir, "akm"), { recursive: true });
   opConfigPath = join(configDir, "akm", "config.json");
   state = { configDir, stashDir: join(root, "knowledge") } as ControlPlaneState;
-  hostConfigPath = join(root, "home", ".config", "akm", "config.json");
 });
 
 afterEach(() => {
@@ -123,144 +120,3 @@ describe("addHostStashToOpenpalmConfig (assistant side, parse-tolerant)", () => 
   });
 });
 
-
-describe("importHostProfiles (read-only snapshot of host engine config)", () => {
-  function seedHostConfig(obj: Record<string, unknown>): string {
-    mkdirSync(join(root, "home", ".config", "akm"), { recursive: true });
-    const original = JSON.stringify(obj, null, 2);
-    writeFileSync(hostConfigPath, original);
-    return original;
-  }
-
-  it("copies engines + defaults + improve.strategies + embedding into an empty config", () => {
-    seedHostConfig({
-      configVersion: "0.9.0",
-      engines: {
-        fast: { kind: "llm", endpoint: "http://h/v1/chat/completions", model: "qwen", provider: "ollama" },
-        reviewer: { kind: "agent", platform: "opencode" },
-      },
-      defaults: { llmEngine: "fast", engine: "reviewer", improveStrategy: "thorough" },
-      improve: { strategies: { thorough: { engine: "fast" } } },
-      embedding: { provider: "ollama", model: "nomic-embed-text", dimension: 768 },
-    });
-    writeFileSync(opConfigPath, "{}");
-    const { imported } = importHostProfiles(state, hostConfigPath);
-    expect(imported).toContain("engines");
-    expect(imported).toContain("defaults.engine");
-    expect(imported).toContain("defaults.llmEngine");
-    expect(imported).toContain("defaults.improveStrategy");
-    expect(imported).toContain("improve.strategies");
-    expect(imported).toContain("embedding");
-    const cfg = readJson(opConfigPath);
-    const engines = cfg.engines as Record<string, Record<string, unknown>>;
-    expect(engines.fast.model).toBe("qwen");
-    expect(engines.reviewer.platform).toBe("opencode");
-    expect((cfg.defaults as Record<string, unknown>).improveStrategy).toBe("thorough");
-    expect(((cfg.improve as Record<string, unknown>).strategies as Record<string, unknown>).thorough).toEqual({ engine: "fast" });
-    expect((cfg.embedding as Record<string, unknown>).model).toBe("nomic-embed-text");
-    expect((cfg.embedding as Record<string, unknown>).dimension).toBe(768);
-    expect(cfg.llm).toBeUndefined();
-    expect(cfg.configVersion).toBe("0.9.0");
-  });
-
-  it("strips retired 0.8 keys and stamps configVersion on the merged write (pre-0.9 OpenPalm config)", () => {
-    seedHostConfig({
-      configVersion: "0.9.0",
-      engines: { fast: { kind: "llm", endpoint: "x", model: "m" } },
-    });
-    // A pre-0.9 / versionless OpenPalm config still carrying retired keys.
-    writeFileSync(opConfigPath, JSON.stringify({
-      stashDir: "/old/stash",
-      profiles: { llm: { default: { endpoint: "x", model: "m" } } },
-      defaults: { llm: "default" },
-    }));
-    const { imported } = importHostProfiles(state, hostConfigPath);
-    expect(imported).toContain("engines");
-    const cfg = readJson(opConfigPath);
-    expect(cfg.configVersion).toBe("0.9.0");
-    expect(cfg.stashDir).toBeUndefined();
-    expect(cfg.profiles).toBeUndefined();
-    expect((cfg.defaults as Record<string, unknown>).llm).toBeUndefined();
-    // bundles/defaultBundle remain untouched by the import path.
-    expect(cfg.bundles).toBeUndefined();
-    expect(cfg.defaultBundle).toBeUndefined();
-  });
-
-  it("is ADDITIVE — never overwrites existing engines, defaults, or embedding fields", () => {
-    seedHostConfig({
-      configVersion: "0.9.0",
-      engines: {
-        default: { kind: "llm", endpoint: "http://host/v1/chat/completions", model: "host-model" }, // conflicts with existing
-        "host-only": { kind: "llm", endpoint: "http://host/v1/chat/completions", model: "extra" },  // new → added
-      },
-      defaults: { llmEngine: "host-only" }, // existing already has defaults.llmEngine → must NOT change
-      embedding: { provider: "ollama", model: "host-emb", dimension: 768, batchSize: 32 }, // model conflicts; batchSize new
-    });
-    writeFileSync(opConfigPath, JSON.stringify({
-      engines: { default: { kind: "llm", endpoint: "http://op/v1/chat/completions", model: "op-model" } },
-      defaults: { llmEngine: "default" },
-      embedding: { provider: "openai", model: "op-emb", dimension: 1536 },
-    }));
-
-    const { imported } = importHostProfiles(state, hostConfigPath);
-    const cfg = readJson(opConfigPath);
-    const engines = cfg.engines as Record<string, Record<string, unknown>>;
-    // Existing 'default' engine is preserved untouched.
-    expect(engines.default.model).toBe("op-model");
-    // Host-only engine is added.
-    expect(engines["host-only"].model).toBe("extra");
-    expect(imported).toContain("engines");
-    // Existing default selection is NOT overwritten.
-    expect((cfg.defaults as Record<string, unknown>).llmEngine).toBe("default");
-    expect(imported).not.toContain("defaults.llmEngine");
-    // Embedding: existing fields win; only the new field (batchSize) is added.
-    const emb = cfg.embedding as Record<string, unknown>;
-    expect(emb.model).toBe("op-emb");
-    expect(emb.provider).toBe("openai");
-    expect(emb.dimension).toBe(1536);
-    expect(emb.batchSize).toBe(32);
-    expect(imported).toContain("embedding");
-  });
-
-  it("does not report a namespace as imported when it adds nothing new", () => {
-    seedHostConfig({
-      engines: { default: { kind: "llm", endpoint: "x", model: "host" } },
-      defaults: { llmEngine: "default" },
-    });
-    writeFileSync(opConfigPath, JSON.stringify({
-      engines: { default: { kind: "llm", endpoint: "y", model: "op" } },
-      defaults: { llmEngine: "default" },
-    }));
-    const { imported } = importHostProfiles(state, hostConfigPath);
-    expect(imported).not.toContain("engines"); // 'default' already present, nothing added
-    expect(imported).not.toContain("defaults.llmEngine");
-    // existing values untouched
-    const cfg = readJson(opConfigPath);
-    expect((cfg.engines as Record<string, Record<string, unknown>>).default.model).toBe("op");
-  });
-
-  it("reads the host config READ-ONLY (host file unchanged byte-for-byte)", () => {
-    const original = seedHostConfig({ engines: { default: { kind: "llm", endpoint: "x", model: "m" } }, defaults: { llmEngine: "default" } });
-    writeFileSync(opConfigPath, "{}");
-    importHostProfiles(state, hostConfigPath);
-    expect(readFileSync(hostConfigPath, "utf-8")).toBe(original);
-  });
-
-  it("imports nothing (and does not throw) when host has no engines — including a retired 0.8 profiles shape", () => {
-    seedHostConfig({
-      stashDir: "/home/u/akm",
-      profiles: { llm: { default: { endpoint: "x", model: "m" } } },
-      defaults: { llm: "default" },
-    });
-    writeFileSync(opConfigPath, "{}");
-    expect(importHostProfiles(state, hostConfigPath).imported).toEqual([]);
-    // The retired shape is never copied into the OpenPalm config.
-    const cfg = readJson(opConfigPath);
-    expect(cfg.profiles).toBeUndefined();
-  });
-
-  it("returns empty imported list (does not throw) when host config is absent", () => {
-    writeFileSync(opConfigPath, "{}");
-    expect(importHostProfiles(state, hostConfigPath).imported).toEqual([]);
-  });
-});

--- a/packages/lib/src/control-plane/akm-sources.ts
+++ b/packages/lib/src/control-plane/akm-sources.ts
@@ -4,8 +4,9 @@
  * The assistant config ALWAYS has a `host-akm` secondary bundle pointing at
  * /host-stash (written once at install, never removed). The compose bind-mount
  * controls what actually lands at /host-stash: the real ~/akm when sharing is
- * enabled, an empty dir when disabled. Engine import is best-effort — missing
- * or corrupt host config is logged and skipped, never an error.
+ * enabled, an empty dir when disabled. That DIRECTORY is the entirety of host
+ * sharing — OpenPalm never reads the host's own akm config or CLI (see
+ * host-akm-sharing.ts for what importing it cost).
  *
  * akm >= 0.9.0: sources are a `bundles` map (`bundles.<id>` entries) instead
  * of the retired `sources[]` array, and LLM/agent execution config lives in
@@ -25,11 +26,8 @@
 import { readFileSync, existsSync } from "node:fs";
 import { join } from "node:path";
 import { writeFileAtomic } from "./fs-atomic.js";
-import { createLogger } from "../logger.js";
 import { PRIMARY_BUNDLE_ID, stripRetiredAkmKeys } from "./setup.js";
 import type { ControlPlaneState } from "./types.js";
-
-const logger = createLogger("akm-sources");
 
 /** Bundle id added to the OpenPalm/container config (points at /host-stash). */
 export const HOST_SOURCE_NAME = "host-akm";
@@ -51,17 +49,6 @@ function readConfigTolerant(configPath: string): AkmConfigObject {
   } catch {
     // We own the OpenPalm config — a corrupt file is recoverable by rewriting.
     return {};
-  }
-}
-
-function readHostConfigBestEffort(configPath: string): AkmConfigObject | null {
-  if (!existsSync(configPath)) return null;
-  try {
-    const parsed = JSON.parse(readFileSync(configPath, "utf-8"));
-    return parsed && typeof parsed === "object" ? (parsed as AkmConfigObject) : null;
-  } catch {
-    logger.warn("host akm config is not valid JSON — skipping engine import", { configPath });
-    return null;
   }
 }
 
@@ -130,101 +117,4 @@ export function addHostStashToOpenpalmConfig(state: ControlPlaneState, writable 
   };
   if (typeof updated.defaultBundle !== "string") updated.defaultBundle = PRIMARY_BUNDLE_ID;
   writeFileAtomic(configPath, JSON.stringify(updated, null, 2), 0o600);
-}
-
-/**
- * Best-effort import of the host's engine/embedding config into the OpenPalm
- * akm config. Reads the personal host config READ-ONLY; never writes back to
- * the host.
- *
- * ADDITIVE MERGE: existing OpenPalm values ALWAYS win — the host only fills
- * gaps. Returns `{ imported: [] }` when the host config is absent or
- * unreadable (never throws — engine import is always optional).
- *
- * Writes the canonical akm 0.9.0 shape (engines + defaults.* + embedding +
- * improve.strategies), stamping configVersion and stripping the retired 0.8
- * keys so the persisted file is always loadable. NEVER touches `bundles`,
- * `defaultBundle`, `registries`, or `defaultWriteTarget`. A host config still
- * in the retired
- * 0.8 `profiles` shape is skipped — akm itself refuses to load it, so there
- * is nothing trustworthy to import.
- */
-export function importHostProfiles(
-  state: ControlPlaneState,
-  hostConfigPath: string,
-): { imported: string[] } {
-  const host = readHostConfigBestEffort(hostConfigPath);
-  if (!host) return { imported: [] };
-
-  const opPath = openpalmConfigPath(state);
-  const op = readConfigTolerant(opPath);
-
-  const imported: string[] = [];
-  const isObj = (v: unknown): v is Record<string, unknown> => typeof v === "object" && v !== null && !Array.isArray(v);
-
-  // ADDITIVE MERGE — existing OpenPalm values always win; the host fills only
-  // gaps. Never overwrite an engine, default selection, strategy, or embedding
-  // field the operator/wizard already set. `imported` lists what was added.
-
-  // engines (akm 0.9.0 config-schema EnginesSchema).
-  const opEngines = isObj(op.engines) ? (op.engines as Record<string, unknown>) : {};
-  let engines = opEngines;
-  if (isObj(host.engines)) {
-    // host first, existing last → existing wins; only host-only engine names are added.
-    const merged: Record<string, unknown> = { ...(host.engines as Record<string, unknown>), ...opEngines };
-    if (Object.keys(merged).length > Object.keys(opEngines).length) {
-      engines = merged;
-      imported.push("engines");
-    }
-  }
-
-  // defaults.engine / defaults.llmEngine / defaults.improveStrategy — only
-  // adopt a host selection when OpenPalm has none.
-  const hostDefaults = isObj(host.defaults) ? (host.defaults as Record<string, unknown>) : {};
-  const opDefaults = isObj(op.defaults) ? { ...(op.defaults as Record<string, unknown>) } : {};
-  for (const key of ["engine", "llmEngine", "improveStrategy"] as const) {
-    if (typeof hostDefaults[key] === "string" && typeof opDefaults[key] !== "string") {
-      opDefaults[key] = hostDefaults[key];
-      imported.push(`defaults.${key}`);
-    }
-  }
-
-  // improve.strategies — additive by strategy name.
-  const hostImprove = isObj(host.improve) ? (host.improve as Record<string, unknown>) : {};
-  const opImprove = isObj(op.improve) ? { ...(op.improve as Record<string, unknown>) } : {};
-  let improveChanged = false;
-  if (isObj(hostImprove.strategies)) {
-    const opStrategies = isObj(opImprove.strategies) ? (opImprove.strategies as Record<string, unknown>) : {};
-    const merged: Record<string, unknown> = { ...(hostImprove.strategies as Record<string, unknown>), ...opStrategies };
-    if (Object.keys(merged).length > Object.keys(opStrategies).length) {
-      opImprove.strategies = merged;
-      improveChanged = true;
-      imported.push("improve.strategies");
-    }
-  }
-
-  // Top-level embedding connection. Per-field additive: existing OpenPalm
-  // fields win; host fills only missing fields.
-  let embedding: Record<string, unknown> | undefined;
-  if (isObj(host.embedding)) {
-    const existing = isObj(op.embedding) ? (op.embedding as Record<string, unknown>) : {};
-    const merged: Record<string, unknown> = { ...(host.embedding as Record<string, unknown>), ...existing };
-    if (Object.keys(merged).length > Object.keys(existing).length) {
-      embedding = merged;
-      imported.push("embedding");
-    }
-  }
-
-  if (imported.length === 0) return { imported };
-
-  const updated: AkmConfigObject = { ...op, engines, defaults: opDefaults };
-  if (improveChanged) updated.improve = opImprove;
-  if (embedding !== undefined) updated.embedding = embedding;
-  // akm 0.9.0 hard-rejects the retired 0.8 keys and requires configVersion —
-  // never persist a config akm refuses to load (same normalization as
-  // persistAkmConfig in setup.ts).
-  stripRetiredAkmKeys(updated);
-  updated.configVersion = "0.9.0";
-  writeFileAtomic(opPath, JSON.stringify(updated, null, 2), 0o600);
-  return { imported };
 }

--- a/packages/lib/src/control-plane/host-akm-sharing.test.ts
+++ b/packages/lib/src/control-plane/host-akm-sharing.test.ts
@@ -64,21 +64,24 @@ describe("enableHostAkmSharing", () => {
     expect(Object.keys((cfg.bundles as Record<string, unknown>) ?? {})).toHaveLength(0);
   });
 
-  it("imports host engines when host config exists", () => {
+  it("never copies the host's akm config into the assistant's, even when one exists", () => {
+    // The regression: enabling used to merge the host's `engines`/`defaults`
+    // into config/akm/config.json — the file bind-mounted at the assistant's
+    // /etc/akm. A host running a NEWER akm than the image wrote keys the
+    // container's CLI could not parse, so every `akm` call in the assistant
+    // failed with INVALID_CONFIG_FILE. The stash mount is the whole of host
+    // sharing; the host's config and CLI are not OpenPalm's to read.
     setHostAkmConfig({
       engines: { fast: { kind: "llm", endpoint: "http://h/v1/chat/completions", model: "qwen" } },
+      defaults: { llmEngine: "fast" },
     });
     writeFileSync(opConfig, "{}");
-    const { profilesImported } = enableHostAkmSharing(state);
-    expect(profilesImported).toContain("engines");
-    const opEngines = readJson(opConfig).engines as Record<string, Record<string, unknown>>;
-    expect(opEngines.fast.model).toBe("qwen");
+    enableHostAkmSharing(state);
+    expect(readJson(opConfig)).toEqual({});
   });
 
-  it("skips engine import (no error) when host config is absent", () => {
-    // ~/akm doesn't exist, ~/.config/akm/config.json doesn't exist — just skips.
-    const { profilesImported } = enableHostAkmSharing(state);
-    expect(profilesImported).toEqual([]);
+  it("sets the env key with no host config present", () => {
+    enableHostAkmSharing(state);
     expect(readFileSync(stackEnv, "utf-8")).toContain("OP_HOST_AKM_STASH=");
   });
 

--- a/packages/lib/src/control-plane/host-akm-sharing.ts
+++ b/packages/lib/src/control-plane/host-akm-sharing.ts
@@ -1,22 +1,29 @@
 /**
  * Host AKM sharing (control-plane logic — lives in lib).
  *
- * Model:
+ * Model — the ONLY thing shared with the host is the stash DIRECTORY:
  *  - The assistant ALWAYS has `/host-stash` as a secondary akm bundle (written
  *    once at install by addHostStashToOpenpalmConfig, never removed).
  *  - Enable/disable = flip OP_HOST_AKM_STASH in stack.env between the real
  *    ~/akm path (enabled) and an empty string / removal (disabled). Compose
  *    reads OP_HOST_AKM_STASH and mounts the real stash or the always-present
  *    empty-dir fallback accordingly.
- *  - Enabling also imports host engine/embedding config (best-effort, additive
- *    merge — akm >= 0.9.0 `engines`/`defaults` shape). If no host akm config
- *    exists the import is silently skipped — it is never a blocking condition.
+ *
+ * Enabling used to ALSO copy the host's engine/embedding config into
+ * `config/akm/config.json`, the file bind-mounted at the assistant's
+ * `/etc/akm`. OpenPalm does not read the host's akm config or CLI: the two
+ * are independent installs on independent upgrade cycles, and importing one
+ * into the other made the assistant's config a function of whatever akm
+ * version happened to be on the host. When the host ran a newer akm than the
+ * image, the merged keys were ones the container's CLI could not parse, so
+ * EVERY `akm` invocation in the assistant failed with INVALID_CONFIG_FILE and
+ * the UI reported "metrics unavailable" with no indication why. The stash
+ * mount is the whole of host sharing.
  */
 import { existsSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { writeFileAtomic } from "./fs-atomic.js";
 import { mergeEnvContent, removeEnvKey, parseEnvFile } from "./env.js";
-import { importHostProfiles } from "./akm-sources.js";
 import { stackEnvPath } from "./paths.js";
 import type { ControlPlaneState } from "./types.js";
 import { createLogger } from "../logger.js";
@@ -32,10 +39,6 @@ function userHome(): string {
 /** The user's personal akm stash dir (mounted into the assistant at /host-stash). */
 export function hostAkmStashPath(): string {
   return `${userHome()}/akm`;
-}
-
-function hostAkmConfigPath(): string {
-  return `${userHome()}/.config/akm/config.json`;
 }
 
 export type HostAkmSharingStatus = {
@@ -56,18 +59,12 @@ export function getHostAkmSharingStatus(state: ControlPlaneState): HostAkmSharin
   };
 }
 
-/**
- * Enable host AKM sharing: point OP_HOST_AKM_STASH at ~/akm and import host
- * engine/embedding config (best-effort — skipped if host akm config is absent).
- */
-export function enableHostAkmSharing(state: ControlPlaneState): { profilesImported: string[] } {
+/** Enable host AKM sharing: point OP_HOST_AKM_STASH at ~/akm. Nothing else. */
+export function enableHostAkmSharing(state: ControlPlaneState): void {
   const envPath = stackEnvPath(state);
   const existing = existsSync(envPath) ? readFileSync(envPath, "utf-8") : "";
   writeFileAtomic(envPath, mergeEnvContent(existing, { [ENV_KEY]: hostAkmStashPath() }), 0o600);
-
-  const { imported: profilesImported } = importHostProfiles(state, hostAkmConfigPath());
-  logger.info("host akm sharing enabled", { hostStashPath: hostAkmStashPath(), profilesImported });
-  return { profilesImported };
+  logger.info("host akm sharing enabled", { hostStashPath: hostAkmStashPath() });
 }
 
 /**

--- a/packages/lib/src/control-plane/setup.test.ts
+++ b/packages/lib/src/control-plane/setup.test.ts
@@ -972,12 +972,12 @@ describe('performSetup', () => {
 		}
 	});
 
-	it('enables sharing even when host has no akm config (engine import silently skipped)', async () => {
+	it('enables sharing even when the host has no akm config at all', async () => {
 		const fakeHome = mkdtempSync(join(tmpdir(), 'openpalm-fakehome-'));
 		const savedHome = process.env.HOME;
 		process.env.HOME = fakeHome;
 		try {
-			// ~/akm and ~/.config/akm/config.json both absent on host — engine import skipped.
+			// ~/akm absent on host — sharing is the mount, so there is nothing else to do.
 			const result = await performSetup(makeValidSpec({ hostAkm: true }));
 			expect(result.ok).toBe(true);
 			// Bundle entry always present (written unconditionally).

--- a/packages/lib/src/control-plane/setup.ts
+++ b/packages/lib/src/control-plane/setup.ts
@@ -536,11 +536,12 @@ export async function performSetup(
 			// config — written once here, never removed. The compose bind-mount
 			// controls what actually arrives at /host-stash: the real ~/akm when
 			// OP_HOST_AKM_STASH is set (enabled), or the always-present empty dir
-			// when it is unset (disabled). Profile import is best-effort on enable.
+			// when it is unset (disabled). The shared DIRECTORY is all of it — the
+			// host's own akm config and CLI are never read (see host-akm-sharing).
 			addHostStashToOpenpalmConfig(state);
 			if (hostAkm !== false) {
-				const { profilesImported } = enableHostAkmSharing(state);
-				logger.info('host akm sharing enabled during setup', { profilesImported });
+				enableHostAkmSharing(state);
+				logger.info('host akm sharing enabled during setup');
 			} else {
 				disableHostAkmSharing(state);
 			}

--- a/packages/lib/src/control-plane/versions.test.ts
+++ b/packages/lib/src/control-plane/versions.test.ts
@@ -10,7 +10,8 @@ import {
 	writeManagedVersions,
 	readVersions,
 	ensureVersionDefaults,
-	advanceManagedImageVersions
+	advanceManagedImageVersions,
+	stripRetiredToolVersions
 } from './versions.js';
 import type { ControlPlaneState } from './types.js';
 import { PLATFORM_VERSION } from './versioning.js';
@@ -166,5 +167,53 @@ describe('version configuration', () => {
 		advanceManagedImageVersions(home.state, PLATFORM_VERSION, '0.99.0');
 
 		expect(readVersions(home.state).OP_ASSISTANT_VERSION).toBe('0.99.0');
+	});
+});
+
+describe('retired OP_TOOL_*_VERSION keys', () => {
+	let home: ReturnType<typeof makeState>;
+	beforeEach(() => {
+		home = makeState();
+	});
+	afterEach(() => {
+		home.cleanup();
+	});
+
+	const envPath = () => join(home.state.homeDir, 'state', 'stack.env');
+
+	it('sweeps the retired tool rows and leaves everything else alone', () => {
+		// Tool management moved to per-container package.json in June 2026;
+		// nothing has read these since, but every older stack.env still has them
+		// sitting beside the live image tags, where they read as a pin that works.
+		writeFileSync(
+			envPath(),
+			[
+				'OP_ASSISTANT_VERSION=0.13.0',
+				'OP_TOOL_AKM_VERSION=0.8.14',
+				'OP_TOOL_CLAUDE_CODE_VERSION=2.1.186',
+				'OP_TOOL_CODEX_VERSION=0.142.0',
+				'OP_TOOL_OPENCODE_VERSION=1.17.9',
+				'OP_PROJECT_NAME=splinter',
+				''
+			].join('\n')
+		);
+
+		expect(stripRetiredToolVersions(home.state)).toBe(true);
+
+		const after = readFileSync(envPath(), 'utf-8');
+		expect(after).not.toContain('OP_TOOL_');
+		expect(after).toContain('OP_ASSISTANT_VERSION=0.13.0');
+		expect(after).toContain('OP_PROJECT_NAME=splinter');
+	});
+
+	it('is a no-op on an env that never had them', () => {
+		writeFileSync(envPath(), 'OP_ASSISTANT_VERSION=0.13.0\n');
+		expect(stripRetiredToolVersions(home.state)).toBe(false);
+	});
+
+	it('runs as part of the lifecycle version pass', () => {
+		writeFileSync(envPath(), 'OP_TOOL_AKM_VERSION=0.8.14\n');
+		ensureVersionDefaults(home.state);
+		expect(readFileSync(envPath(), 'utf-8')).not.toContain('OP_TOOL_AKM_VERSION');
 	});
 });

--- a/packages/lib/src/control-plane/versions.ts
+++ b/packages/lib/src/control-plane/versions.ts
@@ -16,7 +16,7 @@
  */
 import { existsSync, readFileSync, mkdirSync } from 'node:fs';
 import { writeFileAtomic } from './fs-atomic.js';
-import { parseEnvFile, mergeEnvContent } from './env.js';
+import { parseEnvFile, mergeEnvContent, removeEnvKey } from './env.js';
 import { stackEnvFile } from './home.js';
 import type { ControlPlaneState } from './types.js';
 import { normalizeVersion, PLATFORM_VERSION } from './versioning.js';
@@ -51,6 +51,25 @@ export function isVersionKey(key: string): key is VersionKey {
 	return VERSION_KEY_SET.has(key);
 }
 
+/**
+ * Tool-version keys retired when tool management moved to a per-container
+ * `package.json` + `bun update` (b9478492, 2026-06-22).
+ *
+ * Nothing has written or read them since — not the images, not compose, not
+ * this package — but every stack.env written before that commit still carries
+ * them, and a stale row that LOOKS like configuration is worse than no row:
+ * `OP_TOOL_AKM_VERSION=0.8.14` sitting beside the live `OP_*_VERSION` image
+ * tags reads as the knob that pins the assistant's akm, so an operator
+ * debugging a version skew edits it and nothing happens. Swept on the same
+ * lifecycle pass that seeds the real version keys.
+ */
+export const RETIRED_TOOL_VERSION_KEYS = [
+	'OP_TOOL_AKM_VERSION',
+	'OP_TOOL_CLAUDE_CODE_VERSION',
+	'OP_TOOL_CODEX_VERSION',
+	'OP_TOOL_OPENCODE_VERSION'
+] as const;
+
 // ── Version configuration ────────────────────────────────────────────────────
 
 /**
@@ -79,6 +98,22 @@ export function ensureVersionDefaults(state: ControlPlaneState): void {
 		}
 	}
 	writeVersionState(state, missing);
+	stripRetiredToolVersions(state);
+}
+
+/** Drop {@link RETIRED_TOOL_VERSION_KEYS} from `state/stack.env`. No-op once clean. */
+export function stripRetiredToolVersions(state: ControlPlaneState): boolean {
+	const path = stackEnvFile(state.homeDir);
+	if (!existsSync(path)) return false;
+	const content = readFileSync(path, 'utf-8');
+	const parsed = parseEnvFile(path);
+	const retired = RETIRED_TOOL_VERSION_KEYS.filter((key) => Object.hasOwn(parsed, key));
+	if (retired.length === 0) return false;
+	let next = content;
+	for (const key of retired) next = removeEnvKey(next, key);
+	if (next === content) return false;
+	writeFileAtomic(path, next, 0o600);
+	return true;
 }
 
 /** Advance release-managed exact pins while preserving explicit moving or custom pins. */

--- a/packages/lib/src/index.ts
+++ b/packages/lib/src/index.ts
@@ -293,7 +293,6 @@ export {
 export {
   HOST_SOURCE_NAME,
   addHostStashToOpenpalmConfig,
-  importHostProfiles,
 } from "./control-plane/akm-sources.js";
 export type {
   HostAkmSharingStatus,
@@ -368,10 +367,12 @@ export {
 // ── Version variables (stack.env image tags) ─────────────────────────────
 export {
   MANAGED_VERSION_MARKERS,
+  RETIRED_TOOL_VERSION_KEYS,
   SERVICE_VERSION_KEYS,
   VERSION_DEFAULTS,
   isVersionKey,
   readVersions,
+  stripRetiredToolVersions,
   writeVersions,
 } from "./control-plane/versions.js";
 export type { VersionKey } from "./control-plane/versions.js";

--- a/packages/ui/src/lib/api/addons.ts
+++ b/packages/ui/src/lib/api/addons.ts
@@ -53,6 +53,8 @@ export type AddonToggleResult = {
   status: number;
   enabled?: boolean;
   changed?: boolean;
+  /** Set on a 202: the addon is enabled and its services are coming up. */
+  deploying?: boolean;
   /** Present for voice enables: bring-up steps, background-pull status, error. */
   voiceAddon?: {
     steps: VoiceAddonStep[];
@@ -74,9 +76,10 @@ export async function toggleAddon(
   if (res.status === 401) {
     throw Object.assign(new Error('Invalid password.'), { status: 401 });
   }
-  // Voice enables reply 202 (image pulling in the background — poll
-  // fetchAddons() for the activeJob) or 502 (bring-up failed) with a
-  // structured voiceAddon payload; plain toggles reply 200.
+  // An enable that has services to start replies 202 (they are coming up
+  // behind the response — voice adds a structured voiceAddon payload and an
+  // activeJob to poll via fetchAddons()); voice bring-up failure replies 502;
+  // everything else replies 200.
   if (res.status === 200 || res.status === 202 || res.status === 502) {
     const parsed = (await res.json()) as Omit<AddonToggleResult, 'status'>;
     return { ...parsed, status: res.status };

--- a/packages/ui/src/lib/api/akm.ts
+++ b/packages/ui/src/lib/api/akm.ts
@@ -232,7 +232,6 @@ export async function fetchAkmKnowledgeStats(): Promise<AkmKnowledgeStats> {
 export type HostAkmSharing = {
   enabled: boolean;
   hostStashPath: string;
-  profilesImported?: string[];
 };
 
 export async function fetchHostAkmSharing(): Promise<HostAkmSharing> {

--- a/packages/ui/src/lib/components/addons/AddonsTab.svelte
+++ b/packages/ui/src/lib/components/addons/AddonsTab.svelte
@@ -183,9 +183,17 @@
         enabled,
         name === 'voice' && enabled && voiceProfile ? { profile: voiceProfile } : undefined
       );
-      if (result.status === 202) {
+      if (result.status === 202 && name === 'voice') {
         notifications.push('success', 'Voice image is downloading in the background — this can take several minutes.');
         scheduleVoicePoll();
+      } else if (result.status === 202) {
+        // Enabled; the container is starting behind the response. A first
+        // enable pulls the image, so this can take minutes — Containers is
+        // where it actually shows up.
+        notifications.push(
+          'success',
+          `${name} is enabled and starting in the background — a first-time image download can take several minutes. Watch the Containers tab.`
+        );
       } else if (!result.ok) {
         error = result.voiceAddon?.error ?? `Could not ${enabled ? 'enable' : 'disable'} ${name}.`;
       }

--- a/packages/ui/src/lib/components/akm/HostSharingSection.svelte
+++ b/packages/ui/src/lib/components/akm/HostSharingSection.svelte
@@ -32,12 +32,8 @@
         hostSharing = await disableHostAkmSharing();
         notifications.push('success', 'Host stash sharing disabled. Restart the stack to apply.');
       } else {
-        const res = await enableHostAkmSharing();
-        hostSharing = res;
-        const imported = res.profilesImported?.length
-          ? ` Imported host profiles: ${res.profilesImported.join(', ')}.`
-          : '';
-        notifications.push('success', `Host stash sharing enabled.${imported} Restart the stack to apply.`);
+        hostSharing = await enableHostAkmSharing();
+        notifications.push('success', 'Host stash sharing enabled. Restart the stack to apply.');
       }
     } catch (e) {
       notifications.push('error', e instanceof Error ? e.message : 'Failed to update host stash sharing.');

--- a/packages/ui/src/lib/server/addon-helpers.ts
+++ b/packages/ui/src/lib/server/addon-helpers.ts
@@ -2,8 +2,16 @@
  * Shared addon enable/disable logic for admin route handlers.
  *
  * Both /admin/addons and /admin/addons/:name share the same POST flow:
- * validate → stop running services if disabling → mutate state → audit.
- * This module houses the shared mutation step so neither route duplicates it.
+ * validate → stop running services if disabling → mutate state → bring
+ * services up if enabling → audit. This module houses the shared mutation step
+ * so neither route duplicates it.
+ *
+ * A toggle is an APPLY, in both directions. Disable has always stopped the
+ * addon's services; enable used to write OP_ENABLED_ADDONS and stop there, so
+ * the compose profile went active with nothing behind it and the container
+ * appeared only at the next unrelated lifecycle action — "I enabled paperclip
+ * and it never came online". Voice escaped this only because it is routed to
+ * its own bring-up engine. Every other addon now brings its services up here.
  */
 import {
 	activateComposeCommand,
@@ -24,11 +32,43 @@ import { VOICE_ADDON, engageVoiceAddon } from './voice/bring-up.js';
 const logger = createLogger('addon-helpers');
 
 type AddonToggleResult =
-	| { ok: true; enabled: boolean; changed: boolean }
+	| { ok: true; enabled: boolean; changed: boolean; deploying?: Promise<void> }
 	| { ok: false; error: string };
 
 /**
- * Stop running services if disabling, then call setAddonEnabled.
+ * Bring an addon's services up, or null when there is nothing to deploy.
+ *
+ * Returned as a pending promise rather than awaited: a first enable pulls the
+ * addon's image, which for paperclip is minutes. The caller answers 202 and
+ * holds the admin lock until this settles (same contract as the voice engine's
+ * background pull), so a concurrent install cannot interleave with the up.
+ */
+async function deployAddonServices(
+	state: ControlPlaneState,
+	name: string,
+	requestId: string,
+	lock: InstallLockHandle
+): Promise<void> {
+	const serviceNames = getAddonServiceNames(state.homeDir, name);
+	if (serviceNames.length === 0) return;
+	try {
+		await activateComposeCommand(state, ['up', '-d', ...serviceNames], { lock });
+		logger.info('brought addon services up after enable', { name, services: serviceNames, requestId });
+	} catch (err) {
+		// Never rethrow into the deferred lock release: the addon IS enabled and
+		// the operator can retry from Containers. Logged, not silent.
+		logger.error('failed to bring addon services up after enable', {
+			name,
+			services: serviceNames,
+			error: String(err),
+			requestId
+		});
+	}
+}
+
+/**
+ * Stop running services if disabling, then call setAddonEnabled, then bring
+ * services up if enabling.
  */
 async function performAddonToggleMutation(
 	state: ControlPlaneState,
@@ -78,7 +118,18 @@ async function performAddonToggleMutation(
 	if (mutation.changed) resetState();
 
 	const resultEnabled = listEnabledAddonIds(state.homeDir).includes(name);
-	return { ok: true, enabled: resultEnabled, changed: mutation.changed };
+
+	// Newly enabled → apply it. Gated on `changed` so a no-op re-enable does not
+	// recreate a healthy container, and on Docker being reachable for the same
+	// reason the disable path checks: a host without Docker can still record the
+	// intent, it just has nothing to deploy onto yet.
+	let deploying: Promise<void> | undefined;
+	if (resultEnabled && mutation.changed) {
+		const dockerCheck = await checkDocker();
+		if (dockerCheck.ok) deploying = deployAddonServices(state, name, requestId, lock);
+	}
+
+	return { ok: true, enabled: resultEnabled, changed: mutation.changed, deploying };
 }
 
 export function performAddonToggle(
@@ -87,10 +138,21 @@ export function performAddonToggle(
 	requestedEnabled: boolean | undefined,
 	requestId: string
 ): Promise<Response> {
-	return withAdminUpdateLock(state, requestId, async (lock) => {
+	return withAdminUpdateLock(state, requestId, async (lock, deferReleaseUntil) => {
 		const toggle = await performAddonToggleMutation(state, name, requestedEnabled, requestId, lock);
 		if (!toggle.ok) {
 			return errorResponse(500, 'internal_error', toggle.error, {}, requestId);
+		}
+		if (toggle.deploying) {
+			// 202: the services are coming up behind this response (image pull).
+			// Same shape the voice engine already answers with, so the client has
+			// one rule for "enabled, not yet running".
+			deferReleaseUntil(toggle.deploying);
+			return jsonResponse(
+				202,
+				{ ok: true, addon: name, enabled: toggle.enabled, changed: toggle.changed, deploying: true },
+				requestId
+			);
 		}
 		return jsonResponse(
 			200,

--- a/packages/ui/src/routes/api/host/addons/[name]/server.vitest.ts
+++ b/packages/ui/src/routes/api/host/addons/[name]/server.vitest.ts
@@ -1,10 +1,22 @@
-import { afterEach, beforeEach, describe, expect, test } from 'vitest';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { randomBytes } from 'node:crypto';
 import { tmpdir } from 'node:os';
 import { resetState, trackDir, cleanupTempDirs } from '$lib/server/test-helpers.js';
 import { getState } from '$lib/server/state.js';
+
+// An enable now brings the addon's services up; stub the compose layer so this
+// unit test neither needs a docker daemon nor actually starts containers.
+const composeCalls = vi.hoisted(() => [] as string[][]);
+vi.mock('@openpalm/lib', async (orig) => ({
+  ...(await orig<typeof import('@openpalm/lib')>()),
+  checkDocker: async () => ({ ok: true }),
+  activateComposeCommand: async (_state: unknown, args: string[]) => {
+    composeCalls.push(args);
+  },
+}));
+
 import { GET, POST } from './+server.js';
 
 function makeTempDir(): string {
@@ -66,6 +78,7 @@ beforeEach(() => {
   process.env.OP_ENABLE_ADMIN = '1';
   originalHome = process.env.OP_HOME;
   process.env.OP_HOME = makeTempDir();
+  composeCalls.length = 0;
   resetState('admin-token');
 });
 
@@ -129,12 +142,14 @@ describe('POST /api/host/addons/:name', () => {
     expect(res.status).toBe(404);
   });
 
-  test('enables an addon by updating stack.env', async () => {
+  test('enables an addon by updating stack.env AND bringing its services up', async () => {
     const state = getState();
     seedFixedAddon(state.homeDir, 'discord');
 
     const res = await POST(makePostEvent('discord', { enabled: true }));
-    expect(res.status).toBe(200);
+    expect(res.status).toBe(202);
+    // Guardian rides along: it is the shared ingress every portal addon needs.
+    expect(composeCalls).toContainEqual(['up', '-d', 'discord', 'guardian']);
 
     const body = await res.json() as { ok: boolean; addon: string; enabled: boolean; changed: boolean };
     expect(body.ok).toBe(true);

--- a/packages/ui/src/routes/api/host/addons/server.vitest.ts
+++ b/packages/ui/src/routes/api/host/addons/server.vitest.ts
@@ -12,10 +12,18 @@ import { getState } from '$lib/server/state.js';
 // inspect, runtime detection), which is absent in some test environments and
 // has blown the 5s test budget on cold CI runners where docker exists but is
 // slow to first-invoke. Everything else in @openpalm/lib stays real.
+// The compose layer is stubbed too: an enable now brings the addon's services
+// up, and a unit test must neither depend on a docker daemon being present nor
+// actually start containers. `composeCalls` is what the enable assertions read.
+const composeCalls = vi.hoisted(() => [] as string[][]);
 vi.mock('@openpalm/lib', async (orig) => ({
   ...(await orig<typeof import('@openpalm/lib')>()),
   annotateAddonProfileAvailability: async (profiles: AddonProfile[]) =>
     profiles.map((p) => ({ ...p, available: true })),
+  checkDocker: async () => ({ ok: true }),
+  activateComposeCommand: async (_state: unknown, args: string[]) => {
+    composeCalls.push(args);
+  },
 }));
 
 import { GET, POST } from './+server.js';
@@ -77,6 +85,7 @@ beforeEach(() => {
   process.env.OP_ENABLE_ADMIN = '1';
   originalHome = process.env.OP_HOME;
   process.env.OP_HOME = makeTempDir();
+  composeCalls.length = 0;
   resetState('admin-token');
 });
 
@@ -151,19 +160,35 @@ describe('POST /api/host/addons', () => {
     }
   });
 
-  test('enables an addon', async () => {
+  test('enables an addon AND brings its services up', async () => {
+    // The regression: enable wrote OP_ENABLED_ADDONS and stopped there, so the
+    // compose profile went active with no container behind it.
     const state = getState();
     seedRegistryAddon(state.homeDir, 'discord');
 
     const res = await POST(makePostEvent({ name: 'discord', enabled: true }));
-    expect(res.status).toBe(200);
+    expect(res.status).toBe(202);
 
-    const body = await res.json() as { ok: boolean; addon: string; enabled: boolean; changed: boolean };
+    const body = await res.json() as {
+      ok: boolean; addon: string; enabled: boolean; changed: boolean; deploying: boolean;
+    };
     expect(body.ok).toBe(true);
     expect(body.addon).toBe('discord');
     expect(body.enabled).toBe(true);
     expect(body.changed).toBe(true);
+    expect(body.deploying).toBe(true);
     expect(readEnabledAddonsEnv(state.homeDir)).toContain('OP_ENABLED_ADDONS=discord');
+    expect(composeCalls).toContainEqual(['up', '-d', 'discord']);
+  });
+
+  test('a no-op re-enable does not recreate a running container', async () => {
+    const state = getState();
+    seedRegistryAddon(state.homeDir, 'discord');
+    enableAddon(state.homeDir, 'discord');
+
+    const res = await POST(makePostEvent({ name: 'discord', enabled: true }));
+    expect(res.status).toBe(200);
+    expect(composeCalls).toHaveLength(0);
   });
 
   test('disables an enabled addon', async () => {

--- a/packages/ui/src/routes/api/host/akm/host-sharing/+server.ts
+++ b/packages/ui/src/routes/api/host/akm/host-sharing/+server.ts
@@ -2,12 +2,13 @@
  * Host AKM sharing control surface.
  *
  *   GET    /api/host/akm/host-sharing  — { enabled, hostStashPath }
- *   PUT    /api/host/akm/host-sharing  — enable: set OP_HOST_AKM_STASH + import profiles
+ *   PUT    /api/host/akm/host-sharing  — enable: set OP_HOST_AKM_STASH
  *   DELETE /api/host/akm/host-sharing  — disable: unset OP_HOST_AKM_STASH
  *
  * /host-stash is always mounted (core.compose.yml). /host-stash is always a
  * secondary akm source. Enable/disable only changes what the compose mount
- * points at (real stash vs empty dir). Profile import on enable is best-effort.
+ * points at (real stash vs empty dir) — the shared stash DIRECTORY is the
+ * whole of host sharing; the host's own akm config and CLI are never read.
  */
 import type { RequestHandler } from './$types';
 import {
@@ -43,8 +44,8 @@ export const PUT: RequestHandler = async (event) => {
 
   const state = getState();
   return withAdminUpdateLock(state, requestId, () => {
-    const { profilesImported } = enableHostAkmSharing(state);
-    return jsonResponse(200, { ...getHostAkmSharingStatus(state), profilesImported }, requestId);
+    enableHostAkmSharing(state);
+    return jsonResponse(200, getHostAkmSharingStatus(state), requestId);
   });
 };
 

--- a/packages/ui/src/routes/api/host/akm/host-sharing/server.vitest.ts
+++ b/packages/ui/src/routes/api/host/akm/host-sharing/server.vitest.ts
@@ -17,7 +17,7 @@ vi.mock('@openpalm/lib', async (importOriginal) => {
 	const original = await importOriginal<typeof import('@openpalm/lib')>();
 	return {
 		...original,
-		enableHostAkmSharing: vi.fn(() => ({ profilesImported: ['profiles.llm'] })),
+		enableHostAkmSharing: vi.fn(() => undefined),
 		disableHostAkmSharing: vi.fn(() => undefined),
 		getHostAkmSharingStatus: vi.fn(() => ({ enabled: true, hostStashPath: '/home/u/akm' })),
 	};
@@ -56,7 +56,6 @@ beforeEach(() => {
 	process.env.OP_HOME = rootDir;
 	resetState('admin-token');
 	vi.clearAllMocks();
-	vi.mocked(enableHostAkmSharing).mockReturnValue({ profilesImported: ['profiles.llm'] });
 	vi.mocked(getHostAkmSharingStatus).mockReturnValue({ enabled: true, hostStashPath: '/home/u/akm' });
 });
 
@@ -85,12 +84,11 @@ describe('PUT /api/host/akm/host-sharing', () => {
 		expect((await PUT(makeEvent('PUT', {}, ''))).status).toBe(401);
 	});
 
-	test('enables sharing and returns profilesImported', async () => {
+	test('enables sharing and returns the resulting status', async () => {
 		const res = await PUT(makeEvent('PUT', {}));
 		expect(res.status).toBe(200);
 		expect(enableHostAkmSharing).toHaveBeenCalledWith(expect.anything());
-		const body = (await res.json()) as Record<string, unknown>;
-		expect(body.profilesImported).toEqual(['profiles.llm']);
+		expect(await res.json()).toMatchObject({ enabled: true, hostStashPath: '/home/u/akm' });
 	});
 
 	test('returns structured 409 without enabling while an update holds the install lock', async () => {


### PR DESCRIPTION
Three defects found while testing 0.13.0-beta.23 on a real install.

## Enabling an addon never deployed it

`performAddonToggleMutation` was asymmetric: disable stopped the addon's services through compose, enable only wrote `OP_ENABLED_ADDONS` and returned. The compose profile went active with nothing behind it, and the container appeared only at the next unrelated lifecycle action — *"I enabled paperclip and it never came online"*. Voice escaped this solely because it is routed to its own bring-up engine.

A toggle is an APPLY in both directions now: enable brings the services up, answers **202** while they start (a first pull is minutes), and holds the admin lock until the up settles — the same contract the voice engine already uses. Gated on `changed` so a no-op re-enable does not recreate a healthy container, and on Docker being reachable, mirroring the disable path. A failed up is logged, not thrown: the addon stays enabled and Containers can retry.

## AKM metrics were unavailable because OpenPalm fed the assistant the host's config

`enableHostAkmSharing` read `~/.config/akm/config.json` and merged the host's `engines`/`defaults`/`improve.strategies`/`embedding` into `config/akm/config.json` — the file bind-mounted at the assistant's `/etc/akm`. The host and the image are independent installs on independent upgrade cycles, so a host running a newer akm wrote keys the container's CLI could not parse:

```
Invalid config at /etc/akm/config.json:
  - defaults: Unrecognized key(s) in object: 'engine', 'llmEngine'
  - (root): Unrecognized key(s) in object: 'engines', 'bundles', 'defaultBundle'
```

Every `akm` invocation in the assistant failed with `INVALID_CONFIG_FILE`, and the UI reported "metrics unavailable" with nothing pointing at the cause.

The shared stash **directory** is the whole of host sharing. `importHostProfiles` is deleted; enable is now the `OP_HOST_AKM_STASH` flip alone, and the `/host-stash` bundle keeps being written once at install by `addHostStashToOpenpalmConfig`.

## Stale `OP_TOOL_*_VERSION` rows

Tool management moved to a per-container `package.json` in `b9478492` (2026-06-22) and nothing has read these since, but they persist beside the live `OP_*_VERSION` image tags where they read as the knob that pins the assistant's akm — so an operator debugging a version skew edits one and nothing happens. Swept on the lifecycle pass that already seeds the real version keys.

## Verification

- `test:t1` (typecheck) — pass, 0 errors
- `test:t2` — pass, except `packages/cli/src/commands/admin.test.ts`, which hardcodes port 4611 and was blocked by an unrelated local process (`BLOCKED_PLATFORM`); everything else green (2136 + 218). The release workflow runs `bun run test` on the candidate, so this file is gated in CI.
- `test:t3` — flaky on this machine under load (5s timeouts). Confirmed environmental: the pre-change tree fails the same way with an overlapping but different file set. Run per-project, both pass (server 1732, client 421).
- `test:t4` — 19 passed
- `bun run lint` — only the pre-existing `packages/cli/src/commands/install.ts` unused-parameter warning
- Electron: typecheck clean, 193 tests pass

Manual acceptance lanes from `docs/operations/release.md` (onboarding, Tailscale/Paperclip, desktop installers) were **not** run for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)