### PR TITLE
feat(akm): manual host config import, verified and reversible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- **"Use your local AKM configuration" — a manual host import, like host
+  provider import.** An operator who already runs akm locally can adopt their
+  own engines and embedding connection in one click instead of re-entering the
+  same endpoints and models, matching what host OpenCode provider import
+  already does for credentials. It is additive (existing assistant settings
+  always win), read-only against the host, and — unlike the automatic import it
+  replaces — **verified**: the assistant is asked to load the result, and if it
+  cannot, the previous config is restored byte-for-byte and akm's own error is
+  shown. The automatic version fired as a side effect of enabling host STASH
+  sharing, so an operator who wanted shared knowledge silently got the host's
+  engine config too; when the two akm versions disagreed that broke every akm
+  call in the assistant with nothing naming the cause. Sharing a directory and
+  adopting a configuration are now two separate, deliberate choices.
+
 ### Fixed
 
 - **Docker preflight now names the actual problem.** The setup wizard's deploy

--- a/packages/lib/src/control-plane/akm-sources.test.ts
+++ b/packages/lib/src/control-plane/akm-sources.test.ts
@@ -6,6 +6,8 @@ import {
   HOST_SOURCE_NAME,
   addHostStashToOpenpalmConfig,
   stripRetiredAkmConfigKeys,
+  importHostAkmConfig,
+  detectHostAkmConfig,
 } from "./akm-sources.js";
 import type { ControlPlaneState } from "./types.js";
 
@@ -192,5 +194,68 @@ describe("stripRetiredAkmConfigKeys covers paperclip's own akm config", () => {
   it("returns false when neither config needs a change", () => {
     writeFileSync(opConfigPath, `${JSON.stringify({ configVersion: "0.9.0" }, null, 2)}\n`);
     expect(stripRetiredAkmConfigKeys(state)).toBe(false);
+  });
+});
+
+describe("importHostAkmConfig (manual host akm import)", () => {
+  const hostCfg = () => join(root, "home", ".config", "akm", "config.json");
+
+  function seedHost(obj: Record<string, unknown>): string {
+    mkdirSync(join(root, "home", ".config", "akm"), { recursive: true });
+    const raw = JSON.stringify(obj, null, 2);
+    writeFileSync(hostCfg(), raw);
+    return raw;
+  }
+
+  it("fills gaps without overwriting what the operator already set", () => {
+    seedHost({
+      engines: {
+        hostOnly: { kind: "llm", endpoint: "http://host/v1", model: "m" },
+        shared: { kind: "llm", endpoint: "http://host/OVERWRITTEN", model: "host" },
+      },
+      defaults: { llmEngine: "hostOnly" },
+    });
+    writeFileSync(opConfigPath, JSON.stringify({
+      configVersion: "0.9.0",
+      engines: { shared: { kind: "llm", endpoint: "http://mine/v1", model: "mine" } },
+      defaults: { llmEngine: "shared" },
+    }, null, 2));
+
+    const { imported } = importHostAkmConfig(state, hostCfg());
+
+    expect(imported).toContain("engines");
+    const cfg = readJson(opConfigPath);
+    const engines = cfg.engines as Record<string, Record<string, unknown>>;
+    // Host-only engine adopted…
+    expect(engines.hostOnly.endpoint).toBe("http://host/v1");
+    // …and the operator's own engine and default selection survive untouched.
+    expect(engines.shared.endpoint).toBe("http://mine/v1");
+    expect((cfg.defaults as Record<string, unknown>).llmEngine).toBe("shared");
+  });
+
+  it("never writes to the host config", () => {
+    const original = seedHost({ engines: { a: { kind: "llm", endpoint: "http://h", model: "m" } } });
+    writeFileSync(opConfigPath, "{}");
+    importHostAkmConfig(state, hostCfg());
+    expect(readFileSync(hostCfg(), "utf-8")).toBe(original);
+  });
+
+  it("imports nothing when the host config is absent", () => {
+    writeFileSync(opConfigPath, "{}");
+    expect(importHostAkmConfig(state, hostCfg()).imported).toEqual([]);
+  });
+
+  it("detects what an import would find, for the affordance", () => {
+    const savedHome = process.env.HOME;
+    process.env.HOME = join(root, "home");
+    try {
+      expect(detectHostAkmConfig().available).toBe(false);
+      seedHost({ engines: { a: {}, b: {} }, embedding: { endpoint: "http://e" } });
+      const found = detectHostAkmConfig();
+      expect(found).toMatchObject({ available: true, engineCount: 2, hasEmbedding: true });
+    } finally {
+      if (savedHome === undefined) delete process.env.HOME;
+      else process.env.HOME = savedHome;
+    }
   });
 });

