### PR TITLE
fix: apply credential changes where they are consumed, and run tier 4 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -334,6 +334,16 @@ jobs:
       - name: Run client-only PWA acceptance tests (production build + Chromium)
         run: bun run ui:test:pwa
 
+      - name: Run self-contained browser tests (tier 4)
+        # Tier 4 was documented in the release runbook but run by nobody: CI had
+        # no Playwright lane for it, so a PR breaking a browser-level path
+        # merged green and the gap was only caught if a human remembered the
+        # checklist. It needs no Docker — the mocked lane serves its own UI —
+        # and the browsers are already installed two steps above, so there is
+        # no reason it was not here. Tier 5 (live stack) still is not covered;
+        # it needs a daemon and images.
+        run: bun run ui:test:e2e:mocked
+
   electron-tests:
     name: Electron unit tests (Vitest)
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,39 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- **Connecting or disconnecting a provider now reaches the guardian.** The
+  credential routes mutated auth through the assistant's OpenCode API and
+  stopped there. The guardian receives `auth.json` as a Compose secret and
+  copies it into place at boot, so until it restarts it keeps serving every
+  portal with the credentials it started with — connect a provider and
+  chat/api/discord/slack still failed with no credentials; **disconnect one and
+  the revoked credential stayed live behind them indefinitely** while the UI
+  said disconnected. The guardian is now restarted after a credential change,
+  and only the guardian: the assistant was mutated through its own API, so its
+  running auth store is already current and restarting it would drop live chats
+  for nothing. Best-effort — the save is reported as the success it was, with a
+  warning if the restart failed.
+- **Saving addon credentials applies them.** Every schema key reaches its
+  container through Compose interpolation or a Compose secret, both fixed at
+  container-create time, but only four keys triggered a recreate. The rest were
+  written on the reasoning that the operator recreates the container "when
+  ready" — an affordance that does not exist, since Containers offers only
+  start/stop/restart and `compose restart` reuses the existing env, ports and
+  secrets. Rotating a leaked bot token, narrowing an allow-list, or changing
+  `OP_PAPERCLIP_PORT` reported success and left the old value serving. The
+  addon's own container is now recreated whenever a key actually changed,
+  resolved to the selected variant.
+
+### Changed
+
+- **CI runs the self-contained browser tests (tier 4).** They were in the
+  release runbook and in no automated lane, so a PR breaking a browser-level
+  path merged green unless a human remembered the checklist. They need no
+  Docker and the browsers were already installed for the job. Tier 5 (live
+  stack) is still uncovered.
+
 ### Added
 
 - **"Use your local AKM configuration" — a manual host import, like host

