### PR TITLE
fix: surface real causes, apply the host-sharing toggle, finish the akm sweep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,41 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- **Docker preflight now names the actual problem.** The setup wizard's deploy
+  and retry paths asserted "Docker isn't running. Start Docker Desktop or
+  OrbStack" for every `checkDocker()` failure, discarding the daemon's own
+  stderr — while `mapDockerError`, which distinguishes not-installed from
+  permission-denied from actually-stopped, was imported in the same file and
+  used a few lines away. A Linux user whose account is not in the `docker`
+  group finished the whole wizard, clicked Install, and was told to start
+  Docker that was already running, with no next action. Both paths route
+  through the shared mapper now.
+- **Host AKM sharing applies itself instead of asking for an impossible
+  restart.** `OP_HOST_AKM_STASH` is the SOURCE of a bind mount, so only a
+  container recreate can change it — but the card said "Takes effect after the
+  next stack restart", and every restart affordance is `compose restart`, which
+  reuses existing mounts. The toggle now recreates the assistant, the same "a
+  save is an APPLY" rule access-apply.ts enforces elsewhere, and the
+  instruction is gone.
+- **The AKM health endpoint reports what akm said.** It read only `stdout` and
+  returned "assistant AKM unavailable", discarding the `stderr` that names the
+  exact bad config key — the second copy of a flattening that already cost one
+  debugging session. Two sibling routes already did this correctly.
+- **The retired-key sweep now covers Paperclip's akm config too.** Paperclip
+  runs its own akm against `config/paperclip/akm/config.json`, seeded once and
+  never rewritten, so it drifts exactly like the assistant's did and fails the
+  same total way. Sweeping only one of the two was half a fix.
+
+### Removed
+
+- **The Sharing card no longer advertises a host provider import that does not
+  happen.** It claimed enabling "also imports your host LLM and agent
+  connection profiles"; that import was deleted when OpenPalm stopped reading
+  the host's akm config. Importing host provider credentials is a real, separate
+  feature and remains available from Connections and the setup wizard.
+
 ### Added
 
 - **Addons can be marked experimental**, and `paperclip` and `remote` now are.

--- a/packages/lib/src/control-plane/akm-sources.test.ts
+++ b/packages/lib/src/control-plane/akm-sources.test.ts
@@ -169,3 +169,28 @@ describe("stripRetiredAkmConfigKeys (upgrade heals a pre-0.9 config)", () => {
     expect(stripRetiredAkmConfigKeys(state)).toBe(false);
   });
 });
+
+describe("stripRetiredAkmConfigKeys covers paperclip's own akm config", () => {
+  it("sweeps config/paperclip/akm/config.json too", () => {
+    // Paperclip runs a second akm against its own config, seeded once from the
+    // skeleton and never rewritten. Sweeping only the assistant's left the
+    // identical INVALID_CONFIG_FILE failure waiting in that container.
+    const pcDir = join(root, "config", "paperclip", "akm");
+    mkdirSync(pcDir, { recursive: true });
+    const pcPath = join(pcDir, "config.json");
+    writeFileSync(pcPath, JSON.stringify({ profiles: { agent: {} }, stashDir: "/stash" }, null, 2));
+    writeFileSync(opConfigPath, `${JSON.stringify({ configVersion: "0.9.0" }, null, 2)}\n`);
+
+    expect(stripRetiredAkmConfigKeys(state)).toBe(true);
+
+    const pc = JSON.parse(readFileSync(pcPath, "utf-8")) as Record<string, unknown>;
+    expect(pc.profiles).toBeUndefined();
+    expect(pc.stashDir).toBeUndefined();
+    expect(pc.configVersion).toBe("0.9.0");
+  });
+
+  it("returns false when neither config needs a change", () => {
+    writeFileSync(opConfigPath, `${JSON.stringify({ configVersion: "0.9.0" }, null, 2)}\n`);
+    expect(stripRetiredAkmConfigKeys(state)).toBe(false);
+  });
+});

