### PR TITLE
Publish the OpenAI-compatible edge only when guardianOpenaiApi asks for it

### DIFF
--- a/containers/guardian/README.md
+++ b/containers/guardian/README.md
@@ -63,10 +63,10 @@ Managed moderation instructions come from host `system/guardian/`, mounted at
 | Internal `8080` | Docker networks only | Health, stats, and authenticated `/oc/*` proxy |
 | Direct `3830` | `127.0.0.1:3830` | Optional direct `/oc/*` and MCP ingress |
 | Admin `3831` | `127.0.0.1:3831` permanently | `/admin/principals` CRUD |
-| Compatible API `8182` | `127.0.0.1:3821` | OpenAI/Anthropic-compatible edge |
+| Compatible API `8182` | `127.0.0.1:3821` (only when the `guardian.compose.api.yml` overlay is included) | OpenAI/Anthropic-compatible edge |
 | Moderator `4097` | Container loopback only | Content-validation OpenCode process |
 
-One compatible API listener is published through `OP_API_PORT`.
+One compatible API listener; its host publish (`OP_API_PORT`) ships in the opt-in `guardian.compose.api.yml` overlay.
 
 The direct listener returns `404` until `GUARDIAN_DIRECT_INGRESS=true`. TLS
 termination is an operator reverse-proxy concern; Guardian serves plain HTTP.

--- a/docs/backup-restore.md
+++ b/docs/backup-restore.md
@@ -103,6 +103,10 @@ docker compose \
 
 Replace `guardian` with the profiles that were active for the backup. The
 value of `OP_ENABLED_ADDONS` alone is not translated by raw Docker Compose.
+If the backup had the OpenAI-compatible API enabled (`OP_ACCESS_OPENAI_API=true`
+or `api` in `OP_ENABLED_ADDONS`), also add
+`-f "$OP_HOME/system/stack/guardian.compose.api.yml"` — that overlay carries the
+edge's host publish (see the Manual Compose Runbook's conditional overlays).
 If the restored `state/stack.env` records a non-default `OP_PROJECT_NAME`, set
 the shell variable to that exact value as well; `--env-file` does not expand the
 shell's earlier `--project-name` argument.

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -111,7 +111,10 @@ Discord and Slack adapters run from the unified `openpalm/portal` image. They
 translate their native protocols into authenticated Guardian `/oc/*` calls.
 
 The OpenAI/Anthropic-compatible edge runs inside Guardian and is published on
-host port `3821` when configured. There is one compatible listener on a
+host port `3821` only when the OpenAI-compatible API toggle (or the `api`
+addon) asks for it — the publish ships in the `guardian.compose.api.yml`
+overlay, so with the toggle off there is no host listener at all. There is
+one compatible listener on a
 single host port.
 
 Voice is a service addon rather than a portal. It is defined in
@@ -191,7 +194,7 @@ host OS scheduler and call the host `openpalm` binary.
 |---|---|
 | `3800` | Assistant-served OpenPalm UI |
 | `3810` | Assistant OpenCode |
-| `3821` | Guardian-hosted compatible API |
+| `3821` | Guardian-hosted compatible API (published only when enabled) |
 | `3830` | Guardian direct ingress |
 | `3831` | Guardian principal admin, loopback-only |
 | `3880` | Optional host UI/admin process |

--- a/docs/operations/manual-compose-runbook.md
+++ b/docs/operations/manual-compose-runbook.md
@@ -13,16 +13,21 @@ complete install.
 | `$OP_HOME/system/stack/services.compose.yml` | Profile-gated first-party services |
 | `$OP_HOME/system/stack/portals.compose.yml` | Profile-gated Guardian and portals |
 | `$OP_HOME/system/stack/voice.compose.lan.yml` | **Conditional** — only when `OP_VOICE_LAN_ACCESS=true` in `stack.env` (see below) |