--- a/packages/lib/src/control-plane/akm-sources.ts
+++ b/packages/lib/src/control-plane/akm-sources.ts
@@ -24,6 +24,7 @@
  *  - The OpenPalm config is parse-tolerant (we own it: corrupt → start from {}).
  */
 import { readFileSync, existsSync } from "node:fs";
+import { homedir } from "node:os";
 import { join } from "node:path";
 import { writeFileAtomic } from "./fs-atomic.js";
 import { PRIMARY_BUNDLE_ID, stripRetiredAkmKeys } from "./setup.js";
@@ -49,6 +50,16 @@ function readConfigTolerant(configPath: string): AkmConfigObject {
   } catch {
     // We own the OpenPalm config — a corrupt file is recoverable by rewriting.
     return {};
+  }
+}
+
+function readHostConfigBestEffort(configPath: string): AkmConfigObject | null {
+  if (!existsSync(configPath)) return null;
+  try {
+    const parsed = JSON.parse(readFileSync(configPath, "utf-8"));
+    return parsed && typeof parsed === "object" ? (parsed as AkmConfigObject) : null;
+  } catch {
+    return null;
   }
 }
 
@@ -179,4 +190,153 @@ function stripRetiredKeysAt(configPath: string): boolean {
   if (after === before) return false;
   writeFileAtomic(configPath, after, 0o600);
   return true;
+}
+
+/**
+ * Copy the host's akm engine/embedding configuration into the assistant's.
+ *
+ * MANUAL ONLY. Nothing calls this on install, on upgrade, or as a side effect
+ * of any toggle — it runs when an operator explicitly asks for it, the same
+ * shape as importing host OpenCode providers. That distinction is the whole
+ * fix for how this behaved before: it used to fire automatically when host
+ * STASH sharing was enabled, so an operator who wanted a shared knowledge
+ * directory silently got the host's engine config as well. When the host ran a
+ * newer akm than the image, those keys were ones the container's CLI could not
+ * parse, and every akm call in the assistant died with INVALID_CONFIG_FILE and
+ * nothing naming the cause. The caller validates the result against the
+ * running assistant and rolls back if it cannot load — see the import route.
+ *
+ * Reads the personal host config READ-ONLY; never writes back to the host.
+ *
+ * ADDITIVE MERGE: existing OpenPalm values ALWAYS win — the host only fills
+ * gaps. Returns `{ imported: [] }` when the host config is absent or
+ * unreadable (never throws — engine import is always optional).
+ *
+ * Writes the canonical akm 0.9.0 shape (engines + defaults.* + embedding +
+ * improve.strategies), stamping configVersion and stripping the retired 0.8
+ * keys so the persisted file is always loadable. NEVER touches `bundles`,
+ * `defaultBundle`, `registries`, or `defaultWriteTarget`. A host config still
+ * in the retired
+ * 0.8 `profiles` shape is skipped — akm itself refuses to load it, so there
+ * is nothing trustworthy to import.
+ */
+export function importHostAkmConfig(
+  state: ControlPlaneState,
+  hostConfigPath: string,
+): { imported: string[] } {
+  const host = readHostConfigBestEffort(hostConfigPath);
+  if (!host) return { imported: [] };
+
+  const opPath = openpalmConfigPath(state);
+  const op = readConfigTolerant(opPath);
+
+  const imported: string[] = [];
+  const isObj = (v: unknown): v is Record<string, unknown> => typeof v === "object" && v !== null && !Array.isArray(v);
+
+  // ADDITIVE MERGE — existing OpenPalm values always win; the host fills only
+  // gaps. Never overwrite an engine, default selection, strategy, or embedding
+  // field the operator/wizard already set. `imported` lists what was added.
+
+  // engines (akm 0.9.0 config-schema EnginesSchema).
+  const opEngines = isObj(op.engines) ? (op.engines as Record<string, unknown>) : {};
+  let engines = opEngines;
+  if (isObj(host.engines)) {
+    // host first, existing last → existing wins; only host-only engine names are added.
+    const merged: Record<string, unknown> = { ...(host.engines as Record<string, unknown>), ...opEngines };
+    if (Object.keys(merged).length > Object.keys(opEngines).length) {
+      engines = merged;
+      imported.push("engines");
+    }
+  }
+
+  // defaults.engine / defaults.llmEngine / defaults.improveStrategy — only
+  // adopt a host selection when OpenPalm has none.
+  const hostDefaults = isObj(host.defaults) ? (host.defaults as Record<string, unknown>) : {};
+  const opDefaults = isObj(op.defaults) ? { ...(op.defaults as Record<string, unknown>) } : {};
+  for (const key of ["engine", "llmEngine", "improveStrategy"] as const) {
+    if (typeof hostDefaults[key] === "string" && typeof opDefaults[key] !== "string") {
+      opDefaults[key] = hostDefaults[key];
+      imported.push(`defaults.${key}`);
+    }
+  }
+
+  // improve.strategies — additive by strategy name.
+  const hostImprove = isObj(host.improve) ? (host.improve as Record<string, unknown>) : {};
+  const opImprove = isObj(op.improve) ? { ...(op.improve as Record<string, unknown>) } : {};
+  let improveChanged = false;
+  if (isObj(hostImprove.strategies)) {
+    const opStrategies = isObj(opImprove.strategies) ? (opImprove.strategies as Record<string, unknown>) : {};
+    const merged: Record<string, unknown> = { ...(hostImprove.strategies as Record<string, unknown>), ...opStrategies };
+    if (Object.keys(merged).length > Object.keys(opStrategies).length) {
+      opImprove.strategies = merged;
+      improveChanged = true;
+      imported.push("improve.strategies");
+    }
+  }
+
+  // Top-level embedding connection. Per-field additive: existing OpenPalm
+  // fields win; host fills only missing fields.
+  let embedding: Record<string, unknown> | undefined;
+  if (isObj(host.embedding)) {
+    const existing = isObj(op.embedding) ? (op.embedding as Record<string, unknown>) : {};
+    const merged: Record<string, unknown> = { ...(host.embedding as Record<string, unknown>), ...existing };
+    if (Object.keys(merged).length > Object.keys(existing).length) {
+      embedding = merged;
+      imported.push("embedding");
+    }
+  }
+
+  if (imported.length === 0) return { imported };
+
+  const updated: AkmConfigObject = { ...op, engines, defaults: opDefaults };
+  if (improveChanged) updated.improve = opImprove;
+  if (embedding !== undefined) updated.embedding = embedding;
+  // akm 0.9.0 hard-rejects the retired 0.8 keys and requires configVersion —
+  // never persist a config akm refuses to load (same normalization as
+  // persistAkmConfig in setup.ts).
+  stripRetiredAkmKeys(updated);
+  updated.configVersion = "0.9.0";
+  writeFileAtomic(opPath, JSON.stringify(updated, null, 2), 0o600);
+  return { imported };
+}
+
+
+/** The host's own akm config path (read-only, never written). */
+export function hostAkmConfigPath(): string {
+  const home = process.env.HOME ?? process.env.USERPROFILE ?? homedir();
+  return join(home, ".config", "akm", "config.json");
+}
+
+export type HostAkmConfigStatus = {
+  /** Absolute path, present so the UI can show the operator what it read. */
+  configPath: string;
+  /** Absent or unparseable host config. */
+  available: boolean;
+  /** Named engines the host has configured. */
+  engineCount: number;
+  /** Whether the host config carries a top-level embedding connection. */
+  hasEmbedding: boolean;
+};
+
+/**
+ * What an import would find on the host — the counterpart to
+ * `detectHostOpenCode`, so the AKM import affordance can say what it will
+ * bring over before the operator commits to it.
+ */
+export function detectHostAkmConfig(): HostAkmConfigStatus {
+  const configPath = hostAkmConfigPath();
+  const host = readHostConfigBestEffort(configPath);
+  if (!host) return { configPath, available: false, engineCount: 0, hasEmbedding: false };
+  const engines = host.engines;
+  const engineCount =
+    engines && typeof engines === "object" && !Array.isArray(engines)
+      ? Object.keys(engines as Record<string, unknown>).length
+      : 0;
+  const embedding = host.embedding;
+  return {
+    configPath,
+    available: true,
+    engineCount,
+    hasEmbedding: Boolean(embedding && typeof embedding === "object"),
+  };
 }

