### PR TITLE
fix: stop shipping contributor instructions, and stop wiping system/ per launch

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -26,7 +26,6 @@ packages/*/.svelte-kit
 !packages/ui/build/**
 docs/
 *.md
-!AGENTS.md
 !containers/**/*.md
 !packages/**/*.md
 !.openpalm/**/*.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,38 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **The assistant no longer ships OpenPalm's contributor instructions as its
+  own.** The image baked the repository's root `AGENTS.md` — "all work must
+  comply with core-principles.md", commit conventions, the delivery checklist —
+  and the entrypoint seeded it into every operator's OpenCode config as global
+  agent instructions. Verified byte-identical on a real install. The image now
+  ships a user-facing default written for the operator's assistant.
+- **Every app launch no longer backs up and replaces the managed system tree.**
+  The entrypoint seeds `AGENTS.md` into `system/assistant`, which the skeleton
+  does not ship, so it read as a permanently "retired" file: `changed` was true
+  on every run, and each launch copied the whole `system/` tree into a fresh
+  `data/backups/<ts>/` and then replaced it — deleting the plugin `node_modules`
+  the exemption list exists to protect, and swapping the inode of a directory
+  the running assistant has bind-mounted. Backups are only pruned on
+  install/update, so they accumulated (24 on the machine where this was found).
+- **Retired skeleton files are removed from upgraded homes.** Seeding outside
+  `system/` is add-only, so files a release deleted stayed forever and upgraded
+  installs quietly diverged from fresh ones. A migration now removes the
+  `config/{assistant,guardian}/opencode.jsonc` pair (moved into `system/`, but
+  still live-read as OpenCode USER config, the assistant's copy still pinning
+  `akm-opencode@latest`) and the three retired automations
+  (`health-check`, `update-containers`, `validate-config`) that the Automations
+  tab still listed — one as an enabled weekly `openpalm update` — and that akm
+  would never run.
+- **A 0-byte `auth.json` is repaired rather than accepted.** `ensureAuthJson`
+  returned early on any existing file, so an empty one persisted forever and
+  saving a provider credential then failed with an opaque "must be a JSON
+  object". Empty is reachable: single-file bind mounts are pre-created empty,
+  so deleting `auth.json` and enabling an addon produces one. Now treated as
+  absent and re-seeded, the same rule `ensureSecret` already applies.
+
+### Fixed
+
 - **Connecting or disconnecting a provider now reaches the guardian.** The
   credential routes mutated auth through the assistant's OpenCode API and
   stopped there. The guardian receives `auth.json` as a Compose secret and

--- a/containers/assistant/AGENTS.md
+++ b/containers/assistant/AGENTS.md
@@ -1,0 +1,35 @@
+# Working in this assistant
+
+You are the OpenPalm assistant, running on the operator's own machine. These
+are your default working instructions. The operator can replace this file — it
+lives at `system/assistant/AGENTS.md` in their OpenPalm home and is only seeded
+when absent.
+
+## What you have
+
+- **`/stash`** — the operator's knowledge base, managed with `akm`. Search it
+  before answering from memory: `akm search "<query>"`. Record durable facts
+  with `akm remember "<fact>"`. If host stash sharing is on, their personal
+  stash is a second source at `/host-stash`.
+- **`/work`** — the operator's workspace. Files here are theirs, not yours.
+- **Skills and tools** under `/stash` — prefer an existing one over writing
+  something new. `akm search` finds them too.
+
+## How to work
+
+Answer the question that was asked. Check the stash before assuming. When a
+request is ambiguous in a way that changes what you'd do, ask — otherwise pick
+the sensible reading, say which you picked, and continue.
+
+Be honest about what you did and did not do. If a command failed, say so and
+show the output. If you could not verify something, say that rather than
+implying you did. Never describe work as finished when it is not.
+
+Prefer the smallest change that solves the problem. Do not add abstraction,
+configuration, or error handling for situations that cannot happen.
+
+## Care with the operator's data
+
+Never delete a file or directory you did not create without being asked to.
+That applies especially under `/stash`, `/work`, and anything containing
+credentials. Ask first, and name the exact path you intend to remove.