+| `$OP_HOME/system/stack/guardian.compose.api.yml` | **Conditional** — the OpenAI-compatible edge's host publish; only when `OP_ACCESS_OPENAI_API=true` or `api` is in `OP_ENABLED_ADDONS` (see below) |
 | `$OP_HOME/config/stack/custom.compose.yml` | Sole user-owned Compose overlay |
 | `$OP_HOME/state/stack.env` | Sole non-secret Compose env file |
 | `$OP_HOME/private/secrets/` | Delegated service secret sources |
 | `$OP_HOME/knowledge/secrets/auth.json` | Provider auth used by OpenCode |
 
 The first three managed files are always present in a generated install and
-are used by every command. `voice.compose.lan.yml` is not fixed: it joins the
-list only when the voice addon's **Let devices on your network use voice
-through the published UI** setting is on
-(`OP_VOICE_LAN_ACCESS=true` in `state/stack.env`). Every OpenPalm-driven
+are used by every command. Two overlays are not fixed: `voice.compose.lan.yml`
+joins the list only when the voice addon's **Let devices on your network use
+voice through the published UI** setting is on
+(`OP_VOICE_LAN_ACCESS=true` in `state/stack.env`), and
+`guardian.compose.api.yml` — the ONE host publish for the guardian's
+OpenAI-compatible listener — joins only when **Enable the OpenAI-compatible
+API** is on (`OP_ACCESS_OPENAI_API=true`) or the `api` addon is enabled.
+Without it the edge has no host port at all. Every OpenPalm-driven
 Compose invocation (`openpalm start`, an update, a settings-triggered
 recreate) includes it automatically when that flag is set — a manual command
 that leaves it out silently recreates the voice container without
@@ -69,17 +74,25 @@ op() {
     -f "$home/system/stack/portals.compose.yml"
   )
 
-  # Also picks up OP_VOICE_LAN_ACCESS so the voice LAN overlay is never
-  # silently dropped (see Runtime Inputs above).
+  # Also picks up the conditional overlays so they are never silently
+  # dropped (see Runtime Inputs above).
+  local api_publish=0
   while IFS='=' read -r key value; do
     value="${value%$'\r'}"
     if [ -z "${OP_PROJECT_NAME:-}" ] && [ "$key" = "OP_PROJECT_NAME" ]; then
       project="$value"
     elif [ "$key" = "OP_VOICE_LAN_ACCESS" ] && [ "$value" = "true" ]; then
       files+=(-f "$home/system/stack/voice.compose.lan.yml")
+    elif [ "$key" = "OP_ACCESS_OPENAI_API" ] && [ "$value" = "true" ]; then
+      api_publish=1
+    elif [ "$key" = "OP_ENABLED_ADDONS" ]; then
+      case ",$value," in *,api,*) api_publish=1 ;; esac
     fi
   done < "$home/state/stack.env"
 
+  if [ "$api_publish" = 1 ]; then
+    files+=(-f "$home/system/stack/guardian.compose.api.yml")
+  fi
   files+=(-f "$home/config/stack/custom.compose.yml")
 
   docker compose \

--- a/docs/technical/architecture.md
+++ b/docs/technical/architecture.md
@@ -77,7 +77,8 @@ escalated to Guardian's loopback OpenCode moderator; a moderator failure or
 unusable verdict blocks the escalated request.
 
 Guardian also owns the one OpenAI/Anthropic-compatible listener at container
-port `8182`, published on host port `3821` by default. Chat and API are not
+port `8182`, published on host port `3821` only when the OpenAI-compatible
+API is enabled (the `guardian.compose.api.yml` overlay). Chat and API are not
 separate listeners.
 
 ## Secret Topology

--- a/docs/technical/core-principles.md
+++ b/docs/technical/core-principles.md
@@ -315,7 +315,7 @@ Host-exposed OpenPalm services default to a small localhost-friendly port set. C
 | **Guardian moderator** (OpenCode) | 4097 | (loopback only) | Local content-moderation model |
 | **Guardian direct listener** | 3830 | `127.0.0.1:3830` (`OP_GUARDIAN_BIND_ADDRESS`) | Direct (non-portal) ingress; the listener 404s unless `GUARDIAN_DIRECT_INGRESS=true`; serves plain HTTP |
 | **Guardian admin listener** | 3831 | `127.0.0.1:3831` (`OP_GUARDIAN_ADMIN_PORT`; bind address is fixed) | Principal CRUD (`/admin/principals`), Bearer-token auth via `GUARDIAN_ADMIN_TOKEN_FILE` |
