### PR TITLE
fix: paperclip cold start, akm config upgrades, and the release signing race

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -345,11 +345,38 @@ jobs:
         run: cosign sign --yes openpalm/${{ matrix.image }}@${{ steps.build.outputs.digest }}
       - name: Verify image signature (fail loudly on a broken signer)
         if: inputs.dry_run != true && steps.build.outputs.digest != ''
+        # Retried, because the signature is not readable the instant it is
+        # written. cosign 3.x attaches it as an OCI 1.1 referrer, and Docker
+        # Hub's referrers index is eventually consistent: on 0.13.0-beta.24 the
+        # portal job verified one second after signing while guardian and
+        # assistant both failed `no signatures found` at the same one-second
+        # gap — the signatures were there minutes later, and the identical
+        # re-run passed. A single immediate attempt makes every release a coin
+        # flip per image, and this step CANNOT be exercised by a dry run: both
+        # it and the sign above are gated on `dry_run != true`, so the first
+        # time it runs is the run that publishes.
+        #
+        # Still fails closed. Only "not visible yet" is retried; the last
+        # attempt's failure is the step's failure, so a genuinely broken signer
+        # (wrong identity, wrong issuer, absent signature) still stops the
+        # release — it just takes ~1 minute to say so.
         run: |
-          cosign verify \
-            --certificate-identity-regexp "^https://github.com/${{ github.repository }}/.github/workflows/release.yml@refs/.*$" \
-            --certificate-oidc-issuer https://token.actions.githubusercontent.com \
-            openpalm/${{ matrix.image }}@${{ steps.build.outputs.digest }}
+          set -uo pipefail
+          for attempt in 1 2 3 4 5 6; do
+            if cosign verify \
+              --certificate-identity-regexp "^https://github.com/${{ github.repository }}/.github/workflows/release.yml@refs/.*$" \
+              --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+              openpalm/${{ matrix.image }}@${{ steps.build.outputs.digest }}; then
+              echo "Signature verified on attempt ${attempt}."
+              exit 0
+            fi
+            if [ "${attempt}" -eq 6 ]; then
+              echo "::error::cosign verify failed after ${attempt} attempts for openpalm/${{ matrix.image }}@${{ steps.build.outputs.digest }}"
+              exit 1
+            fi
+            echo "Attempt ${attempt} did not see the signature yet; retrying in $((attempt * 5))s."
+            sleep "$((attempt * 5))"
+          done
 
   cli:
     needs: [candidate, preflight, ui-build]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,39 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **Paperclip can cold-start again.** Upstream's `embedded-postgres` hardcodes
+  `--lc-messages=en_US.UTF-8` when it shells out to `initdb`, and the paperclip
+  image (Debian glibc 2.41) ships only `C`, `C.utf8` and `POSIX` — so `initdb`
+  exited 1 with `invalid locale name "en_US.UTF-8"` on any FRESH data
+  directory and the container crash-looped. The library forwards only initdb's
+  stdout to its log and drops stderr, so the only symptom was two banner lines
+  and "The data directory might already exist", naming neither the locale nor
+  the real error. An install whose cluster already existed was unaffected,
+  which is how this stayed hidden through an acceptance run. A one-shot
+  `paperclip-locale` service now aliases the image's OWN `C.utf8` under the
+  name initdb demands and mounts it at glibc's default lookup path; paperclip
+  waits for it to exit cleanly. It is mounted rather than exported through
+  `LOCPATH` because the library spawns initdb with `env: { LC_MESSAGES }` and
+  nothing else, so no container variable can reach it.
+- **An upgrade no longer leaves the assistant's akm config unloadable.**
+  `stripRetiredAkmKeys` ran only on the two paths that WRITE that file — the
+  setup wizard and install — so a config written before akm 0.9 kept its
+  retired keys, and the newer CLI in an upgraded image rejected the whole file
+  (`stashDir is retired in 0.9`). Every `akm` call in the assistant then failed
+  with `INVALID_CONFIG_FILE` and the UI reported AKM metrics as unavailable
+  with nothing naming the cause. The retired keys are now swept on the
+  lifecycle pass, beside the retired `stack.env` keys.
+- **Release signature verification no longer races the registry.** cosign 3.x
+  attaches signatures as OCI 1.1 referrers and Docker Hub's referrers index is
+  eventually consistent, but `cosign verify` ran once, immediately after
+  `cosign sign`. On 0.13.0-beta.24 the portal image verified while guardian and
+  assistant both failed `no signatures found` at the same one-second gap — the
+  signatures were present minutes later and an identical re-run passed. Verify
+  now retries with backoff, and still fails closed: a genuinely broken signer
+  stops the release, it just takes about a minute to say so. This step cannot
+  be exercised by a dry run — it and the sign are both gated on
+  `dry_run != true` — so the first execution is always the publishing one.
+
 - **Enabling an addon now deploys it.** The toggle was asymmetric: disable
   stopped the addon's services through compose, enable only wrote
   `OP_ENABLED_ADDONS` and returned. The compose profile went active with