--- a/packages/lib/src/control-plane/akm-sources.ts
+++ b/packages/lib/src/control-plane/akm-sources.ts
@@ -144,7 +144,23 @@ export function addHostStashToOpenpalmConfig(state: ControlPlaneState, writable 
  * operator owns, so it must not rewrite anything it was not asked to.
  */
 export function stripRetiredAkmConfigKeys(state: ControlPlaneState): boolean {
-  const configPath = openpalmConfigPath(state);
+  // BOTH akm configs, not just the assistant's. Paperclip runs its own akm
+  // against `config/paperclip/akm/config.json` (services.compose.yml mounts it
+  // at /etc/akm), seeded once from the skeleton and never rewritten — so it
+  // drifts exactly like the assistant's did, with the same total failure: the
+  // newer CLI rejects the whole file and every akm call in that container
+  // dies. Sweeping only one of the two was half a fix.
+  let changed = false;
+  for (const configPath of [
+    openpalmConfigPath(state),
+    join(state.configDir, "paperclip", "akm", "config.json"),
+  ]) {
+    if (stripRetiredKeysAt(configPath)) changed = true;
+  }
+  return changed;
+}
+
+function stripRetiredKeysAt(configPath: string): boolean {
   if (!existsSync(configPath)) return false;
   const before = readFileSync(configPath, "utf-8");
   let config: AkmConfigObject;

--- a/packages/ui/src/lib/components/akm/HostSharingSection.svelte
+++ b/packages/ui/src/lib/components/akm/HostSharingSection.svelte
@@ -30,10 +30,10 @@
     try {
       if (hostSharing?.enabled) {
         hostSharing = await disableHostAkmSharing();
-        notifications.push('success', 'Host stash sharing disabled. Restart the stack to apply.');
+        notifications.push('success', 'Host stash sharing disabled.');
       } else {
         hostSharing = await enableHostAkmSharing();
-        notifications.push('success', 'Host stash sharing enabled. Restart the stack to apply.');
+        notifications.push('success', 'Host stash sharing enabled.');
       }
     } catch (e) {
       notifications.push('error', e instanceof Error ? e.message : 'Failed to update host stash sharing.');
@@ -58,9 +58,7 @@
       <section class="config-section">
         <p class="section-note">
           Mount your personal AKM stash (<code>{hostSharing.hostStashPath}</code>) into the
-          assistant as a readable secondary source. Enabling also imports your host LLM and
-          agent connection profiles so the assistant can use the same providers you have
-          configured locally.
+          assistant as a readable secondary source.
         </p>
 
         <div class="controls">
@@ -78,7 +76,6 @@
             {#if busy}<Spinner />{/if}
             {hostSharing.enabled ? 'Disable host sharing' : 'Enable host sharing'}
           </button>
-          <p class="hint">Takes effect after the next stack restart.</p>
         </div>
       </section>
     {/if}
@@ -114,11 +111,5 @@
     font-family: var(--s-font-mono);
     font-size: var(--s-type-mark-sm);
     color: var(--s-ink-3);
-  }
-  .hint {
-    font-family: var(--s-font-display);
-    font-size: var(--s-type-deed);
-    color: var(--s-ink-3);
-    margin: 0;
   }
 </style>

--- a/packages/ui/src/routes/api/host/akm/health/+server.ts
+++ b/packages/ui/src/routes/api/host/akm/health/+server.ts
@@ -30,7 +30,18 @@ export const GET: RequestHandler = async (event) => {
   const parsedInfo = safeParseJsonObject(info.stdout);
 
   if (!parsedHealth && !parsedInfo) {
-    return jsonResponse(200, { available: false, reason: 'assistant AKM unavailable' }, requestId);
+    // Report what akm actually said. Its errors are precise and actionable
+    // ("stashDir is retired in 0.9…"), and flattening them to a generic
+    // string is what left an operator staring at "unavailable" with no route
+    // to the cause. Same shape akm-health-report.ts and reindex already use.
+    const detail = [health.stderr, info.stderr, health.stdout, info.stdout]
+      .map((s) => s?.trim())
+      .find((s) => s);
+    return jsonResponse(
+      200,
+      { available: false, reason: detail || 'assistant AKM unavailable' },
+      requestId,
+    );
   }
 
   // Summarise the hard checks into pass/warn/fail counts.

--- a/packages/ui/src/routes/api/host/akm/host-sharing/+server.ts
+++ b/packages/ui/src/routes/api/host/akm/host-sharing/+server.ts
@@ -9,9 +9,19 @@
  * secondary akm source. Enable/disable only changes what the compose mount
  * points at (real stash vs empty dir) — the shared stash DIRECTORY is the
  * whole of host sharing; the host's own akm config and CLI are never read.
+ *
+ * Both directions APPLY. `OP_HOST_AKM_STASH` is the SOURCE of a bind mount
+ * (core.compose.yml: `${OP_HOST_AKM_STASH:-…}:/host-stash`), and a mount can
+ * only change when the container is created — `compose restart` reuses the
+ * existing mounts. The UI used to tell the operator to "restart the stack",
+ * which cannot work: they would flip the toggle, see Enabled, restart, and
+ * still get the empty-dir fallback with no error anywhere. Recreating the
+ * assistant here is the same "a save is an APPLY" rule access-apply.ts
+ * enforces for every other setting whose effect is a compose fact.
  */
 import type { RequestHandler } from './$types';
 import {
+  activateStack,
   enableHostAkmSharing,
   disableHostAkmSharing,
   getHostAkmSharingStatus,
@@ -43,8 +53,10 @@ export const PUT: RequestHandler = async (event) => {
   if (authError) return authError;
 
   const state = getState();
-  return withAdminUpdateLock(state, requestId, () => {
+  return withAdminUpdateLock(state, requestId, async (lock) => {
     enableHostAkmSharing(state);
+    // The mount source changed; only a recreate picks that up.
+    await activateStack(state, { kind: 'services', services: ['assistant'] }, {}, { lock });
     return jsonResponse(200, getHostAkmSharingStatus(state), requestId);
   });
 };
@@ -57,8 +69,10 @@ export const DELETE: RequestHandler = async (event) => {
   if (authError) return authError;
 
   const state = getState();
-  return withAdminUpdateLock(state, requestId, () => {
+  return withAdminUpdateLock(state, requestId, async (lock) => {
     disableHostAkmSharing(state);
+    // The mount source changed; only a recreate picks that up.
+    await activateStack(state, { kind: 'services', services: ['assistant'] }, {}, { lock });
     return jsonResponse(200, getHostAkmSharingStatus(state), requestId);
   });
 };

--- a/packages/ui/src/routes/api/host/akm/host-sharing/server.vitest.ts
+++ b/packages/ui/src/routes/api/host/akm/host-sharing/server.vitest.ts
@@ -18,13 +18,16 @@ vi.mock('@openpalm/lib', async (importOriginal) => {
 	return {
 		...original,
 		enableHostAkmSharing: vi.fn(() => undefined),
+		// The toggle APPLIES: OP_HOST_AKM_STASH is a bind-mount source, so only a
+		// recreate can change it. Stubbed so the route can be tested without Docker.
+		activateStack: vi.fn(async () => ({ ok: true })),
 		disableHostAkmSharing: vi.fn(() => undefined),
 		getHostAkmSharingStatus: vi.fn(() => ({ enabled: true, hostStashPath: '/home/u/akm' })),
 	};
 });
 
 import { GET, PUT, DELETE } from './+server.js';
-import { enableHostAkmSharing, disableHostAkmSharing, getHostAkmSharingStatus } from '@openpalm/lib';
+import { activateStack, enableHostAkmSharing, disableHostAkmSharing, getHostAkmSharingStatus } from '@openpalm/lib';
 
 let rootDir = '';
 let originalHome: string | undefined;
@@ -88,6 +91,13 @@ describe('PUT /api/host/akm/host-sharing', () => {
 		const res = await PUT(makeEvent('PUT', {}));
 		expect(res.status).toBe(200);
 		expect(enableHostAkmSharing).toHaveBeenCalledWith(expect.anything());
+		// Recreates the assistant — `restart` cannot change a mount source.
+		expect(activateStack).toHaveBeenCalledWith(
+			expect.anything(),
+			{ kind: 'services', services: ['assistant'] },
+			{},
+			expect.anything(),
+		);
 		expect(await res.json()).toMatchObject({ enabled: true, hostStashPath: '/home/u/akm' });
 	});
 

--- a/packages/ui/src/routes/api/setup/complete/+server.ts
+++ b/packages/ui/src/routes/api/setup/complete/+server.ts
@@ -89,13 +89,15 @@ export const POST: RequestHandler = async (event) => {
       // deploy. Returning ok:true here used to leave the client polling the
       // deploy state forever (it never starts). Surface a structured,
       // actionable error instead (#464).
-      return errorResponse(
-        503,
-        "docker_unavailable",
-        "Docker isn't running. Start Docker Desktop or OrbStack, then try again.",
-        {},
-        requestId,
-      );
+      // Route the daemon's own stderr through the shared mapper instead of
+      // asserting "Docker isn't running". It distinguishes not-installed,
+      // permission-denied and actually-stopped — and the first two are the
+      // cases where telling the operator to start Docker is a dead end,
+      // because Docker IS running and the real remedy (install it, or add
+      // your user to the docker group) never reaches them. mapDockerError is
+      // already imported here and already used on the catch path below.
+      const mapped = mapDockerError(dockerCheck.stderr ?? '');
+      return errorResponse(503, mapped.code, mapped.message, {}, requestId);
     }
   }
 

--- a/packages/ui/src/routes/api/setup/retry-deploy/+server.ts
+++ b/packages/ui/src/routes/api/setup/retry-deploy/+server.ts
@@ -1,5 +1,5 @@
 import { json } from '@sveltejs/kit';
-import { checkDocker, isSetupComplete, resolveOpenPalmHome } from '@openpalm/lib';
+import { checkDocker, isSetupComplete, mapDockerError, resolveOpenPalmHome } from '@openpalm/lib';
 import { getState } from '$lib/server/state.js';
 import { getDeployState, startDeploy } from '$lib/server/setup-deploy.js';
 import { errorResponse, getRequestId } from '$lib/server/helpers.js';
@@ -19,7 +19,11 @@ export const POST: RequestHandler = async (event) => {
 
   const docker = await checkDocker();
   if (!docker.ok) {
-    return errorResponse(503, 'docker_unavailable', "Docker isn't running. Start Docker, then retry deploy.", {}, requestId);
+    // Same reasoning as setup/complete: the mapper tells not-installed and
+    // permission-denied apart from actually-stopped, and only the third is
+    // fixed by starting Docker.
+    const mapped = mapDockerError(docker.stderr ?? '');
+    return errorResponse(503, mapped.code, mapped.message, {}, requestId);
   }
 
   if (current.deploying) {


### PR DESCRIPTION
First stabilization cycle. Four findings I verified myself from the audit. Every change **subtracts**: a bespoke error string replaced by an existing shared mapper, an impossible instruction replaced by doing the work, a generic message replaced by the real one, and a claim deleted that no longer describes anything.

## Docker preflight named the wrong problem

`setup/complete` and `setup/retry-deploy` asserted *"Docker isn't running. Start Docker Desktop or OrbStack"* for every `checkDocker()` failure and discarded the daemon's stderr — while `mapDockerError`, which distinguishes not-installed / permission-denied / actually-stopped, **was imported in the same file and used 47 lines above**.

A Linux user not in the `docker` group completes the whole wizard, clicks Install, and is told to start Docker that is already running. No next action. Both paths now route through the mapper; no new code.

## Host AKM sharing asked for a restart that cannot work

`OP_HOST_AKM_STASH` is the **source** of a bind mount (`core.compose.yml:217`), so only a recreate changes it. The card said *"Takes effect after the next stack restart"*, and every restart affordance is `compose restart`, which reuses existing mounts. Flip → Enabled → restart → still the empty-dir fallback, no error.

The toggle now recreates the assistant through the same `activateStack` primitive `access-apply.ts` already uses for this exact class, and the instruction is **deleted** rather than reworded.

## The card advertised an import that does not happen

It claimed enabling *"also imports your host LLM and agent connection profiles"*. That import was removed when OpenPalm stopped reading the host's akm config; the sentence outlived it. Deleted.

To be explicit, since this caused confusion: importing host **provider credentials** is a different, working feature — `auth.json` + `opencode.json` copy, live push to OpenCode, then `restartProviderConsumers`. Verified against this machine's real host config: `{ credentialCount: 2 }`. It remains available from Connections and the setup wizard and was never touched.

## Two half-fixes finished

- `/api/host/akm/health` read only `stdout` and returned `"assistant AKM unavailable"`, discarding the `stderr` that names the bad key. Second copy of a flattening that already cost a debugging session; two sibling routes do it right.
- `stripRetiredAkmConfigKeys` swept only the assistant's config. Paperclip runs its own akm against `config/paperclip/akm/config.json`, seeded once and never rewritten — the identical `INVALID_CONFIG_FILE` was still waiting there. Confirmed the historical seed had no `configVersion`.

## Verification

- `bun run check` — 0 errors, 0 warnings
- `packages/lib` — 1505 pass (incl. new paperclip-sweep tests)
- UI server — 1733 pass (host-sharing route tests now pin the recreate)
- `bun run lint` — back to the single pre-existing `install.ts` warning

Not verified by execution: the Docker permission-denied path (I did not degrade this machine's docker socket) — the change is a pure re-route into a mapper with its own test coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)