-| **Guardian OpenAI/Anthropic API** | 8182 | `127.0.0.1:3821` (`OP_API_BIND_ADDRESS`) | The one compatible API listener on a single host port |
+| **Guardian OpenAI/Anthropic API** | 8182 | `127.0.0.1:3821` (`OP_API_BIND_ADDRESS`; published only when `guardianOpenaiApi` is on or the `api` addon is enabled — `guardian.compose.api.yml`) | The one compatible API listener on a single host port |
 
 Port assignments live in non-secret `state/stack.env`. Configurable host binds are flat and service-specific: `OP_UI_BIND_ADDRESS`, `OP_ASSISTANT_BIND_ADDRESS`, `OP_GUARDIAN_BIND_ADDRESS`, and `OP_API_BIND_ADDRESS`; no listener inherits from a global bind. Voice, Paperclip, and the Guardian admin listener are fixed to loopback. The Guardian `/stats` endpoint is gated by the admin bearer token and denies all when no token is configured. Its internal `8080` listener binds for both `portal_net` and loopback callers inside the container.
 

--- a/docs/technical/environment-and-mounts.md
+++ b/docs/technical/environment-and-mounts.md
@@ -252,7 +252,7 @@ one Compose secret; delegated credentials come from `private/secrets/`.
 | Internal Guardian gateway | `8080` | None |
 | Direct Guardian `/oc` listener | `3830` | `${OP_GUARDIAN_BIND_ADDRESS:-127.0.0.1}:${OP_GUARDIAN_PORT:-3830}` |
 | Principal admin listener | `3831` | `127.0.0.1:${OP_GUARDIAN_ADMIN_PORT:-3831}` |
-| OpenAI/Anthropic-compatible listener | `8182` | `${OP_API_BIND_ADDRESS:-127.0.0.1}:${OP_API_PORT:-3821}` |
+| OpenAI/Anthropic-compatible listener | `8182` | `${OP_API_BIND_ADDRESS:-127.0.0.1}:${OP_API_PORT:-3821}` — published only when `guardian.compose.api.yml` is in the file list (`guardianOpenaiApi` toggle on, or `api` addon enabled); no host port otherwise |
 | Local OpenCode moderator | `4097` | None; loopback inside the container |
 
 There is one Guardian OpenAI-compatible listener and one host publication.
@@ -318,7 +318,7 @@ defaults to `5173`; the root `ui:dev:isolated` script explicitly uses `3880`.
 | Service | Network membership | Host exposure |
 |---|---|---|
 | `assistant` | `assistant_net` | UI `3800`, OpenCode `3810`, loopback by default |
-| `guardian` | `assistant_net`, `portal_net` | Direct `3830`, admin `3831`, compatible API `3821`, loopback by default |
+| `guardian` | `assistant_net`, `portal_net` | Direct `3830`, admin `3831`, loopback by default; compatible API `3821` only via the opt-in `guardian.compose.api.yml` overlay |
 | `discord`, `slack` | `portal_net` | None |
 | `ollama*` | `assistant_net` | None |
 | `voice*` | `addon_net` (default) | `127.0.0.1:${OP_VOICE_PORT_HOST:-8880}` |

--- a/docs/technical/foundations.md
+++ b/docs/technical/foundations.md
@@ -139,7 +139,7 @@ Guardian listeners:
 | Internal `/oc` gateway | `8080` | None |
 | Direct `/oc` ingress | `3830` | `127.0.0.1:3830` by default |
 | Principal admin API | `3831` | Always loopback |
-| OpenAI/Anthropic-compatible API | `8182` | `127.0.0.1:3821` by default |
+| OpenAI/Anthropic-compatible API | `8182` | `127.0.0.1:3821`, only when enabled (opt-in overlay) |
 | OpenCode moderator | `4097` | Container loopback only |
 
 There is one compatible API listener, not separate chat and API listeners.