--- a/packages/lib/src/control-plane/akm-sources.test.ts
+++ b/packages/lib/src/control-plane/akm-sources.test.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import {
   HOST_SOURCE_NAME,
   addHostStashToOpenpalmConfig,
+  stripRetiredAkmConfigKeys,
 } from "./akm-sources.js";
 import type { ControlPlaneState } from "./types.js";
 
@@ -120,3 +121,51 @@ describe("addHostStashToOpenpalmConfig (assistant side, parse-tolerant)", () => 
   });
 });
 
+
+describe("stripRetiredAkmConfigKeys (upgrade heals a pre-0.9 config)", () => {
+  it("removes the retired keys that make akm 0.9 reject the whole file", () => {
+    // The real report: after upgrading to an image with akm 0.9, every akm
+    // call failed with `stashDir is retired in 0.9`, because nothing rewrites
+    // this file on an upgrade — only setup and install ever did.
+    writeFileSync(opConfigPath, JSON.stringify({
+      configVersion: "0.9.0",
+      stashDir: "/stash",
+      profiles: { llm: {} },
+      bundles: { openpalm: { path: "/stash", writable: true } },
+      defaultBundle: "openpalm",
+      engines: { fast: { kind: "llm", endpoint: "http://h/v1", model: "m" } },
+      defaults: { llmEngine: "fast", llm: "retired" },
+    }, null, 2));
+
+    expect(stripRetiredAkmConfigKeys(state)).toBe(true);
+
+    const cfg = readJson(opConfigPath);
+    expect(cfg.stashDir).toBeUndefined();
+    expect(cfg.profiles).toBeUndefined();
+    expect((cfg.defaults as Record<string, unknown>).llm).toBeUndefined();
+    // Everything the operator owns survives untouched.
+    expect(cfg.bundles).toEqual({ openpalm: { path: "/stash", writable: true } });
+    expect(cfg.defaultBundle).toBe("openpalm");
+    expect(cfg.engines).toEqual({ fast: { kind: "llm", endpoint: "http://h/v1", model: "m" } });
+    expect((cfg.defaults as Record<string, unknown>).llmEngine).toBe("fast");
+  });
+
+  it("does not rewrite a config that is already clean", () => {
+    writeFileSync(opConfigPath, `${JSON.stringify({
+      configVersion: "0.9.0",
+      bundles: { openpalm: { path: "/stash", writable: true } },
+    }, null, 2)}\n`);
+    expect(stripRetiredAkmConfigKeys(state)).toBe(false);
+  });
+
+  it("leaves an unparseable config alone rather than destroying it", () => {
+    writeFileSync(opConfigPath, "{ not json");
+    expect(stripRetiredAkmConfigKeys(state)).toBe(false);
+    expect(readFileSync(opConfigPath, "utf-8")).toBe("{ not json");
+  });
+
+  it("is a no-op when there is no config yet", () => {
+    rmSync(opConfigPath, { force: true });
+    expect(stripRetiredAkmConfigKeys(state)).toBe(false);
+  });
+});

--- a/packages/lib/src/control-plane/akm-sources.ts
+++ b/packages/lib/src/control-plane/akm-sources.ts
@@ -118,3 +118,49 @@ export function addHostStashToOpenpalmConfig(state: ControlPlaneState, writable 
   if (typeof updated.defaultBundle !== "string") updated.defaultBundle = PRIMARY_BUNDLE_ID;
   writeFileAtomic(configPath, JSON.stringify(updated, null, 2), 0o600);
 }