--- a/containers/assistant/Dockerfile
+++ b/containers/assistant/Dockerfile
@@ -284,7 +284,7 @@ RUN printf 'export PATH="/opt/persistent/bin:/opt/openpalm/tools/node_modules/.b
 # OpenCode global config, mounted at ~/.config/opencode.
 # AGENTS.md is baked here as a default; the entrypoint seeds it into
 # OPENCODE_CONFIG_DIR only if the operator has not placed their own copy there.
-COPY AGENTS.md /usr/local/share/openpalm/AGENTS.md
+COPY containers/assistant/AGENTS.md /usr/local/share/openpalm/AGENTS.md
 
 EXPOSE 4096 3000
 

--- a/packages/lib/src/control-plane/core-assets.test.ts
+++ b/packages/lib/src/control-plane/core-assets.test.ts
@@ -149,3 +149,32 @@ describe("overwriteSystemTree", () => {
 		expect(backupDir).not.toBeNull();
 	});
 });
+
+describe("AGENTS.md is a runtime extra, not a retirement", () => {
+  it("does not report changed when only the container-seeded AGENTS.md is extra", () => {
+    // The assistant entrypoint seeds the image's AGENTS.md into
+    // system/assistant on every boot and the skeleton ships none. Reading that
+    // as a retired file made `changed` true on EVERY run, so each launch
+    // backed up the whole system/ tree and then replaced it — deleting the
+    // plugin node_modules and swapping the inode of a directory the running
+    // assistant has bind-mounted. Backups are only pruned on install/update,
+    // so they accumulated (24 on the machine where this was found).
+    seedSource("managed\n");
+    overwriteSystemTree(sourceRoot, opHome);
+
+    // The container then writes its own files into the bind mount.
+    writeFileSync(join(opHome, "system", "assistant", "AGENTS.md"), "# seeded by the image\n");
+    mkdirSync(join(opHome, "system", "assistant", "node_modules", "x"), { recursive: true });
+    writeFileSync(join(opHome, "system", "assistant", "node_modules", "x", "i.js"), "//\n");
+
+    const second = overwriteSystemTree(sourceRoot, opHome);
+
+    // No backup written and nothing replaced — the observable form of
+    // "this run was a no-op".
+    expect(second.backupDir).toBeNull();
+    expect(second.updated).toEqual([]);
+    // Both survive — that is the point.
+    expect(existsSync(join(opHome, "system", "assistant", "AGENTS.md"))).toBe(true);
+    expect(existsSync(join(opHome, "system", "assistant", "node_modules", "x", "i.js"))).toBe(true);
+  });
+});