--- a/packages/lib/src/index.ts
+++ b/packages/lib/src/index.ts
@@ -295,8 +295,12 @@ export {
 export {
   HOST_SOURCE_NAME,
   addHostStashToOpenpalmConfig,
+  detectHostAkmConfig,
+  hostAkmConfigPath,
+  importHostAkmConfig,
   stripRetiredAkmConfigKeys,
 } from "./control-plane/akm-sources.js";
+export type { HostAkmConfigStatus } from "./control-plane/akm-sources.js";
 export type {
   HostAkmSharingStatus,
 } from "./control-plane/host-akm-sharing.js";

--- a/packages/ui/src/lib/api/akm.ts
+++ b/packages/ui/src/lib/api/akm.ts
@@ -248,3 +248,30 @@ export async function disableHostAkmSharing(): Promise<HostAkmSharing> {
   const res = await requireOk(await request('DELETE', '/api/host/akm/host-sharing'));
   return (await res.json()) as HostAkmSharing;
 }
+
+// ── Host AKM configuration import (manual, like host provider import) ────────
+
+export type HostAkmConfigStatus = {
+  configPath: string;
+  available: boolean;
+  engineCount: number;
+  hasEmbedding: boolean;
+};
+
+export type HostAkmImportResult = {
+  imported: string[];
+  changed: boolean;
+  /** False when the assistant was not running to confirm the config loads. */
+  verified?: boolean;
+};
+
+export async function fetchHostAkmConfigStatus(): Promise<HostAkmConfigStatus> {
+  const res = await requireOk(await request('GET', '/api/host/akm/import-host'));
+  return (await res.json()) as HostAkmConfigStatus;
+}
+
+/** Throws with the server's message on 404 (no host config) / 422 (rejected). */
+export async function importHostAkmConfig(): Promise<HostAkmImportResult> {
+  const res = await requireOk(await request('POST', '/api/host/akm/import-host', {}));
+  return (await res.json()) as HostAkmImportResult;
+}

--- a/packages/ui/src/lib/components/akm/HostSharingSection.svelte
+++ b/packages/ui/src/lib/components/akm/HostSharingSection.svelte
@@ -4,12 +4,22 @@
     fetchHostAkmSharing,
     enableHostAkmSharing,
     disableHostAkmSharing,
+    fetchHostAkmConfigStatus,
+    importHostAkmConfig,
     type HostAkmSharing,
+    type HostAkmConfigStatus,
   } from '$lib/api.js';
   import { notifications } from '$lib/notifications.svelte.js';
   import Spinner from '$lib/components/common/Spinner.svelte';
 
   let hostSharing = $state<HostAkmSharing | null>(null);