+
+/**
+ * Strip retired 0.8 keys from an EXISTING assistant akm config so the pinned
+ * akm-cli can still load it after an upgrade.
+ *
+ * `stripRetiredAkmKeys` already runs on every OpenPalm WRITE of this file —
+ * but the only writers are the setup wizard (`persistAkmConfig`) and install
+ * (`addHostStashToOpenpalmConfig`). Neither runs on an upgrade, so a config
+ * written before akm 0.9 keeps its retired keys forever, and the newer CLI in
+ * the upgraded image refuses the whole file:
+ *
+ *   Invalid config at /etc/akm/config.json:
+ *     - stashDir: stashDir is retired in 0.9; the stash path now comes from
+ *       `bundles`.
+ *
+ * Every `akm` invocation in the assistant then fails with INVALID_CONFIG_FILE
+ * and the UI reports AKM metrics as unavailable, with nothing naming the
+ * cause. Swept on the lifecycle pass instead, beside the retired stack.env
+ * keys, so an upgraded install heals itself.
+ *
+ * Deliberately narrow: it removes retired keys and stamps `configVersion`, and
+ * writes ONLY when one of those actually changed. It does not reshape bundles
+ * or defaults — this runs on every lifecycle action against a file the
+ * operator owns, so it must not rewrite anything it was not asked to.
+ */
+export function stripRetiredAkmConfigKeys(state: ControlPlaneState): boolean {
+  const configPath = openpalmConfigPath(state);
+  if (!existsSync(configPath)) return false;
+  const before = readFileSync(configPath, "utf-8");
+  let config: AkmConfigObject;
+  try {
+    const parsed: unknown = JSON.parse(before);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return false;
+    config = parsed as AkmConfigObject;
+  } catch {
+    // Unparseable: leave it alone. Rewriting would destroy whatever the
+    // operator has, and akm reports a parse error clearly on its own.
+    return false;
+  }
+  stripRetiredAkmKeys(config);
+  config.configVersion = "0.9.0";
+  const after = `${JSON.stringify(config, null, 2)}\n`;
+  if (after === before) return false;
+  writeFileAtomic(configPath, after, 0o600);
+  return true;
+}

--- a/packages/lib/src/control-plane/lifecycle.ts
+++ b/packages/lib/src/control-plane/lifecycle.ts
@@ -48,6 +48,7 @@ import { getAddonServiceNames, listEnabledAddonIds, pruneRemovedAddonState } fro
 import { backupOpenPalmHome, pruneBackupDirs } from './backup.js';
 import { hasGuardianIngressAddon } from './addon-ids.js';
 import { advanceManagedImageVersions, ensureVersionDefaults } from './versions.js';
+import { stripRetiredAkmConfigKeys } from './akm-sources.js';
 import {
 	captureRunningImageIds,
 	restoreRunningImageIds,
@@ -209,6 +210,9 @@ async function applyHome(state: ControlPlaneState): Promise<void> {
 	}
 	pruneRemovedAddonState(state.homeDir);
 	ensureVersionDefaults(state);
+	// An upgrade can leave the assistant's akm config carrying keys the newer
+	// pinned akm-cli hard-rejects, which breaks every akm call in the container.
+	stripRetiredAkmConfigKeys(state);
 	ensureOpenCodeConfig();
 	ensureOpenCodeSystemConfig();
 }

