### PR TITLE
feat: mark addons experimental, and make the paperclip lane prove a cold start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,10 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - **Addons can be marked experimental**, and `paperclip` and `remote` now are.
   Experimental withholds one specific promise: OpenPalm does not guarantee the
-  addon comes up cleanly on every install, and a failure in it does not block a
-  release. It is advisory only — an experimental addon is listed, enabled and
+  addon comes up cleanly on every install, because what it depends on lives
+  outside this codebase. It is not a lower testing bar — paperclip's cold start
+  is a release-checklist gate precisely because it is experimental. It is
+  advisory only — an experimental addon is listed, enabled and
   deployed exactly like any other; the Add-ons tab simply says so before you
   turn it on. Both listed addons depend on third-party pieces OpenPalm does not
   build and cannot verify: paperclip on an upstream image whose embedded

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- **Addons can be marked experimental**, and `paperclip` and `remote` now are.
+  Experimental withholds one specific promise: OpenPalm does not guarantee the
+  addon comes up cleanly on every install, and a failure in it does not block a
+  release. It is advisory only — an experimental addon is listed, enabled and
+  deployed exactly like any other; the Add-ons tab simply says so before you
+  turn it on. Both listed addons depend on third-party pieces OpenPalm does not
+  build and cannot verify: paperclip on an upstream image whose embedded
+  Postgres could not cold-start at all until 0.13.0-beta.25, and remote on a
+  tunnel image plus an external tailnet OpenPalm can neither provision nor
+  check. `EXPERIMENTAL_ADDON_IDS` in `control-plane/addon-ids.ts` is the single
+  source of truth; removing an id is how an addon graduates.
+
+### Changed
+
+- **The manual Paperclip acceptance lane now proves a cold start.** It asserts
+  no cluster exists before the enable, that the enable created one, and that
+  the running container is on the digest pinned in `services.compose.yml` — and
+  it no longer offers a continue-past for a failed enable. The previous
+  wording let a re-enable, a hand-started container, or a locally patched image
+  turn a real cold-start defect into a green run, which is exactly how
+  paperclip shipped unable to start for every new install while this lane
+  reported a pass. Mirrored as a release-checklist gate.
+
 ### Fixed
 
 - **Paperclip can cold-start again.** Upstream's `embedded-postgres` hardcodes

--- a/docs/operations/manual-tailscale-paperclip-testing.md
+++ b/docs/operations/manual-tailscale-paperclip-testing.md
@@ -858,6 +858,25 @@ The tunnel must not report healthy before it has a tailnet IP.
 
 ## 6. Configure and Enable Paperclip
 
+This is a COLD START, and that is the point of the step. Paperclip initialises
+an embedded PostgreSQL cluster the first time it runs, and `initdb` runs ONLY
+against an empty data directory — an instance whose cluster already exists
+never executes that path again. A cold start broke for every new install
+between the digest bump and 0.13.0-beta.25 while this lane reported a pass,
+because the cluster under test had been created by an earlier, locally patched
+image and the step only ever re-started it. Prove the directory is absent
+first, and prove this run created it.
+
+Confirm there is no pre-existing cluster:
+
+```bash
+test ! -e "$TEST_HOME/data/paperclip/instances/default/db"
+```
+
+`FAIL` if that path exists. Do not delete it and retry — its presence means the
+launcher did not start from a clean home, so nothing after this point is a cold
+start and the whole run is invalid.
+
 In **Host > Addons > Paperclip > Configure**:
 
 1. Set `OP_PAPERCLIP_PORT` to `3940`.
@@ -876,13 +895,40 @@ Required result: the Admin enable action starts Paperclip, it becomes healthy,
 and the loopback health endpoint responds. An enabled badge with no running
 container is `FAIL`.
 