--- a/packages/lib/src/control-plane/config-persistence.ts
+++ b/packages/lib/src/control-plane/config-persistence.ts
@@ -10,7 +10,7 @@ import { errMessage } from './errors.js';
 import { dirname, resolve as resolvePath } from "node:path";
 import { composeConfigJsonSync, type ComposeConfigJsonResult } from "./docker.js";
 import { createLogger } from "../logger.js";
-import { parseEnvContent, parseEnvFile, mergeEnvContent, removeEnvKey } from './env.js';
+import { parseEnabledAddons, parseEnvContent, parseEnvFile, mergeEnvContent, removeEnvKey } from './env.js';
 import {
   ACCESS_ENV_KEYS,
   hasStoredAccessIntent,
@@ -450,6 +450,20 @@ export function dismissSecretStripNotice(state: ControlPlaneState): void {
  * is purely a writable secondary source entry in config/akm/config.json. No
  * conditional overlay file is involved.
  */
+/**
+ * True when the OpenAI-compatible edge's host publish belongs in the compose
+ * file list: the operator turned the guardianOpenaiApi toggle on, or the
+ * `api` addon (the pre-toggle exposure alias) is enabled. Reads the stored
+ * intent the same way every consumer does — via readAccessToggles, so a
+ * pre-intent row falls back to bind inference and a restored backup keeps
+ * the publish it had.
+ */
+function isOpenaiEdgePublished(homeDir: string): boolean {
+  const env = parseEnvFile(stackEnvFile(homeDir));
+  if (readAccessToggles(env).guardianOpenaiApi) return true;
+  return parseEnabledAddons(env.OP_ENABLED_ADDONS).includes('api');
+}
+
 export function discoverStackOverlays(homeDir: string): string[] {
   const files: string[] = [];
 
@@ -477,6 +491,25 @@ export function discoverStackOverlays(homeDir: string): string[] {
   if (isVoiceLanAccessEnabled(homeDir)) {
     const voiceLan = composeFilePath(homeDir, 'voice.compose.lan.yml');
     if (existsSync(voiceLan)) files.push(voiceLan);
+  }
+
+  // OpenAI-compatible edge host publish: the guardian's compatible listener
+  // (8182) has NO unconditional `ports:` entry in portals.compose.yml — this
+  // overlay carries the one host publish, so the guardianOpenaiApi toggle's
+  // OFF position means no host listener at all rather than "loopback with a
+  // fully working edge behind it". Same double-gate and same shared-file-list
+  // rationale as the voice overlay above: every compose invocation must agree
+  // on the file list, or a plain `openpalm start` would recreate the guardian
+  // without (or with) the publish and silently flip the operator's setting.
+  //
+  // The `api` addon is the second inclusion reason: it is the pre-toggle
+  // exposure alias (and the v7→v8 migration's substitute for `chat`), so an
+  // upgraded install that enabled it keeps its loopback edge byte-identical.
+  // Bind address and port still come from the flat access model
+  // (OP_API_BIND_ADDRESS / OP_API_PORT); the overlay only interpolates them.
+  if (isOpenaiEdgePublished(homeDir)) {
+    const apiPublish = composeFilePath(homeDir, 'guardian.compose.api.yml');
+    if (existsSync(apiPublish)) files.push(apiPublish);
   }
 
   // User custom overlay lives in the config/ tree (not system/stack).

--- a/packages/lib/src/control-plane/guardian-api-overlay.test.ts
+++ b/packages/lib/src/control-plane/guardian-api-overlay.test.ts
@@ -1,0 +1,103 @@
+/**
+ * guardian.compose.api.yml — the opt-in overlay that carries the OpenAI-
+ * compatible edge's ONE host publish, so the guardianOpenaiApi toggle's OFF
+ * position means "no host listener" instead of "loopback with a fully
+ * working edge behind it".
+ *
+ * Covers the overlay-inclusion gate (discoverStackOverlays,
+ * config-persistence.ts). Content assertions for the overlay file itself
+ * live in network-partitioning.test.ts / skeleton-guardrail.test.ts.
+ */
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { discoverStackOverlays } from "./config-persistence.js";
+
+let homeDir = "";
+
+afterEach(() => {
+  if (homeDir) rmSync(homeDir, { recursive: true, force: true });
+  homeDir = "";
+});
+
+function makeHome(): string {
+  const dir = mkdtempSync(join(tmpdir(), "openpalm-api-overlay-"));
+  mkdirSync(join(dir, "system", "stack"), { recursive: true });
+  mkdirSync(join(dir, "state"), { recursive: true });
+  writeFileSync(join(dir, "system", "stack", "core.compose.yml"), "services: {}\n");
+  return dir;
+}
+
+function writeStackEnv(dir: string, content: string): void {
+  writeFileSync(join(dir, "state", "stack.env"), content);
+}
+
+function writeApiOverlay(dir: string): void {
+  writeFileSync(join(dir, "system", "stack", "guardian.compose.api.yml"), "services: {}\n");
+}
+
+function includesOverlay(dir: string): boolean {
+  return discoverStackOverlays(dir).some((f) => f.endsWith("guardian.compose.api.yml"));
+}
+
+describe("discoverStackOverlays — guardian.compose.api.yml inclusion", () => {
+  test("excluded by default: toggle off, no api addon", () => {
+    homeDir = makeHome();
+    writeApiOverlay(homeDir);
+    writeStackEnv(homeDir, "OP_ACCESS_OPENAI_API=false\n");
+    expect(includesOverlay(homeDir)).toBe(false);
+  });
+
+  test("excluded with no stack.env at all — a fresh home publishes nothing", () => {
+    homeDir = makeHome();
+    writeApiOverlay(homeDir);
+    expect(includesOverlay(homeDir)).toBe(false);
+  });
+
+  test("included when the guardianOpenaiApi toggle is on", () => {
+    homeDir = makeHome();
+    writeApiOverlay(homeDir);
+    writeStackEnv(homeDir, "OP_ACCESS_OPENAI_API=true\n");
+    expect(includesOverlay(homeDir)).toBe(true);
+  });
+
+  test("included when the api addon is enabled — the pre-toggle exposure alias keeps its loopback edge", () => {
+    homeDir = makeHome();
+    writeApiOverlay(homeDir);
+    writeStackEnv(homeDir, "OP_ENABLED_ADDONS=api\nOP_ACCESS_OPENAI_API=false\n");
+    expect(includesOverlay(homeDir)).toBe(true);
+  });
+
+  test("included via bind inference on a pre-intent row — a restored backup keeps its publish", () => {
+    homeDir = makeHome();
+    writeApiOverlay(homeDir);
+    writeStackEnv(homeDir, "OP_API_BIND_ADDRESS=0.0.0.0\n");
+    expect(includesOverlay(homeDir)).toBe(true);
+  });
+
+  test("double-gate: toggle on but overlay not seeded — no file, no entry", () => {
+    homeDir = makeHome();
+    writeStackEnv(homeDir, "OP_ACCESS_OPENAI_API=true\n");
+    expect(includesOverlay(homeDir)).toBe(false);
+  });
+
+  test("a non-api addon does not include it", () => {
+    homeDir = makeHome();
+    writeApiOverlay(homeDir);
+    writeStackEnv(homeDir, "OP_ENABLED_ADDONS=discord,gateway\n");
+    expect(includesOverlay(homeDir)).toBe(false);
+  });
+
+  test("ordering: the overlay joins between the managed set and the user custom overlay", () => {
+    homeDir = makeHome();
+    writeApiOverlay(homeDir);
+    writeStackEnv(homeDir, "OP_ACCESS_OPENAI_API=true\n");
+    mkdirSync(join(homeDir, "config", "stack"), { recursive: true });
+    writeFileSync(join(homeDir, "config", "stack", "custom.compose.yml"), "services: {}\n");
+
+    const files = discoverStackOverlays(homeDir).map((f) => f.split("/").pop());
+    expect(files.indexOf("guardian.compose.api.yml")).toBeGreaterThan(files.indexOf("core.compose.yml"));
+    expect(files.indexOf("custom.compose.yml")).toBeGreaterThan(files.indexOf("guardian.compose.api.yml"));
+  });
+});

--- a/packages/lib/src/control-plane/network-partitioning.test.ts
+++ b/packages/lib/src/control-plane/network-partitioning.test.ts
@@ -297,11 +297,21 @@ describe("access toggles — the generated bind set matches compose reality (pin
     expect(core.services?.assistant?.environment?.OP_PROJECT_NAME).toBe("${OP_PROJECT_NAME:-openpalm}");
   });
 
-  test("ONE flat host port onto the guardian's OpenAI-compatible listener", () => {
+  test("the OpenAI-compatible listener has NO unconditional host publish — the overlay carries the ONE flat port", () => {
+    // Base file: no 8182 publish at all. The guardianOpenaiApi toggle's OFF
+    // position means no host listener, not a loopback one; the publish ships
+    // in guardian.compose.api.yml, included by discoverStackOverlays only
+    // when the toggle (or the api addon) asks for it.
     const guardianPorts = allServices.guardian?.ports ?? [];
-    expect(guardianPorts).toContain("${OP_API_BIND_ADDRESS:-127.0.0.1}:${OP_API_PORT:-3821}:8182");
-    // The duplicate chat host port onto the same :8182 listener is retired.
-    expect(guardianPorts.filter((p) => String(p).endsWith(":8182"))).toHaveLength(1);
+    expect(guardianPorts.filter((p) => String(p).endsWith(":8182"))).toHaveLength(0);
+
+    const overlay = loadCompose("guardian.compose.api.yml") as ComposeDoc;
+    const overlayPorts = (overlay.services?.guardian as { ports?: string[] })?.ports ?? [];
+    expect(overlayPorts).toEqual(["${OP_API_BIND_ADDRESS:-127.0.0.1}:${OP_API_PORT:-3821}:8182"]);
+    // The overlay must not re-declare profiles (it would override the base
+    // gate) and must not touch any other service.
+    expect((overlay.services?.guardian as { profiles?: string[] })?.profiles).toBeUndefined();
+    expect(Object.keys(overlay.services ?? {})).toEqual(["guardian"]);
   });
 
   test("the guardian's own front door binds flat, and its admin listener is a literal", () => {

--- a/packages/lib/src/control-plane/skeleton-guardrail.test.ts
+++ b/packages/lib/src/control-plane/skeleton-guardrail.test.ts
@@ -191,7 +191,14 @@ describe("skeleton: config/ structure", () => {
     expect(coreCompose).toContain('${OP_UI_BIND_ADDRESS:-127.0.0.1}:${OP_UI_PORT:-3800}:3000');
     expect(coreCompose).toContain('${OP_ASSISTANT_BIND_ADDRESS:-127.0.0.1}:${OP_ASSISTANT_PORT:-3810}:4096');
     expect(channelsCompose).toContain('${OP_GUARDIAN_BIND_ADDRESS:-127.0.0.1}:${OP_GUARDIAN_PORT:-3830}:3830');
-    expect(channelsCompose).toContain('${OP_API_BIND_ADDRESS:-127.0.0.1}:${OP_API_PORT:-3821}:8182');
+    // The OpenAI-compatible publish lives ONLY in the opt-in overlay — the
+    // base file must not publish 8182 at all.
+    expect(channelsCompose).not.toContain(':8182');
+    const apiOverlay = readFileSync(
+      join(SKELETON_DIR, 'system', 'stack', 'guardian.compose.api.yml'),
+      'utf-8',
+    );
+    expect(apiOverlay).toContain('${OP_API_BIND_ADDRESS:-127.0.0.1}:${OP_API_PORT:-3821}:8182');
 
     // Voice serves an API reached through the UI's /voice proxy — it never
     // needs a host port, so its bind is a literal, not a knob.

--- a/packages/skeleton/system/stack/README.md
+++ b/packages/skeleton/system/stack/README.md
@@ -37,7 +37,7 @@ targeting it).
 | Assistant UI | Always | `127.0.0.1:3800 -> 3000` |
 | Guardian direct ingress | Guardian profile | `127.0.0.1:3830 -> 3830` |
 | Guardian principal admin | Guardian profile | `127.0.0.1:3831 -> 3831` |
-| Compatible API | Guardian profile | `127.0.0.1:3821 -> 8182` |
+| Compatible API | `guardian.compose.api.yml` overlay (guardianOpenaiApi toggle or `api` addon) | `127.0.0.1:3821 -> 8182`; no host port otherwise |
 | Discord / Slack | Matching profile | No host port; outbound bot connections |
 | Voice | `addon.voice.*` | `127.0.0.1:8880 -> 8880` |
 | Ollama | `addon.ollama.*` | Internal model service |

--- a/packages/skeleton/system/stack/guardian.compose.api.yml
+++ b/packages/skeleton/system/stack/guardian.compose.api.yml
@@ -1,0 +1,31 @@
+# OpenAI-compatible API host-publish overlay — publishes the guardian's
+# compatible edge (container port 8182) onto the host.
+#
+# Opt-in, default OFF: included only when the `guardianOpenaiApi` access
+# toggle is on or the `api` addon is enabled, checked by
+# discoverStackOverlays (packages/lib/src/control-plane/config-persistence.ts).
+# Applied on EVERY compose invocation once the condition holds — `openpalm
+# start`, an update, the settings-save recreate — not just one bring-up call;
+# see discoverStackOverlays' comment for why conditional membership must live
+# in the shared file list.
+#
+# WHY an overlay: the edge process itself starts on every guardian boot (it
+# serves 8182 inside the container for portal_net peers and the loopback
+# moderator topology), but the HOST publish is exposure, and exposure is what
+# the toggle governs. With this file absent from the invocation there is no
+# host listener on ${OP_API_PORT} at all — the toggle's OFF position is
+# enforced, instead of "loopback with a fully working edge behind it".
+# The bind address still follows the flat access model: the toggle generates
+# OP_API_BIND_ADDRESS (127.0.0.1 or 0.0.0.0) and this file only interpolates
+# it. The api-addon inclusion keeps upgraded installs that enabled the addon
+# (the pre-toggle exposure alias) serving their loopback edge unchanged.
+#
+# No `profiles:` key on purpose: the merged guardian service keeps the base
+# file's profile gate, so including this overlay never deploys the guardian
+# by itself — it only adds the port publish when something else deploys it.
+services:
+  guardian:
+    ports:
+      # ONE host port onto the OpenAI-compatible listener (see the base
+      # guardian service in portals.compose.yml for the other listeners).
+      - "${OP_API_BIND_ADDRESS:-127.0.0.1}:${OP_API_PORT:-3821}:8182"

--- a/packages/skeleton/system/stack/portals.compose.yml
+++ b/packages/skeleton/system/stack/portals.compose.yml
@@ -189,10 +189,11 @@ services:
       - "${OP_GUARDIAN_BIND_ADDRESS:-127.0.0.1}:${OP_GUARDIAN_PORT:-3830}:3830"
       # The admin listener is loopback-only, permanently — it mints principals.
       - "127.0.0.1:${OP_GUARDIAN_ADMIN_PORT:-3831}:3831"
-      # ONE host port onto the OpenAI-compatible listener. This used to be two
-      # separate chat/api host ports mapping to the same container port 8182 —
-      # two knobs, two bind addresses and two firewall holes for one service.
-      - "${OP_API_BIND_ADDRESS:-127.0.0.1}:${OP_API_PORT:-3821}:8182"
+      # The OpenAI-compatible listener (8182) has NO unconditional host
+      # publish: guardian.compose.api.yml adds the one host port, and
+      # discoverStackOverlays includes that overlay only when the
+      # guardianOpenaiApi toggle is on or the api addon is enabled — the
+      # toggle's OFF position means no host listener, not a loopback one.
     volumes:
       - ${OP_HOME}/data/guardian:/opt/openpalm/guardian
       # S1: see core.compose.yml — regenerable cache on a pre-created host

--- a/scripts/dev-e2e-test.sh
+++ b/scripts/dev-e2e-test.sh
@@ -130,6 +130,7 @@ compose() {
     -f "${OP_E2E_HOME}/system/stack/core.compose.yml" \
     -f "${OP_E2E_HOME}/system/stack/services.compose.yml" \
     -f "${OP_E2E_HOME}/system/stack/portals.compose.yml" \
+    -f "${OP_E2E_HOME}/system/stack/guardian.compose.api.yml" \
     -f "${OP_E2E_HOME}/config/stack/custom.compose.yml" \
     -f compose.dev.yml \
     --env-file "${OP_E2E_HOME}/state/stack.env" \


### PR DESCRIPTION
Work item 2 of the 0.13.0 stabilization, kept separate from #616 as specified.

## What changed

- **The edge's host publish (`3821 → 8182`) moves out of `portals.compose.yml`** into a new opt-in overlay, `packages/skeleton/system/stack/guardian.compose.api.yml`. The base file no longer publishes 8182 at all, so the `guardianOpenaiApi` toggle's OFF position now means **no host listener** — previously it meant "loopback with a fully working, key-authenticated edge behind it" on every install that deployed the guardian for any reason.
- **`discoverStackOverlays` includes the overlay** when the `guardianOpenaiApi` toggle is on (via `readAccessToggles`, so pre-intent rows fall back to bind inference and restored backups keep their publish) **or the `api` addon is enabled**. Same double-gate (setting AND seeded file) and same shared-file-list placement as `voice.compose.lan.yml`: every compose invocation — `openpalm start`, updates, toggle-save recreates — agrees on the publish, so nothing drifts.
- **The `api`-addon inclusion is the compatibility half**: the addon is the pre-toggle exposure alias (and the v7→v8 migration's substitute for `chat`), so upgraded installs that enabled it keep their loopback edge byte-identical across this change. `portal_api_secret` is untouched — it is the edge's own principal credential (`PRINCIPAL_SECRET_FILE`) and stays seeded and mounted on every guardian deploy, per the constraint verified in the task.
- The overlay deliberately declares **no `profiles:` key** (the merged guardian keeps the base profile gate, so including the overlay can never deploy the guardian by itself) and touches no other service — both pinned by tests.
- `dev-e2e-test.sh` adds the overlay to its raw compose file list (it enables the `api` addon and polls the edge's `/health`). The manual-compose runbook's `op()` helper now picks the overlay up from `stack.env` alongside the voice LAN overlay, backup-restore mentions it, and the port tables across the docs say "published only when enabled".

Not gated: the edge **process** itself still starts on every guardian boot and serves 8182 inside the container for `portal_net` peers — the task scoped this item to the host publish, which is the exposure the toggle governs.

## Verification

Ran here (no Docker daemon in this environment):

- `bun test packages/lib`: 1545 pass / 0 fail — includes the new `guardian-api-overlay.test.ts` (inclusion by toggle, by `api` addon, by bind inference on pre-intent rows; exclusion by default, on missing file, and for other addons; ordering between the managed set and the user overlay), plus updated `network-partitioning.test.ts` / `skeleton-guardrail.test.ts` (base file publishes no 8182; the overlay carries exactly the one flat port and declares no profiles).
- guardian + cli + portal-sdk/discord/slack + scripts: 874 pass / 0 fail. `bun run check`: 0 errors. CLI `tsc --noEmit`: clean. `bun run lint`: only the pre-existing `install.ts:385` warning. UI vitest: 2157 pass, same 2 pre-existing environmental chromium focus-outline failures as `main`.
- Client-side `docker compose config` over the assembled skeleton: without the overlay the guardian renders **zero** 8182/3821 publications; with it, exactly one (`host_ip: 127.0.0.1, target: 8182, published: "3821"`), and the guardian's profile gate still holds.

**Not run here** (needs Docker): the rootless smokes and the e2e lane that exercises the edge's `/health` through the updated file list. CI runs them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AqFsC3UuCwXL7S7oY1gTho

---
_Generated by [Claude Code](https://claude.ai/code/session_01AqFsC3UuCwXL7S7oY1gTho)_