--- a/packages/lib/src/index.ts
+++ b/packages/lib/src/index.ts
@@ -63,6 +63,7 @@ export {
   BUILTIN_ADDON_IDS,
   EXPERIMENTAL_ADDON_IDS,
   GUARDIAN_INGRESS_ADDON_IDS,
+  hasGuardianIngressAddon,
   isExperimentalAddon,
 } from "./control-plane/addon-ids.js";
 export {

--- a/packages/ui/src/routes/api/host/addons/[name]/credentials/+server.ts
+++ b/packages/ui/src/routes/api/host/addons/[name]/credentials/+server.ts
@@ -29,6 +29,7 @@ import {
   createLogger,
   getAddonProfiles,
   getAddonProfileSelection,
+  getAddonServiceNames,
   getRegistryAddonConfig,
   listAvailableAddonIds,
   readStackSecretEnv,
@@ -127,6 +128,22 @@ function resolveVoiceScopeService(homeDir: string, service: string): string {
   if (!selected) return service;
   const services = getAddonProfiles(homeDir, "voice").find((p) => p.id === selected)?.services;
   return services?.[0] ?? service;
+}
+
+/**
+ * The addon's OWN container, resolved to the variant that is actually
+ * selected, or nothing when the addon has no container of its own.
+ *
+ * Deliberately one service, not the addon's whole declared set:
+ * `getAddonServiceNames('voice')` returns every variant (`voice`,
+ * `voice-cuda`, `voice-rocm`) because all three are declared under different
+ * profiles, and recreating all of them targets two services that are not up.
+ * The declared set is still consulted, so a name is never invented for an
+ * addon that has no container (`chat`, `api` — guardian serves those).
+ */
+function addonOwnServices(homeDir: string, name: string): string[] {
+  const resolved = resolveVoiceScopeService(homeDir, name);
+  return getAddonServiceNames(homeDir, name).includes(resolved) ? [resolved] : [];
 }
 
 export const GET: RequestHandler = async (event) => {
@@ -301,13 +318,21 @@ export const POST: RequestHandler = async (event) => {
       remoteWarning = remote.warning;
     }
 
-    // Most schema keys are read by the addon container alone, so persisting them
-    // IS the apply and the operator recreates that one container when ready.
-    // A few reach further — see ADDON_ENV_RECREATE_SCOPE — and for those a write
-    // with no apply is a setting that silently does nothing. Recreate exactly
-    // the services the key reaches (scoped to keys that actually CHANGED, see
-    // changedKeys above), under the lock we already hold, so compose rebuilds
-    // its file list and the affected entrypoints re-read the value.
+    // A save is an APPLY. Every schema key reaches its container through
+    // Compose interpolation or a Compose secret, both of which are fixed at
+    // container-CREATE time — so the addon's own services are recreated
+    // whenever a key actually changed.
+    //
+    // This used to stop at ADDON_ENV_RECREATE_SCOPE, a table of the four keys
+    // that reach OTHER services, on the reasoning that a key read by the addon
+    // alone is applied by "the operator recreating that one container when
+    // ready". There is no such affordance: Containers offers start / stop /
+    // restart, and `compose restart` reuses the existing env, ports and
+    // secrets. So rotating a Discord token, narrowing DISCORD_ALLOWED_GUILDS,
+    // or moving OP_PAPERCLIP_PORT wrote to disk, reported success, and left
+    // the old value serving — the leaked token still authenticating, the port
+    // still on its old number. The table now answers only "which OTHER
+    // services does this key reach"; the addon's own services are implied.
     const scope = [
       ...new Set([
         // The remote apply owns the complete scope for remote saves. The
@@ -316,9 +341,12 @@ export const POST: RequestHandler = async (event) => {
         // state. Other addons still use their schema-declared scope.
         ...(name === 'remote'
           ? []
-          : changedKeys.flatMap((key) =>
-              (ADDON_ENV_RECREATE_SCOPE[key] ?? []).map((svc) => resolveVoiceScopeService(state.homeDir, svc)),
-            )),
+          : [
+              ...(changedKeys.length > 0 ? addonOwnServices(state.homeDir, name) : []),
+              ...changedKeys.flatMap((key) =>
+                (ADDON_ENV_RECREATE_SCOPE[key] ?? []).map((svc) => resolveVoiceScopeService(state.homeDir, svc)),
+              ),
+            ]),
         ...remoteServices,
       ]),
     ];

--- a/packages/ui/src/routes/api/host/addons/[name]/credentials/server.vitest.ts
+++ b/packages/ui/src/routes/api/host/addons/[name]/credentials/server.vitest.ts
@@ -180,8 +180,9 @@ describe('@boolean schema field (OP_VOICE_LAN_ACCESS)', () => {
 	// scope must derive from keys whose value actually CHANGED — an unchanged
 	// OP_VOICE_LAN_ACCESS round-tripped alongside a cosmetic edit must not
 	// force-recreate voice+assistant (killing live OpenCode sessions).
-	test('posting an unchanged OP_VOICE_LAN_ACCESS alongside a changed cosmetic key recreates nothing', async () => {
+	test('posting an unchanged OP_VOICE_LAN_ACCESS alongside a changed cosmetic key recreates only the addon', async () => {
 		writeRemoteStackEnv('OP_VOICE_LAN_ACCESS=true\nOP_VOICE_KOKORO_VOICE=bf_isabella\n');
+		activateStackMock.mockResolvedValue({ ok: true, started: ['voice'], failed: [] });
 
 		const res = await POST(
 			makePostEvent({ OP_VOICE_LAN_ACCESS: 'true', OP_VOICE_KOKORO_VOICE: 'am_michael' }, 'voice')
@@ -191,8 +192,14 @@ describe('@boolean schema field (OP_VOICE_LAN_ACCESS)', () => {
 		const body = (await res.json()) as { ok: boolean; updated: string[]; recreated: string[] };
 		expect(body.ok).toBe(true);
 		expect(body.updated).toContain('OP_VOICE_KOKORO_VOICE');
-		expect(body.recreated).toEqual([]);
-		expect(activateStackMock).not.toHaveBeenCalled();
+		// The cosmetic key changed, so voice is recreated to pick it up — but
+		// OP_VOICE_LAN_ACCESS did NOT change, so its wider scope (assistant) is
+		// still not dragged in. That narrowing is what this test guards.
+		expect(activateStackMock).toHaveBeenCalledTimes(1);
+		expect(activateStackMock.mock.calls[0]?.[1]).toMatchObject({
+			kind: 'services',
+			services: ['voice']
+		});
 		const after = readFileSync(join(homeDir, 'state', 'stack.env'), 'utf-8');
 		expect(after).toContain('OP_VOICE_KOKORO_VOICE=am_michael');
 	});
@@ -225,16 +232,20 @@ describe('@boolean schema field (OP_VOICE_LAN_ACCESS)', () => {
 		});
 	});
 
-	test('an ordinary schema field still saves with no compose apply at all', async () => {
-		// The guarantee that keeps the common path Docker-free: only keys listed in
-		// ADDON_ENV_RECREATE_SCOPE trigger a recreate, so a bot token or a model
-		// name saves exactly as before — 200, nothing recreated.
+	test('an ordinary schema field applies by recreating the addon container', async () => {
+		// A save is an APPLY. Every schema key reaches its container through
+		// Compose interpolation or a Compose secret, both fixed at create time,
+		// and there is no "recreate" affordance for the operator to reach for —
+		// so a bot token that saved without recreating left the OLD token
+		// authenticating while the drawer showed the new one as set.
+		activateStackMock.mockResolvedValue({ ok: true, started: ['discord'], failed: [] });
+
 		const res = await POST(makePostEvent({ DISCORD_APPLICATION_ID: '123456789' }, 'discord'));
 		expect(res.status).toBe(200);
 		const body = (await res.json()) as { ok: boolean; updated: string[]; recreated: string[] };
 		expect(body.ok).toBe(true);
 		expect(body.updated).toContain('DISCORD_APPLICATION_ID');
-		expect(body.recreated).toEqual([]);
+		expect(body.recreated).toContain('discord');
 	});
 });
 

--- a/packages/ui/src/routes/api/host/opencode/providers/[id]/auth/+server.ts
+++ b/packages/ui/src/routes/api/host/opencode/providers/[id]/auth/+server.ts
@@ -9,7 +9,14 @@ import {
   jsonBodyError,
   getOpenCodeClient,
 } from '$lib/server/helpers.js';
-import { createLogger } from '@openpalm/lib';
+import {
+  buildComposeOptions,
+  composeRestart,
+  createLogger,
+  hasGuardianIngressAddon,
+  listEnabledAddonIds,
+} from '@openpalm/lib';
+import { getState } from '$lib/server/state.js';
 
 const logger = createLogger('opencode.auth');
 
@@ -85,6 +92,38 @@ export const GET: RequestHandler = async (event) => {
   return jsonResponse(200, { status: 'pending', message: 'Waiting for authorization...' }, requestId);
 };
 
+/**
+ * Propagate a credential change to the guardian.
+ *
+ * Only the guardian. This route mutates credentials THROUGH the assistant's
+ * own OpenCode API, so the assistant's running auth store is already current
+ * and restarting it would drop live chats for nothing. The guardian is
+ * different: it receives `auth.json` as a Compose secret and copies it into
+ * place at boot (containers/guardian/entrypoint.sh), so until it restarts it
+ * keeps serving every portal with the credentials it started with.
+ *
+ * That is the security half. Disconnecting a provider left the revoked
+ * credential live behind chat/api/discord/slack indefinitely — the UI said
+ * disconnected and the portals kept working.
+ *
+ * Best-effort by design: the credential change itself already succeeded and
+ * must be reported as such. A failed restart is logged and surfaced as a
+ * warning on the response, never as a failure of the save.
+ */
+async function propagateToGuardian(requestId: string): Promise<string | undefined> {
+  const state = getState();
+  if (!hasGuardianIngressAddon(listEnabledAddonIds(state.homeDir))) return undefined;
+  try {
+    const result = await composeRestart(['guardian'], buildComposeOptions(state));
+    if (result.ok) return undefined;
+    logger.warn('guardian restart after credential change failed', { requestId, stderr: result.stderr });
+    return 'The credential was saved, but the guardian could not be restarted, so portals may still use the previous credentials until it restarts.';
+  } catch (err) {
+    logger.warn('guardian restart after credential change threw', { requestId, error: String(err) });
+    return 'The credential was saved, but the guardian could not be restarted, so portals may still use the previous credentials until it restarts.';
+  }
+}
+
 export const POST: RequestHandler = async (event) => {
   const requestId = getRequestId(event);
   const capabilityError = requireCapability(event, 'host:secrets', requestId);
@@ -130,7 +169,8 @@ export const POST: RequestHandler = async (event) => {
 
     logger.info('provider API key saved to OpenCode auth.json', { providerId, requestId });
 
-    return jsonResponse(200, { ok: true, mode: 'api_key' }, requestId);
+    const warning = await propagateToGuardian(requestId);
+    return jsonResponse(200, { ok: true, mode: 'api_key', ...(warning ? { warning } : {}) }, requestId);
   }
 
   if (mode === 'oauth') {
@@ -197,5 +237,6 @@ export const DELETE: RequestHandler = async (event) => {
 
   logger.info('provider credential removed via OpenCode /auth DELETE', { providerId, requestId });
 
-  return jsonResponse(200, { ok: true }, requestId);
+  const warning = await propagateToGuardian(requestId);
+  return jsonResponse(200, { ok: true, ...(warning ? { warning } : {}) }, requestId);
 };


### PR DESCRIPTION
Cycle three. Two more instances of **"a write is not an apply"**, plus the CI lane that would have caught them.

## Provider connect/disconnect never reached the guardian

Both routes mutate credentials through the assistant's OpenCode API and stop. The guardian receives `auth.json` as a Compose secret and **copies it into place at boot** (`containers/guardian/entrypoint.sh:35`), so until it restarts it serves every portal with the credentials it started with.

- Connect a provider → chat/api/discord/slack still report no credentials.
- **Disconnect one → the revoked credential keeps working behind them indefinitely**, while the UI says disconnected.

The second is a security gap, not an inconvenience.

Only the guardian is restarted. The assistant was mutated through its own API, so its auth store is already current, and restarting it would drop live chats for nothing. Best-effort: the credential change succeeded and is reported as such, with a `warning` when propagation failed.

## Addon credential saves did not apply

Every schema key reaches its container through Compose interpolation or a Compose secret — both fixed at container-**create** time — yet only the four keys in `ADDON_ENV_RECREATE_SCOPE` triggered a recreate. The rest relied on the comment's own reasoning: *"the operator recreates that one container when ready."* That affordance does not exist. Containers offers start/stop/restart, and `compose restart` reuses the existing env, ports and secrets.

So rotating a leaked bot token, narrowing `DISCORD_ALLOWED_GUILDS`, or moving `OP_PAPERCLIP_PORT` wrote to disk, reported success, and left the old value serving.

The addon's own container is now recreated whenever a key actually changed — **one** service, not the declared set. `getAddonServiceNames('voice')` returns every variant, and recreating `voice` / `voice-cuda` / `voice-rocm` together targets two services that are not up. An existing test caught that on my first attempt; the fix resolves to the selected variant and still consults the declared set so no name is invented for an addon with no container of its own (`chat`, `api`).

## CI runs tier 4

It was in the release runbook and in no automated lane — a PR breaking a browser-level path merged green unless a human remembered the checklist. It needs no Docker and the browsers were already installed for that job two steps earlier. Verified locally: 19 passed.

**Tier 5 (live stack) is still uncovered** — it needs a daemon and images, and I have not attempted it.

## Verification

- `bun run check` — 0 errors / 0 warnings
- `packages/lib` — 1509 pass
- UI server — 1738 pass, including updated contract tests for the new apply behaviour
- tier 4 — 19 passed locally
- lint — unchanged (one pre-existing `install.ts` warning)

Not verified by execution: the guardian restart against a live stack with portals enabled; the code path reuses `composeRestart` + `hasGuardianIngressAddon`, both already covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)