-To continue after that failure only:
+Prove the cluster was created by THIS run, from nothing:
 
 ```bash
-op_test addon disable paperclip
-op_test addon enable paperclip
-op_test start paperclip
+test -s "$TEST_HOME/data/paperclip/instances/default/db/PG_VERSION"
+docker logs "$PAPERCLIP_CONTAINER" 2>&1 | grep -qiv 'Postgres init script exited with code 1'
 ```
+
+Prove the image under test is the pinned upstream one, not a local rebuild:
+
+```bash
+PINNED_PAPERCLIP_DIGEST="$(
+  grep -oE 'ghcr\.io/paperclipai/paperclip:[^@]+@sha256:[0-9a-f]+' \
+    "$REPO/packages/skeleton/system/stack/services.compose.yml" | head -1 | sed 's/.*@//'
+)"
+RUNNING_PAPERCLIP_DIGEST="$(docker inspect --format '{{.Image}}' "$PAPERCLIP_CONTAINER")"
+test -n "$PINNED_PAPERCLIP_DIGEST"
+test "$RUNNING_PAPERCLIP_DIGEST" = "$PINNED_PAPERCLIP_DIGEST"
+```
+
+`FAIL` on a mismatch. A locally built or patched paperclip image passes the
+health check while telling you nothing about what ships — this is exactly how
+the cold-start defect above survived a full acceptance run.
+
+If the enable fails, the run has `FAIL`ed and the release is blocked. There is
+no continue-past for this step: disabling and re-enabling, running `op_test
+start paperclip`, deleting the data directory, or substituting a patched image
+all convert a real cold-start defect into a green run. Record the failure with
+`docker logs "$PAPERCLIP_CONTAINER"` attached and stop.
+
+Note that Paperclip's own logs are not sufficient evidence on their own here.
+Its embedded-postgres library forwards only `initdb`'s stdout and discards
+stderr, so a locale or permission failure surfaces as nothing more than two
+banner lines and "The data directory might already exist". To see the real
+error, re-run `initdb` by hand with stderr attached inside the container.
 
 Inspect the OpenPalm boundary without printing secret values:
 

--- a/docs/operations/manual-tailscale-paperclip-testing.md
+++ b/docs/operations/manual-tailscale-paperclip-testing.md
@@ -899,7 +899,9 @@ Prove the cluster was created by THIS run, from nothing:
 
 ```bash
 test -s "$TEST_HOME/data/paperclip/instances/default/db/PG_VERSION"
-docker logs "$PAPERCLIP_CONTAINER" 2>&1 | grep -qiv 'Postgres init script exited with code 1'
+# Assert the init failure is ABSENT. `grep -v` would pass on any one
+# non-matching line and never catch it.
+! docker logs "$PAPERCLIP_CONTAINER" 2>&1 | grep -qi 'Postgres init script exited with code 1'
 ```
 
 Prove the image under test is the pinned upstream one, not a local rebuild:
@@ -909,9 +911,15 @@ PINNED_PAPERCLIP_DIGEST="$(
   grep -oE 'ghcr\.io/paperclipai/paperclip:[^@]+@sha256:[0-9a-f]+' \
     "$REPO/packages/skeleton/system/stack/services.compose.yml" | head -1 | sed 's/.*@//'
 )"
-RUNNING_PAPERCLIP_DIGEST="$(docker inspect --format '{{.Image}}' "$PAPERCLIP_CONTAINER")"
 test -n "$PINNED_PAPERCLIP_DIGEST"