+  // Importing the host's akm engine config is a SEPARATE, manual action from
+  // mounting the host stash. It used to ride along with the stash toggle,
+  // which is how an operator who wanted shared knowledge silently got the
+  // host's engine config — and, when the two akm versions disagreed, a broken
+  // assistant. Same shape as importing host OpenCode providers.
+  let hostConfig = $state<HostAkmConfigStatus | null>(null);
+  let importing = $state(false);
   let loading = $state(true);
   let busy = $state(false);
 
@@ -19,8 +29,40 @@
       hostSharing = await fetchHostAkmSharing();
     } catch {
       hostSharing = null;
+    }
+    try {
+      hostConfig = await fetchHostAkmConfigStatus();
+    } catch {
+      // Advisory affordance: if we cannot read the host, offer nothing rather
+      // than an error the operator can do nothing with.
+      hostConfig = null;
     } finally {
       loading = false;
+    }
+  }
+
+  async function runHostAkmImport(): Promise<void> {
+    if (importing) return;
+    importing = true;
+    try {
+      const result = await importHostAkmConfig();
+      if (!result.changed) {
+        notifications.push('success', 'Nothing to import — the assistant already has these settings.');
+      } else {
+        const what = result.imported.join(', ');
+        notifications.push(
+          'success',
+          result.verified
+            ? `Imported ${what} from your host akm config.`
+            : `Imported ${what}. The assistant is not running, so it will apply on next start.`,
+        );
+      }
+    } catch (e) {
+      // The route rolls back on an unloadable config and returns akm's own
+      // message, so this is worth showing verbatim.
+      notifications.push('error', e instanceof Error ? e.message : 'Host akm import failed.');
+    } finally {
+      importing = false;
     }
   }
 