--- a/packages/lib/src/control-plane/paperclip-compose-contract.test.ts
+++ b/packages/lib/src/control-plane/paperclip-compose-contract.test.ts
@@ -63,6 +63,10 @@ describe('Paperclip addon Compose contract', () => {
 		const paperclip = services.services?.paperclip;
 		expect(paperclip?.volumes).toEqual([
 			'${OP_HOME}/data/paperclip:/paperclip',
+			// The en_US.UTF-8 alias the paperclip-locale one-shot materializes,
+			// at glibc's DEFAULT lookup path — the library wipes the environment
+			// when it spawns initdb, so LOCPATH could never reach it.
+			'${OP_HOME}/data/paperclip/.locale/en_US.UTF-8:/usr/lib/locale/en_US.UTF-8:ro',
 			'${OP_HOME}/config/paperclip/opencode:/paperclip/.config/opencode:ro',
 			'${OP_HOME}/system/paperclip:/opt/openpalm/paperclip:ro',
 			'${OP_HOME}/cache/paperclip-opencode/runtime:/etc/opencode',
@@ -220,5 +224,27 @@ describe('Paperclip addon Compose contract', () => {
 		expect(akmConfig.configVersion).toBe('0.9.0');
 		expect(akmConfig.defaults?.engine).toBe('opencode');
 		expect(akmConfig.engines?.opencode).toEqual({ kind: 'agent', platform: 'opencode' });
+	});
+
+	test('the locale one-shot repairs upstream initdb before paperclip starts', () => {
+		// Upstream's embedded-postgres hardcodes `--lc-messages=en_US.UTF-8`, a
+		// locale the paperclip image does not ship, so initdb exits 1 on any FRESH
+		// data dir and the container crash-loops. This one-shot aliases the image's
+		// own C.utf8 under that name; without it, a first-time paperclip enable
+		// never comes online.
+		const locale = services.services?.['paperclip-locale'];
+		const paperclip = services.services?.paperclip;
+		expect(locale?.profiles).toEqual(['addon.paperclip']);
+		// One-shot, not a service: paperclip is gated on it EXITING cleanly.
+		expect(locale?.restart).toBe('no');
+		expect(paperclip?.depends_on?.['paperclip-locale']?.condition).toBe(
+			'service_completed_successfully'
+		);
+		// Same digest as paperclip, always. The locale it copies is glibc-version
+		// specific, so a digest bump that moved only one of the two would hand
+		// paperclip a locale built by a different libc.
+		expect(locale?.image).toBe(paperclip?.image);
+		// It must copy the image's own locale, never generate or vendor one.
+		expect(String(locale?.command)).toContain('/usr/lib/locale/C.utf8');
 	});
 });

--- a/packages/lib/src/index.ts
+++ b/packages/lib/src/index.ts
@@ -293,6 +293,7 @@ export {
 export {
   HOST_SOURCE_NAME,
   addHostStashToOpenpalmConfig,
+  stripRetiredAkmConfigKeys,
 } from "./control-plane/akm-sources.js";
 export type {
   HostAkmSharingStatus,

--- a/packages/skeleton/system/stack/services.compose.yml
+++ b/packages/skeleton/system/stack/services.compose.yml
@@ -25,8 +25,60 @@
 # weakening.
 
 services:
+  # Upstream cannot cold-start its embedded Postgres in its own image, and this
+  # one-shot repairs that before paperclip runs.
+  #
+  # `embedded-postgres` hardcodes `--lc-messages=en_US.UTF-8` when it shells out
+  # to initdb (paperclip's own `initdbFlags` are `--encoding=UTF8 --locale=C`,
+  # and a later flag does NOT rescue the earlier bad one). The paperclip image
+  # is Debian glibc 2.41 carrying only `C`, `C.utf8` and `POSIX`, so initdb
+  # exits 1 with `invalid locale name "en_US.UTF-8"` on any FRESH data
+  # directory. The library forwards only initdb's stdout to its log and drops
+  # stderr, so the container just crash-loops with two banner lines and
+  # "The data directory might already exist" — naming neither the locale nor
+  # the real error. An install whose cluster already exists is unaffected,
+  # which is why this hid: initdb never runs again.
+  #
+  # The fix is the smallest thing that makes the name resolve: alias the
+  # image's OWN `C.utf8` under the name initdb demands, and mount it at glibc's
+  # DEFAULT lookup path. Not `LOCPATH`: the library spawns initdb with
+  # `env: { LC_MESSAGES }` and nothing else, wiping the container environment,
+  # so no variable set here can reach the process that needs it — the locale
+  # has to be somewhere glibc looks without being told. Copying the image's own
+  # locale keeps it byte-compatible with the glibc that will read it — no
+  # generated locale, no vendored binaries, no rebuilt image (this file does
+  # not rebuild upstream images, and must not start). It only ever affects
+  # `--lc-messages`, the language of initdb's own messages, which paperclip
+  # already asks to be `C` anyway.
+  #
+  # Idempotent, and NOT a persistent service: it exits 0 and paperclip waits on
+  # that. Remove this once upstream stops demanding a locale it does not ship.
+  paperclip-locale:
+    profiles: ["addon.paperclip"]
+    image: ghcr.io/paperclipai/paperclip:sha-59e29af@sha256:048034718f9922e3c1eb168f21c3fc6f4d3e1689ad7e1dd13322a331217d8457
+    restart: "no"
+    user: "${OP_UID:-1000}:${OP_GID:-1000}"
+    entrypoint: ["/bin/sh", "-c"]
+    command:
+      - |
+        set -e
+        target=/paperclip/.locale/en_US.UTF-8
+        if [ ! -d "$$target" ]; then
+          mkdir -p /paperclip/.locale
+          cp -r /usr/lib/locale/C.utf8 "$$target"
+          echo "materialized en_US.UTF-8 from the image's C.utf8 at $$target"
+        else
+          echo "en_US.UTF-8 already present at $$target"
+        fi
+    volumes:
+      - ${OP_HOME}/data/paperclip:/paperclip
+    networks: [addon_net]
+
   paperclip:
     profiles: ["addon.paperclip"]
+    depends_on:
+      paperclip-locale:
+        condition: service_completed_successfully
     # Upstream image, digest-pinned — the same third-party pattern as ollama and
     # tunnel above. OpenPalm does NOT rebuild it. Paperclip's OpenCode adapter
     # gets AKM through user-owned OpenCode config and the published plugin; the
@@ -45,6 +97,9 @@ services:
       - "127.0.0.1:${OP_PAPERCLIP_PORT:-3840}:3100"
     volumes:
       - ${OP_HOME}/data/paperclip:/paperclip
+      # The `en_US.UTF-8` alias the paperclip-locale one-shot materialized, at
+      # glibc's default lookup path so initdb resolves it with no environment.
+      - ${OP_HOME}/data/paperclip/.locale/en_US.UTF-8:/usr/lib/locale/en_US.UTF-8:ro
       # User settings, read-only managed bootstrap, and a mutable regenerable
       # runtime config. OpenCode may install exact-pinned plugin dependencies,
       # but it never writes into lifecycle-owned system/.


### PR DESCRIPTION
Three defects found while testing 0.13.0-beta.24 on a real install.

## Paperclip could never cold-start

Upstream's `embedded-postgres` hardcodes `--lc-messages=en_US.UTF-8`; the paperclip image (Debian glibc 2.41) ships only `C`, `C.utf8`, `POSIX`. So `initdb` exits 1 against any **fresh** data directory:

```
initdb: error: invalid locale name "en_US.UTF-8"
```

The library forwards only initdb's **stdout** to its log and drops stderr, so all you see is a crash loop with two banner lines and *"The data directory might already exist"* — naming neither the locale nor the real error. Paperclip's own `initdbFlags` are `["--encoding=UTF8", "--locale=C"]`, and a later flag does not rescue the earlier bad one.

This survived an acceptance run because an install whose cluster already exists never calls initdb again. The e2e cluster was seeded on Aug 6 by a locally patched image (`openpalm/paperclip:manual-c-utf8`, built one minute before that cluster's `PG_VERSION`), so it looked healthy while cold start was broken for every new install.

**Fix:** a `paperclip-locale` one-shot aliases the image's *own* `C.utf8` under the name initdb demands; paperclip mounts it at glibc's default lookup path and waits for the one-shot to exit cleanly. Copying the image's own locale keeps it byte-compatible with the glibc that reads it — no generated locale, no vendored binary, no rebuilt upstream image. It is a **mount, not `LOCPATH`**: the library spawns initdb with `env: { LC_MESSAGES }` and nothing else, so no compose variable can reach it. (I tried `LOCPATH` first and it failed on the real stack for exactly this reason.) The contract test pins the one-shot to paperclip's exact digest — a bump moving only one would hand paperclip a locale built by a different libc.

## An upgrade left the assistant's akm config unloadable

`stripRetiredAkmKeys` ran only on the paths that *write* the file — the setup wizard and install. Neither runs on an upgrade, so a pre-0.9 config kept its retired keys and the newer CLI rejected the whole file:

```
Invalid config at /etc/akm/config.json:
  - stashDir: stashDir is retired in 0.9; the stash path now comes from `bundles`.
```

Every `akm` call in the assistant failed with `INVALID_CONFIG_FILE` and the UI reported metrics unavailable, with nothing naming the cause. Now swept on the lifecycle pass, beside the retired `stack.env` keys. Deliberately narrow: strips retired keys, stamps `configVersion`, writes only if one of those changed, and leaves an unparseable file alone rather than destroying it.

## Release signature verification raced the registry

cosign 3.x attaches signatures as OCI 1.1 referrers; Docker Hub's referrers index is eventually consistent. `cosign verify` ran once, one second after `cosign sign`. On 0.13.0-beta.24 portal verified while guardian and assistant both failed `no signatures found` at the same gap — the signatures were readable minutes later (confirmed via the referrers API) and an identical re-run published cleanly.

Verify now retries with backoff and still fails closed. Worth noting: this step **cannot be exercised by a dry run** — it and the sign are both gated on `dry_run != true` — so its first execution is always the run that publishes.

## Verification

Real stack, not just unit tests. Paperclip on the reporter's install:

```
splinter-paperclip-locale-1  Exited (0)   "materialized en_US.UTF-8 from the image's C.utf8"
splinter-paperclip-1         Up (healthy) "Server listening on 0.0.0.0:3100"
PG_VERSION → 18 ;  /api/health → 200 ;  / → 200
```

AKM after stripping the retired key: `akm health` → `{"ok": true}`, `akm info` and `akm proposal list` both return.

- `test:t1` typecheck — 0 errors
- `packages/lib` — 1497 pass
- portals/sdk/guardian/scripts — 646 pass
- UI server — 1732 pass
- `bun run lint` — only the pre-existing `install.ts` warning

The cosign retry is the one change that cannot be verified before it runs for real, by its own nature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)