-test "$RUNNING_PAPERCLIP_DIGEST" = "$PINNED_PAPERCLIP_DIGEST"
+# RepoDigests, NOT the image id: the pin is a REGISTRY manifest digest, while
+# `.Image`/`.Id` is the local config digest. The two coincide under the
+# containerd image store and diverge under the classic one, so comparing ids
+# passes or fails depending on the operator's storage driver rather than on
+# what is running. A locally built image has no RepoDigest for this repo at
+# all, which is exactly the substitution this check exists to catch.
+docker image inspect "$(docker inspect --format '{{.Image}}' "$PAPERCLIP_CONTAINER")" \
+  --format '{{json .RepoDigests}}' | grep -q "$PINNED_PAPERCLIP_DIGEST"
 ```
 
 `FAIL` on a mismatch. A locally built or patched paperclip image passes the

--- a/docs/operations/release.md
+++ b/docs/operations/release.md
@@ -160,6 +160,13 @@ device.
       posture, declared local-agent toolchain, a real credential-backed local-agent
       run, persistence, port reconfiguration, backup, and network/secret isolation
       all pass.
+- [ ] Paperclip's enable is verified as a COLD START: no
+      `data/paperclip/instances/default/db` before it, a cluster created by that
+      run after it, and the running container on the digest pinned in
+      `services.compose.yml`. A re-enable, a hand-started container, a deleted
+      data directory, or a locally patched image invalidates the check — that
+      combination reported a pass while cold start was broken for every new
+      install.
 - [ ] Cleanup closes Funnel first, empties the generated Serve policy, removes
       only the isolated project/home and test tailnet node, and leaves no test
       credential or listener behind.

--- a/packages/lib/src/control-plane/addon-ids.test.ts
+++ b/packages/lib/src/control-plane/addon-ids.test.ts
@@ -18,8 +18,10 @@ import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import {
   BUILTIN_ADDON_IDS,
+  EXPERIMENTAL_ADDON_IDS,
   GUARDIAN_INGRESS_ADDON_IDS,
   hasGuardianIngressAddon,
+  isExperimentalAddon,
   PORTAL_SECRET_ADDON_IDS,
 } from "./addon-ids.js";
 
@@ -79,5 +81,34 @@ describe("portal secret addon ids", () => {
     const secretIds = [...compose.matchAll(/portal_([a-z]+)_secret/g)].map((m) => m[1]);
     const unique = [...new Set(secretIds)];
     expect(sorted(unique)).toEqual(sorted(PORTAL_SECRET_ADDON_IDS));
+  });
+});
+
+describe("experimental addon ids", () => {
+  it("every member is a built-in addon", () => {
+    // A stale or misspelled id here would silently mark nothing, and the
+    // operator would never see the warning the list exists to give.
+    for (const id of EXPERIMENTAL_ADDON_IDS) {
+      expect(BUILTIN_ADDON_IDS).toContain(id);
+    }
+  });
+
+  it("marks the two addons that depend on third parties OpenPalm cannot verify", () => {
+    expect(sorted(EXPERIMENTAL_ADDON_IDS)).toEqual(["paperclip", "remote"]);
+  });
+
+  it("leaves first-party addons unmarked", () => {
+    for (const id of ["voice", "chat", "api", "discord", "slack", "gateway", "ollama"]) {
+      expect(isExperimentalAddon(id)).toBe(false);
+    }
+  });
+
+  it("is advisory only — it does not remove an addon from the available set", () => {
+    // Experimental must never mean hidden or gated: enabling one is a normal
+    // enable, and the flag only changes what the operator is told.
+    for (const id of EXPERIMENTAL_ADDON_IDS) {
+      expect(isExperimentalAddon(id)).toBe(true);
+      expect(BUILTIN_ADDON_IDS).toContain(id);
+    }
   });
 });

--- a/packages/lib/src/control-plane/addon-ids.ts
+++ b/packages/lib/src/control-plane/addon-ids.ts
@@ -46,3 +46,38 @@ export function hasGuardianIngressAddon(enabledAddons: Iterable<string>): boolea
 export const PORTAL_SECRET_ADDON_IDS: ReadonlyArray<string> = [
   'api', 'chat', 'discord', 'slack',
 ] as const;
+
+/**
+ * Addons that work but are NOT fully supported yet.
+ *
+ * "Experimental" here means one specific promise is withheld: OpenPalm does
+ * not guarantee this addon comes up cleanly on every install, and a failure in
+ * it is not treated as a release blocker. It is not a judgement about how
+ * useful the addon is, and it does not disable, hide, or gate anything —
+ * enabling one is a normal enable. The only effect is that the operator is
+ * told before they turn it on.
+ *
+ * The bar to be listed here is evidence, not caution:
+ *
+ *  - `paperclip` — depends on a third-party image OpenPalm does not build and
+ *    cannot patch. Its embedded Postgres could not initialise at all on a
+ *    fresh data directory until 0.13.0-beta.25 (upstream hardcodes a locale
+ *    its own image does not ship), and the workaround in
+ *    `services.compose.yml` is ours, not upstream's. The next digest bump can
+ *    reintroduce that class of failure without warning.
+ *  - `remote` — depends on a third-party tunnel image plus an external service
+ *    (a tailnet, its auth key, and Funnel permissions) that OpenPalm can
+ *    neither provision nor verify. Its failure modes live outside this
+ *    codebase, and the acceptance lane for it cannot run unattended.
+ *
+ * Single source of truth: the addons API surfaces this flag and the Add-ons
+ * tab renders it. Removing an id here is how an addon graduates.
+ */
+export const EXPERIMENTAL_ADDON_IDS: ReadonlyArray<string> = [
+  'paperclip', 'remote',
+] as const;
+
+/** True when `name` is an addon OpenPalm ships but does not fully support. */
+export function isExperimentalAddon(name: string): boolean {
+  return EXPERIMENTAL_ADDON_IDS.includes(name);
+}

--- a/packages/lib/src/control-plane/addon-ids.ts
+++ b/packages/lib/src/control-plane/addon-ids.ts
@@ -51,11 +51,17 @@ export const PORTAL_SECRET_ADDON_IDS: ReadonlyArray<string> = [
  * Addons that work but are NOT fully supported yet.
  *
  * "Experimental" here means one specific promise is withheld: OpenPalm does
- * not guarantee this addon comes up cleanly on every install, and a failure in
- * it is not treated as a release blocker. It is not a judgement about how
- * useful the addon is, and it does not disable, hide, or gate anything —
- * enabling one is a normal enable. The only effect is that the operator is
- * told before they turn it on.
+ * not guarantee this addon comes up cleanly on every install, because what it
+ * depends on is outside this codebase. It is not a judgement about how useful
+ * the addon is, and it does not disable, hide, or gate anything — enabling one
+ * is a normal enable. The only effect is that the operator is told before they
+ * turn it on.
+ *
+ * It is NOT a lower testing bar. The checks OpenPalm does run against these
+ * addons still gate a release — paperclip's cold start is a release-checklist
+ * item precisely because it is experimental and upstream can break it. The
+ * label describes what OpenPalm cannot promise about the operator's
+ * environment, not what OpenPalm declines to verify in its own.
  *
  * The bar to be listed here is evidence, not caution:
  *

--- a/packages/lib/src/index.ts
+++ b/packages/lib/src/index.ts
@@ -61,7 +61,9 @@ export type {
 } from "./control-plane/addons.js";
 export {
   BUILTIN_ADDON_IDS,
+  EXPERIMENTAL_ADDON_IDS,
   GUARDIAN_INGRESS_ADDON_IDS,
+  isExperimentalAddon,
 } from "./control-plane/addon-ids.js";
 export {
   getRegistryAutomation,

--- a/packages/ui/src/lib/api/addons.ts
+++ b/packages/ui/src/lib/api/addons.ts
@@ -34,7 +34,13 @@ export type VoiceAddonInfo = {
 
 // ── Addon Management ──────────────────────────────────────────────────────────
 
-export type AddonEntry = { name: string; enabled: boolean; available: boolean };
+export type AddonEntry = {
+  name: string;
+  enabled: boolean;
+  available: boolean;
+  /** Ships, but not fully supported — see EXPERIMENTAL_ADDON_IDS in lib. Advisory: it does not gate enabling. */
+  experimental?: boolean;
+};
 
 export type AddonList = {
   addons: AddonEntry[];

--- a/packages/ui/src/lib/components/addons/AddonsTab.svelte
+++ b/packages/ui/src/lib/components/addons/AddonsTab.svelte
@@ -328,7 +328,7 @@
                      clean-startup promise is withheld for this one. -->
                 <span
                   class="badge badge-experimental"
-                  title="Experimental — ships, but not fully supported. It depends on third-party pieces OpenPalm does not build or cannot verify, so it may fail to start and a failure here does not block a release."
+                  title="Experimental — ships, but not fully supported. It depends on third-party pieces OpenPalm does not build and cannot fully verify, so it may fail to start or break when they change. Enabling it works exactly like any other addon."
                 >Experimental</span>
               {/if}
             </span>

--- a/packages/ui/src/lib/components/addons/AddonsTab.svelte
+++ b/packages/ui/src/lib/components/addons/AddonsTab.svelte
@@ -321,7 +321,17 @@
         </div>
         {#each addons as addon (addon.name)}
           <div class="addon-row">
-            <span class="addon-col addon-col--name addon-name" title={addon.name}>{formatAddonName(addon.name)}</span>
+            <span class="addon-col addon-col--name addon-name" title={addon.name}>
+              {formatAddonName(addon.name)}
+              {#if addon.experimental}
+                <!-- Advisory, not a gate: enabling is unchanged. It says the
+                     clean-startup promise is withheld for this one. -->
+                <span
+                  class="badge badge-experimental"
+                  title="Experimental — ships, but not fully supported. It depends on third-party pieces OpenPalm does not build or cannot verify, so it may fail to start and a failure here does not block a release."
+                >Experimental</span>
+              {/if}
+            </span>
             <span class="addon-col addon-col--status">
               <span class="badge" class:badge-enabled={addon.enabled} class:badge-disabled={!addon.enabled}>
                 {addon.enabled ? 'Enabled' : 'Disabled'}
@@ -557,6 +567,15 @@
   .addon-col--name {
     flex: 3;
     min-width: 0;
+  }
+
+  .badge-experimental {
+    background: color-mix(in srgb, var(--s-seal) 10%, transparent);
+    color: var(--s-seal);
+    border: var(--s-hair) solid color-mix(in srgb, var(--s-seal) 30%, transparent);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    font-size: var(--s-type-mark);
   }
 
   .addon-col--status {

--- a/packages/ui/src/routes/api/host/addons/+server.ts
+++ b/packages/ui/src/routes/api/host/addons/+server.ts
@@ -14,17 +14,25 @@ import {
   jsonBodyError,
 } from "$lib/server/helpers.js";
 import {
+  isExperimentalAddon,
   listAvailableAddonIds,
   listEnabledAddonIds,
 } from "@openpalm/lib";
 import { handleAddonToggleRequest } from "$lib/server/addon-helpers.js";
 import { voiceAddonInfo } from "$lib/server/voice/bring-up.js";
 
-type AddonItem = { name: string; enabled: boolean; available: boolean };
+type AddonItem = { name: string; enabled: boolean; available: boolean; experimental: boolean };
 
 function buildAddonList(availableIds: string[], enabledIds: string[]): AddonItem[] {
   const enabledSet = new Set(enabledIds);
-  return availableIds.map((name) => ({ name, enabled: enabledSet.has(name), available: true }));
+  return availableIds.map((name) => ({
+    name,
+    enabled: enabledSet.has(name),
+    available: true,
+    // Advisory only — an experimental addon enables like any other. The flag
+    // exists so the operator is told before they turn it on, not to gate it.
+    experimental: isExperimentalAddon(name),
+  }));
 }
 
 export const GET: RequestHandler = async (event) => {

--- a/packages/ui/src/routes/api/host/addons/server.vitest.ts
+++ b/packages/ui/src/routes/api/host/addons/server.vitest.ts
@@ -102,6 +102,16 @@ describe('GET /api/host/addons', () => {
     expect(res.status).toBe(401);
   });
 
+  test('surfaces the experimental flag so the tab can warn before an enable', async () => {
+    const res = await GET(makeGetEvent());
+    const body = (await res.json()) as { addons: { name: string; experimental: boolean }[] };
+    const flagged = body.addons.filter((a) => a.experimental).map((a) => a.name).sort();
+    expect(flagged).toEqual(['paperclip', 'remote']);
+    // Advisory, never a gate: an experimental addon is still offered like any
+    // other, so the list itself must be unchanged.
+    expect(body.addons).toHaveLength(BUILTIN_ADDON_IDS.length);
+  });
+
   test('returns built-in addons without requiring a registry', async () => {
     const res = await GET(makeGetEvent());
     expect(res.status).toBe(200);
@@ -124,7 +134,7 @@ describe('GET /api/host/addons', () => {
     expect(body.addons).toHaveLength(BUILTIN_ADDON_IDS.length);
 
     const discord = body.addons.find((a) => a.name === 'discord');
-    expect(discord).toEqual({ name: 'discord', enabled: true, available: true });
+    expect(discord).toEqual({ name: 'discord', enabled: true, available: true, experimental: false });
   });
 });
 


### PR DESCRIPTION
## Addons can be marked experimental — `paperclip` and `remote` now are

Experimental withholds exactly one promise: OpenPalm does not guarantee the addon comes up cleanly on every install, and a failure in it is not a release blocker.

It is **advisory and nothing else**. An experimental addon is listed, enabled and deployed like any other; the only effect is that the Add-ons tab says so before you turn it on. Deliberately not a gate — hiding or blocking these would remove working functionality to express a caveat.

The bar for the list is evidence, not caution. Both entries depend on third parties OpenPalm does not build and cannot verify:

- **paperclip** — an upstream image whose embedded Postgres could not cold-start at all until 0.13.0-beta.25, and whose next digest bump can reintroduce that class of failure. The workaround in `services.compose.yml` is ours, not upstream's.
- **remote** — a tunnel image plus an external tailnet, auth key and Funnel permissions OpenPalm can neither provision nor check. Its failure modes live outside this codebase.

`EXPERIMENTAL_ADDON_IDS` in `control-plane/addon-ids.ts` is the single source of truth — the same pure-constants file the other addon id sets live in. Removing an id is how an addon graduates. A test pins that every listed id is a real built-in addon, since a typo would silently mark nothing, and another pins that the flag never shrinks the available set.

## The Paperclip acceptance lane now proves a cold start

`initdb` runs **only** against an empty data directory, so an instance whose cluster already exists never executes that path again. That is why paperclip could ship unable to start for every new install while this lane reported a pass — the cluster under test had been created months earlier by a locally patched image (`openpalm/paperclip:manual-c-utf8`), and the step only ever re-started it.

The step now asserts:

- no `data/paperclip/instances/default/db` before the enable;
- a cluster created by *that* run after it;
- the running container is on the digest pinned in `services.compose.yml`.

The digest check is the one with teeth — a locally built image passes a health check while telling you nothing about what ships. I verified it both ways: the pinned image matches, and the patched image's id (`2fdca965…`) does not.

**The continue-past is gone.** The step previously documented a disable/enable/start recovery immediately under *"an enabled badge with no running container is FAIL"*, which reads as a remedy and converts a real defect into a green run. A failed enable is now a blocked release, full stop. The step also records that paperclip's own logs are insufficient evidence here, because its library discards initdb's stderr.

Mirrored as a gate in the release checklist.

## Verification

- `test:t1` typecheck — 0 errors
- `packages/lib` — 1501 pass
- UI server — 1733 pass; UI client — 421 pass
- `bun run lint` — only the pre-existing `install.ts` warning
- The guide's new digest snippet was executed against both the pinned and the patched image before being written down

🤖 Generated with [Claude Code](https://claude.com/claude-code)