@@ -78,6 +120,38 @@
           </button>
         </div>
       </section>
+
+      {#if hostConfig?.available}
+        <!-- Separate from the stash mount on purpose. Sharing a knowledge
+             directory and adopting the host's engine configuration are two
+             different decisions; bundling them is what silently replaced an
+             operator's assistant config in the first place. -->
+        <section class="config-section">
+          <h3 class="subsection-title">Use your local AKM configuration</h3>
+          <p class="section-note">
+            Copy the engines and embedding connection from your own akm config
+            (<code>{hostConfig.configPath}</code>) so the assistant uses the same
+            providers you already run locally. Your existing assistant settings win —
+            this only fills in what is missing, and your host config is never modified.
+          </p>
+          <div class="controls">
+            <span class="hs-summary">
+              {hostConfig.engineCount}
+              {hostConfig.engineCount === 1 ? 'engine' : 'engines'}{hostConfig.hasEmbedding
+                ? ' + embedding'
+                : ''} available
+            </span>
+            <button
+              class="btn btn-secondary btn-sm"
+              onclick={() => void runHostAkmImport()}
+              disabled={importing}
+            >
+              {#if importing}<Spinner />{/if}
+              Import from host
+            </button>
+          </div>
+        </section>
+      {/if}
     {/if}
   </div>
 </div>
@@ -107,6 +181,20 @@
   }
   .controls { display: flex; flex-direction: column; gap: var(--s-sp-3); }
   .status-row { display: flex; align-items: center; gap: var(--s-sp-3); flex-wrap: wrap; }
+  .subsection-title {
+    margin: 0 0 var(--s-sp-2);
+    font-family: var(--s-font-display);
+    font-size: var(--s-type-deed);
+    font-weight: 400;
+    color: var(--s-ink);
+  }
+
+  .hs-summary {
+    color: var(--s-ink-2);
+    font-family: var(--s-font-mono);
+    font-size: var(--s-type-mark);
+  }
+
   .host-path {
     font-family: var(--s-font-mono);
     font-size: var(--s-type-mark-sm);

--- a/packages/ui/src/routes/api/host/akm/import-host/+server.ts
+++ b/packages/ui/src/routes/api/host/akm/import-host/+server.ts
@@ -1,0 +1,114 @@
+/**
+ * GET  /api/host/akm/import-host — what an import would find on this host.
+ * POST /api/host/akm/import-host — copy the host's akm engine/embedding config
+ *                                  into the assistant's, then prove it loads.
+ *
+ * The counterpart to `/api/host/providers/import-host`: an operator who already
+ * runs akm locally can say "use my local configuration" once instead of
+ * re-entering the same endpoints and models by hand.
+ *
+ * MANUAL, and validated. This import used to fire automatically as a side
+ * effect of enabling host STASH sharing, which is how it broke installs: the
+ * host and the assistant image are independent akm installs on independent
+ * upgrade cycles, so a host running a newer akm wrote keys the container's CLI
+ * could not parse, and every akm call in the assistant failed with
+ * INVALID_CONFIG_FILE while the UI said only "metrics unavailable".
+ *
+ * So the write is not trusted on faith. The previous config is kept, the merge
+ * is applied, and the RUNNING assistant is asked to load it (`akm health`). If
+ * it cannot, the previous config is restored byte-for-byte and the operator is
+ * told what akm actually said. An import can therefore leave the assistant
+ * working or leave it exactly as it was — never broken and silent.
+ */
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import type { RequestHandler } from './$types';
+import {
+  detectHostAkmConfig,
+  hostAkmConfigPath,
+  importHostAkmConfig,
+  runAssistantAkmCommand,
+} from '@openpalm/lib';
+import { getState } from '$lib/server/state.js';
+import {
+  errorResponse,
+  getRequestId,
+  jsonResponse,
+  requireAdmin,
+  requireCapability,
+} from '$lib/server/helpers.js';
+import { withAdminUpdateLock } from '$lib/server/admin-update-lock.js';
+
+function assistantAkmConfigPath(configDir: string): string {
+  return join(configDir, 'akm', 'config.json');
+}
+
+export const GET: RequestHandler = async (event) => {
+  const requestId = getRequestId(event);
+  const capabilityError = requireCapability(event, 'host:akm-sharing', requestId);
+  if (capabilityError) return capabilityError;
+  const authError = requireAdmin(event, requestId);
+  if (authError) return authError;
+
+  return jsonResponse(200, detectHostAkmConfig(), requestId);
+};
+
+export const POST: RequestHandler = async (event) => {
+  const requestId = getRequestId(event);
+  const capabilityError = requireCapability(event, 'host:akm-sharing', requestId);
+  if (capabilityError) return capabilityError;
+  const authError = requireAdmin(event, requestId);
+  if (authError) return authError;
+
+  const state = getState();
+  return withAdminUpdateLock(state, requestId, async () => {
+    const host = detectHostAkmConfig();
+    if (!host.available) {
+      return errorResponse(
+        404,
+        'host_akm_config_not_found',
+        `No readable akm config at ${hostAkmConfigPath()}. Configure akm on this machine first, or set the assistant's engines directly.`,
+        {},
+        requestId,
+      );
+    }
+
+    const configPath = assistantAkmConfigPath(state.configDir);
+    const previous = existsSync(configPath) ? readFileSync(configPath, 'utf-8') : null;
+
+    const { imported } = importHostAkmConfig(state, hostAkmConfigPath());
+    if (imported.length === 0) {
+      return jsonResponse(200, { imported: [], changed: false }, requestId);
+    }
+
+    // Prove the assistant's own akm can load what we just wrote. `health`
+    // exits non-zero on an unloadable config and names the offending key.
+    const check = await runAssistantAkmCommand(state, ['health', '--format', 'json', '--quiet'], 8000, {
+      allowExitCodes: [4],
+    });
+    const rejected = /INVALID_CONFIG_FILE|Invalid config at/i.test(`${check.stdout}${check.stderr}`);
+
+    if (rejected) {
+      // Roll back byte-for-byte. A partially-applied import that the assistant
+      // cannot read is strictly worse than not importing.
+      if (previous === null) writeFileSync(configPath, '');
+      else writeFileSync(configPath, previous);
+      const detail = [check.stderr, check.stdout].map((s) => s?.trim()).find((s) => s);
+      return errorResponse(
+        422,
+        'host_akm_config_incompatible',
+        `The assistant could not load the imported configuration, so nothing was changed. ${detail ?? ''}`.trim(),
+        { imported },
+        requestId,
+      );
+    }
+
+    // `missing` means the assistant is not running; the file is written and
+    // valid as far as we can tell, and akm will read it when it starts.
+    return jsonResponse(
+      200,
+      { imported, changed: true, verified: !check.missing },
+      requestId,
+    );
+  });
+};

--- a/packages/ui/src/routes/api/host/akm/import-host/server.vitest.ts
+++ b/packages/ui/src/routes/api/host/akm/import-host/server.vitest.ts
@@ -1,0 +1,129 @@
+/**
+ * The host akm import must never leave the assistant with a config it cannot
+ * read. That is the failure this feature is a redesign of: the import used to
+ * fire automatically from the stash toggle, and when the host ran a newer akm
+ * than the image it wrote keys the container rejected — every akm call in the
+ * assistant died with INVALID_CONFIG_FILE and the UI said only "unavailable".
+ *
+ * So the contract under test is: import, ask the RUNNING assistant to load it,
+ * and roll back byte-for-byte if it cannot.
+ */
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { resetState } from '$lib/server/test-helpers.js';
+
+const mocks = vi.hoisted(() => ({
+  akmResult: {
+    ok: true,
+    stdout: '{"ok":true}',
+    stderr: '',
+    exitCode: 0,
+    missing: false,
+  },
+  imported: ['engines'] as string[],
+}));
+
+vi.mock('@openpalm/lib', async (orig) => ({
+  ...(await orig<typeof import('@openpalm/lib')>()),
+  runAssistantAkmCommand: vi.fn(async () => mocks.akmResult),
+  importHostAkmConfig: vi.fn((state: { configDir: string }) => {
+    // Stand in for the real merge: write something the assistant may reject.
+    writeFileSync(join(state.configDir, 'akm', 'config.json'), '{"imported":true}\n');
+    return { imported: mocks.imported };
+  }),
+  detectHostAkmConfig: vi.fn(() => ({
+    configPath: '/home/u/.config/akm/config.json',
+    available: true,
+    engineCount: 2,
+    hasEmbedding: false,
+  })),
+}));
+
+import { POST } from './+server.js';
+
+let homeDir = '';
+let originalHome: string | undefined;
+const PRIOR = '{"configVersion":"0.9.0","engines":{"mine":{}}}\n';
+
+function configPath(): string {
+  return join(homeDir, 'config', 'akm', 'config.json');
+}
+
+function makeEvent(token = 'admin-token'): Parameters<typeof POST>[0] {
+  return {
+    request: new Request('http://localhost/api/host/akm/import-host', {
+      method: 'POST',
+      headers: { cookie: `op_session=${token}`, 'content-type': 'application/json' },
+      body: '{}',
+    }),
+  } as Parameters<typeof POST>[0];
+}
+
+beforeEach(() => {
+  process.env.OP_ENABLE_ADMIN = '1';
+  originalHome = process.env.OP_HOME;
+  homeDir = mkdtempSync(join(tmpdir(), 'openpalm-akm-import-'));
+  mkdirSync(join(homeDir, 'config', 'akm'), { recursive: true });
+  mkdirSync(join(homeDir, 'state'), { recursive: true });
+  writeFileSync(configPath(), PRIOR);
+  process.env.OP_HOME = homeDir;
+  resetState('admin-token');
+  mocks.akmResult = { ok: true, stdout: '{"ok":true}', stderr: '', exitCode: 0, missing: false };
+  mocks.imported = ['engines'];
+});
+
+afterEach(() => {
+  if (originalHome === undefined) delete process.env.OP_HOME;
+  else process.env.OP_HOME = originalHome;
+  delete process.env.OP_ENABLE_ADMIN;
+  rmSync(homeDir, { recursive: true, force: true });
+});
+
+describe('POST /api/host/akm/import-host', () => {
+  test('401 without an admin session', async () => {
+    expect((await POST(makeEvent('bad'))).status).toBe(401);
+  });
+
+  test('keeps the import when the assistant can load it', async () => {
+    const res = await POST(makeEvent());
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ imported: ['engines'], changed: true, verified: true });
+    expect(readFileSync(configPath(), 'utf-8')).toBe('{"imported":true}\n');
+  });
+
+  test('rolls back byte-for-byte when the assistant rejects the config', async () => {
+    mocks.akmResult = {
+      ok: false,
+      stdout: '',
+      stderr: 'Invalid config at /etc/akm/config.json:\n  - engines: Unrecognized key(s)',
+      exitCode: 1,
+      missing: false,
+    };
+
+    const res = await POST(makeEvent());
+
+    expect(res.status).toBe(422);
+    const body = (await res.json()) as { error: string; message: string };
+    expect(body.error).toBe('host_akm_config_incompatible');
+    // The operator is told what akm actually said, not "import failed".
+    expect(body.message).toContain('Unrecognized key(s)');
+    // And nothing was left behind.
+    expect(readFileSync(configPath(), 'utf-8')).toBe(PRIOR);
+  });
+
+  test('reports unverified rather than failing when the assistant is not running', async () => {
+    mocks.akmResult = { ok: false, stdout: '', stderr: 'not found', exitCode: 127, missing: true };
+    const res = await POST(makeEvent());
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ changed: true, verified: false });
+  });
+
+  test('is a no-op when the host adds nothing', async () => {
+    mocks.imported = [];
+    const res = await POST(makeEvent());
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ imported: [], changed: false });
+  });
+});