--- a/packages/lib/src/control-plane/core-assets.ts
+++ b/packages/lib/src/control-plane/core-assets.ts
@@ -195,12 +195,23 @@ export function overwriteSystemTree(
 
 /**
  * A target-only path the release never shipped and that must not be read as a
- * retirement. Only the assistant's runtime dependency tree qualifies today:
- * OP_HOME/system/assistant is bind-mounted as OPENCODE_CONFIG_DIR, so OpenCode
- * installs plugin dependencies into node_modules/ underneath it.
+ * retirement. OP_HOME/system/assistant is bind-mounted as OPENCODE_CONFIG_DIR,
+ * so the container writes into it:
+ *
+ *  - `node_modules/` — OpenCode installs plugin dependencies there.
+ *  - `assistant/AGENTS.md` — the entrypoint seeds the image's default there on
+ *    every boot, and the skeleton ships no copy. So it read as permanently
+ *    "retired": `changed` was true on EVERY run, which made each launch copy
+ *    the whole system/ tree into a fresh data/backups/<ts>/ and then replace
+ *    the tree — deleting the very node_modules the first entry protects, and
+ *    swapping the inode of a directory the running assistant has bind-mounted.
+ *    Electron does this per launch and the backup prune only runs on
+ *    install/update, so backups accumulated (24 where this was found).
  */
 function isRuntimeExtra(rel: string): boolean {
-	return rel.split(/[\\/]/).includes('node_modules');
+	const segments = rel.split(/[\\/]/);
+	if (segments.includes('node_modules')) return true;
+	return segments.length === 2 && segments[0] === 'assistant' && segments[1] === 'AGENTS.md';
 }
 
 function listFiles(root: string): string[] {

--- a/packages/lib/src/control-plane/home-schema.test.ts
+++ b/packages/lib/src/control-plane/home-schema.test.ts
@@ -7,7 +7,7 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
 import {
   HOME_SCHEMA_VERSION,
   ensureHomeDirs,
@@ -175,5 +175,49 @@ describe('an existing home migrates exactly once', () => {
 
     expect(readHomeSchemaVersion(homeDir)).toBe(0);
     expect(runHomeMigrations(homeDir)).toBe(true);
+  });
+});
+
+describe("retired skeleton files are removed from an upgraded home", () => {
+  test("deletes the moved opencode.jsonc pair and the three retired tasks, and nothing else", () => {
+    // Seeding outside system/ is add-only, so a file a release DELETED stays
+    // on every upgraded home. Both orphan sets were confirmed present on a
+    // real install: the .jsonc pair is live-read USER config (the assistant's
+    // still pins akm-opencode@latest), and the retired tasks are listed by the
+    // Automations tab as real automations akm will never run.
+    const home = mkdtempSync(join(tmpdir(), "op-retired-"));
+    try {
+      const write = (rel: string, body = "x\n") => {
+        mkdirSync(dirname(join(home, rel)), { recursive: true });
+        writeFileSync(join(home, rel), body);
+      };
+      for (const rel of [
+        "config/assistant/opencode.jsonc",
+        "config/guardian/opencode.jsonc",
+        "knowledge/tasks/health-check.yml",
+        "knowledge/tasks/update-containers.yml",
+        "knowledge/tasks/validate-config.yml",
+      ]) write(rel);
+      // Live files the current skeleton still ships — must survive untouched.
+      write("config/assistant/opencode.json", '{"keep":true}\n');
+      write("knowledge/tasks/akm-improve.yml", "version: 2\n");
+
+      // Migrations correctly no-op on a home with no stack env (an absent
+      // install, not an unmigrated one), so give it one.
+      mkdirSync(join(home, "state"), { recursive: true });
+      writeFileSync(join(home, "state", "stack.env"), "OP_SETUP_COMPLETE=true\n");
+      runHomeMigrations(home);
+
+      expect(existsSync(join(home, "config/assistant/opencode.jsonc"))).toBe(false);
+      expect(existsSync(join(home, "config/guardian/opencode.jsonc"))).toBe(false);
+      expect(existsSync(join(home, "knowledge/tasks/update-containers.yml"))).toBe(false);
+      expect(existsSync(join(home, "knowledge/tasks/health-check.yml"))).toBe(false);
+      expect(existsSync(join(home, "knowledge/tasks/validate-config.yml"))).toBe(false);
+      // Untouched.
+      expect(readFileSync(join(home, "config/assistant/opencode.json"), "utf-8")).toContain("keep");
+      expect(existsSync(join(home, "knowledge/tasks/akm-improve.yml"))).toBe(true);
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
   });
 });

--- a/packages/lib/src/control-plane/home-schema.ts
+++ b/packages/lib/src/control-plane/home-schema.ts
@@ -20,6 +20,7 @@
  * not need to move when a migration is removed.
  */
 import { existsSync, readFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
 import {
   HOME_SCHEMA_VERSION,
   hasAnyStackEnvFile,
@@ -119,6 +120,53 @@ function migrateToSingleStackEnv(homeDir: string): boolean {
  * consolidation; `migrateProfileOnlyAddonEnablement` reads the *effective*
  * env and writes the app-owned record, so it must follow it.
  */
+/**
+ * Delete skeleton files a release moved or retired.
+ *
+ * Seeding outside `system/` is add-only: `copyTree(..., skipExisting)` never
+ * overwrites and `overwriteSystemTree` prunes only inside `system/`. So a file
+ * a release DELETED from the skeleton stays on every upgraded home forever,
+ * and upgraded installs quietly diverge from fresh ones.
+ *
+ * Two sets, both confirmed present on a real upgraded home:
+ *
+ *  - `config/{assistant,guardian}/opencode.jsonc` — moved into `system/` by
+ *    3087384a. These sit in directories mounted as OpenCode's USER config, so
+ *    the stale copies are live-read: the assistant one still lists
+ *    `akm-opencode@latest` (the unpinned spec the pinned managed config exists
+ *    to eliminate) and `./instructions/*.md` paths that no longer exist there.
+ *  - `knowledge/tasks/{health-check,update-containers,validate-config}.yml` —
+ *    deleted by d9bc7ee4. akm never runs them, but OpenPalm's own task reader
+ *    does not check `version`, so the Automations tab lists them as real
+ *    automations — one of them as an enabled weekly `openpalm update`.
+ *
+ * Removal only. It never touches a file the current skeleton still ships, so
+ * an operator's own edits to live files are untouched.
+ */
+function migrateRetiredSkeletonFiles(homeDir: string): boolean {
+  const retired = [
+    "config/assistant/opencode.jsonc",
+    "config/guardian/opencode.jsonc",
+    "knowledge/tasks/health-check.yml",
+    "knowledge/tasks/update-containers.yml",
+    "knowledge/tasks/validate-config.yml",
+  ];
+  let removed = false;
+  for (const rel of retired) {
+    const path = join(homeDir, rel);
+    if (!existsSync(path)) continue;
+    try {
+      rmSync(path);
+      removed = true;
+    } catch {
+      // Best-effort: a home we cannot clean is not a home we should refuse to
+      // start. The stale file is inert config, not a blocker.
+    }
+  }
+  if (removed) logger.warn("Removed retired skeleton files from OP_HOME", { retired });
+  return removed;
+}
+
 const MIGRATIONS: { since: number; run: (homeDir: string) => boolean }[] = [
   { since: 0, run: migrateLegacyDefaultPorts },
   { since: 0, run: migrateLegacyBindAddresses },
@@ -151,6 +199,9 @@ const MIGRATIONS: { since: number; run: (homeDir: string) => boolean }[] = [
   // Paperclip originally seeded an upstream key unused by the pinned image.
   // Preserve its entropy while moving it to the agent-JWT key the image reads.
   { since: 5, run: migrateLegacyPaperclipEnv },
+  // Files a release deleted from the skeleton but that add-only seeding leaves
+  // behind on every upgraded home.
+  { since: 6, run: migrateRetiredSkeletonFiles },
 ];
 
 /**

--- a/packages/lib/src/control-plane/home.ts
+++ b/packages/lib/src/control-plane/home.ts
@@ -154,7 +154,7 @@ export function hasAnyStackEnvFile(home: string): boolean {
  * it is pure layout — putting it in `home-schema.ts` would make this module
  * depend on `config-persistence`/`addons`, which depend back on this one.
  */
-export const HOME_SCHEMA_VERSION = 6;
+export const HOME_SCHEMA_VERSION = 7;
 
 /** The recorded schema version, or 0 when nothing is recorded (pre-record home). */
 export function readHomeSchemaVersion(home: string): number {

--- a/packages/lib/src/control-plane/secrets.ts
+++ b/packages/lib/src/control-plane/secrets.ts
@@ -1,5 +1,5 @@
 /** Secrets and capability key management. */
-import { mkdirSync, writeFileSync, readFileSync, existsSync, chmodSync, lstatSync, rmSync, renameSync, copyFileSync } from "node:fs";
+import { mkdirSync, writeFileSync, readFileSync, existsSync, chmodSync, lstatSync, statSync, rmSync, renameSync, copyFileSync } from "node:fs";
 import { errMessage } from './errors.js';
 import { createLogger } from "../logger.js";
 import { parseEnvFile, mergeEnvContent, parseEnabledAddons } from './env.js';
@@ -244,10 +244,17 @@ function ensureAuthJson(state: ControlPlaneState): void {
             error: errMessage(moveError),
           });
         }
-      } else {
+      } else if (statSync(authJsonPath).size > 0) {
         chmodSync(authJsonPath, VAULT_FILE_MODE);
         return;
       }
+      // A 0-byte auth.json is treated as ABSENT and re-seeded with `{}`, the
+      // same rule ensureSecret already applies to every other secret. Empty is
+      // reachable: `ensureComposeVolumeTargets` pre-creates single-file bind
+      // mounts with `writeFileSync(path, '')`, so deleting auth.json and then
+      // enabling an addon leaves one permanently — and nothing else repairs it.
+      // `writeCanonicalProviderCredential` then throws "must be a JSON object"
+      // and saving a provider credential fails with an opaque error.
     } catch (error) {
       logger.warn("failed to repair auth.json path", {
         path: authJsonPath,


### PR DESCRIPTION
Cycle four. Every item was verified against a real install before being touched, and two turned out worse than the audit claimed.

## The assistant shipped OpenPalm's contributor instructions as its own

`.dockerignore:29` un-ignored the repo root `AGENTS.md` specifically so `containers/assistant/Dockerfile:287` could bake it, and the entrypoint seeds it into every operator's OpenCode config as **global agent instructions**.

Confirmed byte-identical on a live install:

```
20336 AGENTS.md
20336 ~/.openpalm/system/assistant/AGENTS.md
IDENTICAL

# AGENTS.md — OpenPalm
> CRITICAL: All work must comply with docs/technical/core-principles.md
```

End users' assistants were primed with this repo's architectural rules, commit conventions and delivery checklist. The image now ships a `containers/assistant/AGENTS.md` written for the operator's assistant.

## That same file wiped the managed tree on every launch

The entrypoint writes it into `system/assistant`, the skeleton ships no copy, and `overwriteSystemTree`'s retired-file check exempts only `node_modules` — so `changed` was true on **every run**. Each launch copied the whole `system/` tree into a fresh `data/backups/<ts>/` and replaced the tree: deleting the plugin `node_modules` that exemption exists to protect, and swapping the inode of a directory the *running* assistant has bind-mounted. Electron does this per launch; the prune only runs on install/update.

The machine this was found on: **24 backup directories**. `AGENTS.md` is now a runtime extra, pinned by a test I confirmed fails against the old behaviour.

## Retired skeleton files never left upgraded homes

Seeding outside `system/` is add-only. Confirmed present on the same install:

```
config/assistant/opencode.jsonc   10865  Jun 24
config/guardian/opencode.jsonc     1943  Jun 22
knowledge/tasks/{health-check,update-containers,validate-config}.yml
```

The `.jsonc` pair is still live-read as OpenCode **user** config — the assistant's copy still pins `akm-opencode@latest`, the unpinned spec the managed config exists to eliminate. The three tasks are listed by the Automations tab as real automations (one as an enabled weekly `openpalm update`) that akm will never run. A migration removes exactly those five and nothing the skeleton still ships.

## A 0-byte `auth.json` is repaired, not accepted

`ensureAuthJson` returned early on any existing file. Empty is reachable — single-file bind mounts are pre-created empty — and the result is that saving a provider credential fails with an opaque *"must be a JSON object"*. Now treated as absent and re-seeded, the rule `ensureSecret` already applies.

## Verification

- `bun run check` 0/0 · `packages/lib` 1511 pass · portals/guardian/scripts 646 pass · lint unchanged
- The `AGENTS.md` test was confirmed to fail when the exemption is reverted
- The migration test asserts the five removals **and** that live skeleton files survive

🤖 Generated with [Claude Code](https://claude.com/claude-code)