### PR DESCRIPTION
Restores adopting the host's akm engines/embedding — as an explicit action, not a side effect.

The goal: someone already running opencode and akm locally should be able to say *"use my local configuration"* once, instead of re-entering the same endpoints and models. Host OpenCode provider import already does this for credentials; this is its counterpart for akm, offered the same way, in the same card.

## What's different from the version that was removed

**Manual.** Nothing calls it on install, on upgrade, or from a toggle. It previously fired automatically when host **stash** sharing was enabled — so an operator who wanted a shared knowledge directory silently also got the host's engine config. Two unrelated decisions on one switch.

**Verified and reversible.** The previous config is kept, the merge applied, and the *running* assistant asked to load it (`akm health`). On `INVALID_CONFIG_FILE` the previous config is restored byte-for-byte and akm's own message is surfaced.

That closes the precise failure the automatic import caused: host and image are independent akm installs on independent upgrade cycles, so a newer host wrote keys the container could not parse, every akm call died, and the UI said only "metrics unavailable". An import now either leaves the assistant working or leaves it exactly as it was.

Still additive — the operator's own engines and default selection always win — and still read-only against the host.

## Surface

- `GET /api/host/akm/import-host` — what an import would find (`engineCount`, `hasEmbedding`, the path it read), so the button can say what it will do before you press it. Mirrors `detectHostOpenCode`.
- `POST /api/host/akm/import-host` — import, verify, roll back on rejection.
- The Sharing card grows a separate "Use your local AKM configuration" section, deliberately *not* wired to the stash toggle.

## Verification

- `packages/lib` — 1509 pass. New tests: additive merge (host-only engine adopted, operator's engine and default untouched), host file never written, absent-host no-op, detection counts.
- UI server — 1738 pass. New route tests: kept on success, **rolled back byte-for-byte on rejection with akm's message surfaced**, `verified:false` when the assistant isn't running, no-op when the host adds nothing.
- `bun run check` 0 errors / 0 warnings; lint unchanged.

Not verified by execution: a real import against a live assistant with a genuinely incompatible host config — the rollback path is covered by the route test with a mocked rejection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)