### PR TITLE
Apply rotated secrets, rename-with-toggle saves, and honest Secrets copy

### DIFF
--- a/packages/guardian/src/openai-api.test.ts
+++ b/packages/guardian/src/openai-api.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, afterEach } from 'bun:test';
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, rmSync, statSync, utimesSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { GuardianOpenAiApi } from './openai-api.ts';
@@ -210,6 +210,57 @@ describe('guardian openai api auth', () => {
       rmSync(dir, { recursive: true, force: true });
     }
   });
+
+  // A rotated key must take effect on the NEXT request, not on the next
+  // container recreate. Compose grants these as file secrets (a bind mount)
+  // and the Secrets tab rewrites them in place, so the container sees the new
+  // bytes immediately — but the read cache used to be keyed by path alone and
+  // held for the process lifetime, so the REVOKED key kept authenticating
+  // while the UI reported the new one.
+  it('re-reads a rotated API key file instead of serving the revoked value', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'openpalm-key-rotation-'));
+    const keyFile = join(dir, 'api-key');
+    writeFileSync(keyFile, 'old-key\n');
+    const savedKeyFile = Bun.env.OPENAI_COMPAT_API_KEY_FILE;
+    const savedSecretFile = Bun.env.PRINCIPAL_SECRET_FILE;
+    Bun.env.OPENAI_COMPAT_API_KEY_FILE = keyFile;
+    delete Bun.env.PRINCIPAL_SECRET_FILE;
+
+    const call = async (api: GuardianOpenAiApi, key: string): Promise<number> => {
+      const handler = api.createFetch(ocFetchStub() as typeof fetch);
+      const resp = await handler(
+        new Request('http://api/v1/chat/completions', {
+          method: 'POST',
+          headers: { authorization: `Bearer ${key}` },
+          body: JSON.stringify({ model: 'gpt-4', messages: [{ role: 'user', content: 'hello' }] }),
+        }),
+      );
+      return resp.status;
+    };
+
+    try {
+      const api = new GuardianOpenAiApi();
+      // Prime the cache with the old key, through the real getter.
+      expect(await call(api, 'old-key')).not.toBe(401);
+
+      // Rotate in place, as writeSecretFile does (same inode, new bytes).
+      // Bump mtime explicitly: a same-millisecond rewrite of an equal-length
+      // value is the one case a stat-validated cache could otherwise miss,
+      // and the test must not depend on wall-clock granularity.
+      writeFileSync(keyFile, 'new-key\n');
+      const future = new Date(Date.now() + 2000);
+      utimesSync(keyFile, future, future);
+
+      expect(await call(api, 'new-key')).not.toBe(401);
+      expect(await call(api, 'old-key')).toBe(401);
+    } finally {
+      if (savedKeyFile === undefined) delete Bun.env.OPENAI_COMPAT_API_KEY_FILE;
+      else Bun.env.OPENAI_COMPAT_API_KEY_FILE = savedKeyFile;
+      if (savedSecretFile === undefined) delete Bun.env.PRINCIPAL_SECRET_FILE;
+      else Bun.env.PRINCIPAL_SECRET_FILE = savedSecretFile;
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
 });
 
 // --- CHARACTERIZATION: non-streaming path is a pure text accumulator ----------
@@ -304,7 +355,7 @@ describe('guardian openai api shared injectable client', () => {
     expect(streamingCalls).toContain('GET /event');
   });
 
-  it('reads the secret file from disk once and caches it by path', () => {
+  it('caches the secret file by path, and revalidates it against the file identity', () => {
     const dir = mkdtempSync(join(tmpdir(), 'op-secret-'));
     const fileA = join(dir, 'a.secret');
     const fileB = join(dir, 'b.secret');
@@ -315,9 +366,28 @@ describe('guardian openai api shared injectable client', () => {
       Bun.env.PRINCIPAL_SECRET_FILE = fileA;
       const api = new GuardianOpenAiApi();
       expect(api.secret).toBe('secret-A');
-      // Mutate on disk; a cached read must NOT observe the change (proves one read).
-      writeFileSync(fileA, 'CHANGED\n');
+
+      // An UNCHANGED file is served from cache — proven by mutating the bytes
+      // while pinning mtime+size to the same values, which is exactly what
+      // the cache validates on. (A cache that re-read unconditionally would
+      // see the new bytes here.) The stamp is set explicitly rather than
+      // restored from a natural stat: utimes takes millisecond Dates while
+      // st_mtim carries nanoseconds, so a restore cannot round-trip.
+      const pinned = new Date(Date.now() - 60_000);
+      utimesSync(fileA, pinned, pinned);
       expect(api.secret).toBe('secret-A');
+      writeFileSync(fileA, 'CHANGED-\n');
+      utimesSync(fileA, pinned, pinned);
+      expect(statSync(fileA).size).toBe('secret-A\n'.length);
+      expect(api.secret).toBe('secret-A');
+
+      // A file that actually changed is re-read: this is the rotation the
+      // Secrets tab performs, and a lifetime cache kept the revoked value.
+      writeFileSync(fileA, 'rotated-A\n');
+      const future = new Date(Date.now() + 2000);
+      utimesSync(fileA, future, future);
+      expect(api.secret).toBe('rotated-A');
+
       // Switching the env path re-reads from disk.
       Bun.env.PRINCIPAL_SECRET_FILE = fileB;
       expect(api.secret).toBe('secret-B');

--- a/packages/guardian/src/openai-api.ts
+++ b/packages/guardian/src/openai-api.ts
@@ -1,3 +1,4 @@
+import { statSync } from 'node:fs';
 import { createLogger } from './logger.ts';
 import { constantTimeEqual } from './crypto.ts';
 import { runTurn } from './openai-api-oc-events.ts';
@@ -87,8 +88,28 @@ const log = createLogger('guardian:openai-api');
 
 // Cache secret-file reads keyed by the resolved path, so the auth gate and the
 // forward/stream paths don't hit the filesystem on every request (mirrors
-// admin.ts's readAdminToken caching). A changed env path re-reads.
-const secretFileCache = new Map<string, string>();
+// admin.ts's readAdminToken caching, INCLUDING its revalidation).
+//
+// The cache is validated against the file's mtime+size on every read, not
+// held for the process lifetime. Compose grants these as file secrets — a
+// bind mount — and the Secrets tab rewrites them in place (writeFileInPlace
+// keeps the inode, so the container sees the new bytes immediately). A
+// lifetime cache therefore made a rotated `op_api_key` a no-op until someone
+// recreated the container: the revoked key kept authenticating while the UI
+// reported the new one, which is a security gap, not a staleness annoyance.
+// One `stat` per request is the same syscall admin.ts already pays.
+type CachedSecret = { mtimeMs: number; size: number; value: string };
+const secretFileCache = new Map<string, CachedSecret>();
+
+/** File identity for cache validation; `null` when it cannot be stat'd. */
+function secretFileStamp(path: string): { mtimeMs: number; size: number } | null {
+  try {
+    const stats = statSync(path);
+    return { mtimeMs: stats.mtimeMs, size: stats.size };
+  } catch {
+    return null;
+  }
+}
 // (G7) readOptionalSecretFile still THROWS SecretFileError when the env var is
 // set but the file is present-and-empty (or unreadable) — only "unset" is
 // silently optional. Left uncaught, that throw happens inside the auth-check
@@ -99,8 +120,18 @@ const secretFileCache = new Map<string, string>();
 // a clean 401, the same as "unset" and "missing file".
 function readCachedSecretFile(envKey: string): string {
   const path = Bun.env[envKey]?.trim() ?? '';
+  // An unset env var has no file to stat and no value to rotate.
+  if (!path) return '';
+
+  const stamp = secretFileStamp(path);
   const cached = secretFileCache.get(path);
-  if (cached !== undefined) return cached;
+  // A file that cannot be stat'd is re-read every time rather than served
+  // from a stale entry: the read below collapses its failure to '' (a clean
+  // 401), and caching "unreadable" would outlive the condition.
+  if (stamp && cached && cached.mtimeMs === stamp.mtimeMs && cached.size === stamp.size) {
+    return cached.value;
+  }
+
   let value = '';
   try {
     value = readOptionalSecretFile(envKey);
@@ -108,7 +139,8 @@ function readCachedSecretFile(envKey: string): string {
     if (!(err instanceof SecretFileError)) throw err;
     log.warn('secret_file_error', { envKey, reason: err.message });
   }
-  secretFileCache.set(path, value);
+  if (stamp) secretFileCache.set(path, { ...stamp, value });
+  else secretFileCache.delete(path);
   return value;
 }
 

--- a/packages/lib/src/control-plane/access-apply.test.ts
+++ b/packages/lib/src/control-plane/access-apply.test.ts
@@ -210,15 +210,6 @@ describe("applyAccessToggles", () => {
     expect(result.error).toBe("docker daemon not running");
   });
 
-  test("extraEnv rides along in the same patch", async () => {
-    const state = makeHome("");
-    const { deps } = makeDeps([]);
-
-    await applyAccessToggles(state, ALL_OFF, { deps, extraEnv: { OP_PROJECT_NAME: "renamed" } });
-
-    expect(readEnv(state).OP_PROJECT_NAME).toBe("renamed");
-  });
-
   test("skipRecreate leaves the apply to a caller that deploys the whole stack", async () => {
     const state = makeHome("OP_UI_BIND_ADDRESS=127.0.0.1\n");
     const { deps, calls } = makeDeps(["assistant"]);

--- a/packages/lib/src/control-plane/access-apply.ts
+++ b/packages/lib/src/control-plane/access-apply.ts
@@ -197,8 +197,6 @@ export async function applyAccessToggles(
   requested: unknown,
   options: {
     lock?: InstallLockHandle | null;
-    /** Extra env written in the same patch (e.g. OP_PROJECT_NAME). */
-    extraEnv?: Record<string, string>;
     /** Skip the Compose apply — the caller deploys the whole stack itself. */
     skipRecreate?: boolean;
     deps?: Partial<AccessApplyDeps>;
@@ -278,7 +276,6 @@ export async function applyAccessToggles(
   // rather than an inference from bind addresses (which is what could disagree
   // with Compose and then be made real by the following save).
   patchSecretsEnvFile(state.homeDir, {
-    ...(options.extraEnv ?? {}),
     ...resolveAccessIntentEnv(toggles),
     ...nextEnv,
   });

--- a/packages/ui/e2e/host-stack-lock-contract.vitest.ts
+++ b/packages/ui/e2e/host-stack-lock-contract.vitest.ts
@@ -9,7 +9,7 @@ const routeSource = readFileSync(
 describe('host stack access apply lock contract', () => {
   test('passes the outer admin update lock into applyAccessToggles', () => {
     expect(routeSource).toMatch(
-      /withAdminUpdateLock\(state,\s*requestId,\s*async \(lock\) => \{[\s\S]*?applyAccessToggles\([\s\S]*?\{\s*extraEnv:\s*\{ OP_PROJECT_NAME: projectName \},\s*lock,\s*\}\s*\)/,
+      /withAdminUpdateLock\(state,\s*requestId,\s*async \(lock\) => \{[\s\S]*?applyAccessToggles\([\s\S]*?\{ lock \}\s*\)/,
     );
   });
 });

--- a/packages/ui/src/lib/components/admin/secrets/SecretsTab.svelte
+++ b/packages/ui/src/lib/components/admin/secrets/SecretsTab.svelte
@@ -104,7 +104,12 @@
   <div class="panel-header">
     <div>
       <h2>Secrets</h2>
-      <p class="panel-subtitle">Encrypted key files under knowledge/secrets/</p>
+      <!-- Says what these files ARE. They are not encrypted — they are
+           plaintext, 0600, in two trees: knowledge/secrets/ (provider auth
+           the assistant reads through /stash) and private/secrets/ (delegated
+           UI/guardian/portal credentials, never in /stash). listSecretFiles
+           reads both, so naming only the first was wrong twice over. -->
+      <p class="panel-subtitle">Plaintext credential files (0600) in knowledge/secrets/ and private/secrets/</p>
     </div>
     <div class="panel-header-actions">
       <button class="btn btn-secondary btn-sm" onclick={() => void loadFiles()} disabled={filesRes.loading || busy}>

--- a/packages/ui/src/routes/api/host/stack/+server.ts
+++ b/packages/ui/src/routes/api/host/stack/+server.ts
@@ -19,6 +19,7 @@ import {
   applyAccessToggles,
   patchSecretsEnvFile,
   readStackEnv,
+  reconcileMdnsResponder,
   recordProjectRename,
   resolveMdnsStatus,
   coerceAccessToggles,
@@ -139,12 +140,33 @@ export const PUT: RequestHandler = async (event) => {
       // over mDNS only once that succeeded. Compose interpolation is the sole consumer of these values,
       // so a write alone changed nothing — and every "restart" the product
       // offers runs `compose restart`, which cannot republish a port.
-      const applied = await applyAccessToggles(state, coerceAccessToggles(body.access), {
-        extraEnv: { OP_PROJECT_NAME: projectName },
-        lock,
-      });
+      //
+      // ORDER: the toggle apply runs against the CURRENT project name, and the
+      // rename is written after it. OP_PROJECT_NAME used to ride along in this
+      // call's `extraEnv`, which landed in stack.env before the apply's own
+      // `compose ps`/`up` — and those resolve `--project-name` from the env
+      // file (buildComposeCommandArgs -> collectComposeEnvOverrides). So a
+      // save that renamed the project AND flipped a toggle addressed a project
+      // that did not exist yet: `ps` returned nothing, the recreate scope came
+      // out empty, no container was touched, and the response still advertised
+      // over mDNS. The toggle read back as applied while the running stack
+      // kept its old ports. Applying first keeps the apply pointed at the
+      // containers it must actually change; the rename then lands in its own
+      // write and is torn down by the next locked apply (#540).
+      const applied = await applyAccessToggles(state, coerceAccessToggles(body.access), { lock });
 
+      // The rename write is unconditional (it must land even when the toggle
+      // apply failed — the operator asked for both, and the failure path below
+      // reports the toggle half). recordProjectRename is what makes the next
+      // apply tear the outgoing project down.
+      patchSecretsEnvFile(state.homeDir, { OP_PROJECT_NAME: projectName });
       const projectRenamed = recordRenameIfChanged();
+
+      // mDNS names derive from OP_PROJECT_NAME (mdns-responder.ts), so the
+      // reconcile inside the apply above saw the OLD name. Re-reconcile after
+      // the rename write so the advertised `<name>.local` matches the project
+      // the operator just named — still after the containers, never before.
+      const mdns = projectRenamed ? reconcileMdnsResponder(state.homeDir) : applied.mdns;
 
       if (!applied.ok) {
         return errorResponse(
@@ -164,7 +186,7 @@ export const PUT: RequestHandler = async (event) => {
           projectName,
           projectRenamed,
           stackEnvPath: 'state/stack.env',
-          mdns: applied.mdns,
+          mdns,
           access: applied.access,
           /** Services recreated so the new binds are actually published. */
           recreated: applied.recreated,

--- a/packages/ui/src/routes/api/host/stack/rename-apply-order.vitest.ts
+++ b/packages/ui/src/routes/api/host/stack/rename-apply-order.vitest.ts
@@ -1,0 +1,116 @@
+/**
+ * A save that renames the project AND flips an access toggle must apply the
+ * toggle to the project that is actually RUNNING.
+ *
+ * OP_PROJECT_NAME used to ride along in `applyAccessToggles`'s `extraEnv`, so
+ * the new name landed in stack.env before the apply's own `compose ps` / `up`
+ * — and both resolve `--project-name` from that env file
+ * (buildComposeCommandArgs -> collectComposeEnvOverrides). The apply therefore
+ * addressed a project that did not exist yet: `ps` returned nothing, the
+ * recreate scope came out empty, no container was touched, and the response
+ * still advertised over mDNS. The toggle read back as applied while the
+ * running stack kept its old published ports.
+ *
+ * The observable invariant without Docker: at the moment applyAccessToggles
+ * runs, stack.env still names the OLD project; the rename lands after.
+ */
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { existsSync, mkdirSync, readFileSync, rmSync } from 'node:fs';
+import { randomBytes } from 'node:crypto';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+/** OP_PROJECT_NAME as stack.env held it when applyAccessToggles was entered. */
+let projectNameDuringApply: string | null = null;
+
+vi.mock('@openpalm/lib', async (orig) => {
+  const actual = await orig<typeof import('@openpalm/lib')>();
+  return {
+    ...actual,
+    applyAccessToggles: (...args: Parameters<typeof actual.applyAccessToggles>) => {
+      const [state] = args;
+      const path = join(state.homeDir, 'state', 'stack.env');
+      const content = existsSync(path) ? readFileSync(path, 'utf-8') : '';
+      projectNameDuringApply = content.match(/^OP_PROJECT_NAME=(.*)$/m)?.[1] ?? null;
+      return actual.applyAccessToggles(...args);
+    },
+  };
+});
+
+const { resetState } = await import('$lib/server/test-helpers.js');
+const { PUT } = await import('./+server.js');
+
+let rootDir = '';
+let originalHome: string | undefined;
+
+function makePutEvent(body: unknown) {
+  const url = new URL('http://localhost/api/host/stack');
+  return {
+    request: new Request(url, {
+      method: 'PUT',
+      headers: {
+        cookie: 'op_session=admin-token',
+        'x-request-id': 'req-host-stack-order',
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify(body),
+    }),
+    url,
+    params: {},
+  } as Parameters<typeof PUT>[0];
+}
+
+const ALL_OFF = {
+  networkAccess: false,
+  assistantDirect: false,
+  guardianNetwork: false,
+  guardianOpenaiApi: false,
+};
+
+beforeEach(() => {
+  process.env.OP_ENABLE_ADMIN = '1';
+  rootDir = join(tmpdir(), `openpalm-stack-order-${randomBytes(4).toString('hex')}`);
+  mkdirSync(rootDir, { recursive: true });
+  originalHome = process.env.OP_HOME;
+  process.env.OP_HOME = rootDir;
+  projectNameDuringApply = null;
+  resetState('admin-token');
+});
+
+afterEach(() => {
+  if (originalHome === undefined) delete process.env.OP_HOME;
+  else process.env.OP_HOME = originalHome;
+  delete process.env.OP_ENABLE_ADMIN;
+  rmSync(rootDir, { recursive: true, force: true });
+});
+
+describe('PUT /api/host/stack — rename + toggle ordering', () => {
+  test('the toggle apply sees the OLD project name; the rename lands after it', async () => {
+    const res = await PUT(
+      makePutEvent({ projectName: 'renamed-stack', access: { ...ALL_OFF, networkAccess: true } }),
+    );
+    expect(res.status).toBe(200);
+
+    // The apply ran against the project that is actually running — either the
+    // pre-save name or an unset key (a fresh home), never the new name.
+    expect(projectNameDuringApply).not.toBe('renamed-stack');
+
+    // ...and the rename still landed, with the marker the next apply needs.
+    const stackEnv = readFileSync(join(rootDir, 'state', 'stack.env'), 'utf-8');
+    expect(stackEnv).toMatch(/^OP_PROJECT_NAME=renamed-stack$/m);
+    expect(stackEnv).toMatch(/^OP_UI_BIND_ADDRESS=0\.0\.0\.0$/m);
+    expect((await res.json() as Record<string, unknown>).projectRenamed).toBe(true);
+  });
+
+  test('a toggle-only save (no rename) still applies and reports no rename', async () => {
+    const res = await PUT(
+      makePutEvent({ projectName: 'openpalm', access: { ...ALL_OFF, networkAccess: true } }),
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.projectRenamed).toBe(false);
+    expect(readFileSync(join(rootDir, 'state', 'stack.env'), 'utf-8')).toMatch(
+      /^OP_UI_BIND_ADDRESS=0\.0\.0\.0$/m,
+    );
+  });
+});


### PR DESCRIPTION
The three backlog items the prior session's audit reported but had **not verified**. I reproduced each against the real code path before fixing; all three were real. Two are the same shape the last two cycles kept finding — *a write is not an apply*.

## 1. The guardian served a revoked API key until recreate (security)

`packages/guardian/src/openai-api.ts` cached secret-file reads keyed by path alone, for the process lifetime. Compose grants `op_api_key` / `portal_api_secret` as **file secrets** (a bind mount) and `writeSecretFile` rewrites in place (same inode), so the container already sees new bytes the moment the Secrets tab saves — only the in-process cache was stale. Rotating the key therefore did nothing until someone recreated the guardian: **the revoked key kept authenticating** while the UI showed the new one. The host UI half was already fine (`session-store.ts` re-reads live), which is why the audit flagged only the guardian.

The cache now revalidates against the file's `mtime`+`size` on every read — exactly what the code comment always claimed ("mirrors `admin.ts`'s `readAdminToken` caching"; that one *does* revalidate, this one didn't). One `stat` per request, the same syscall `admin.ts` already pays.

The existing test **pinned the bug** — it asserted an on-disk change is *not* observed ("proves one read"). It now pins both halves: an unchanged file is still served from cache (bytes mutated under a deliberately pinned `mtime`+`size`, since that is what the cache validates on), and a rotated file is re-read. A second test walks the full auth path: prime with `old-key`, rotate, `new-key` authenticates and `old-key` gets a 401.

## 2. Rename + access toggle in one save applied neither

`api/host/stack/+server.ts` passed `OP_PROJECT_NAME` through `applyAccessToggles`'s `extraEnv`, so the new name landed in `stack.env` **before** the apply's own `compose ps` / `up` — and both resolve `--project-name` from that env file (`buildComposeCommandArgs` → `collectComposeEnvOverrides`). The apply addressed a project that did not exist yet: `ps` returned nothing, the recreate scope came out empty, no container was touched, and the response still advertised over mDNS. The toggle read back as applied while the running stack kept its old published ports.

The toggle apply now runs **first**, against the project that is actually running; the rename lands in its own write afterwards and is torn down by the next locked apply (#540). mDNS is re-reconciled after the rename write, since `.local` names derive from `OP_PROJECT_NAME` — still after the containers, never before. `extraEnv` had no other caller and is deleted rather than left as a loaded footgun.

New `rename-apply-order.vitest.ts` pins the invariant that is observable without Docker: at the moment `applyAccessToggles` is entered, `stack.env` still names the old project — and the rename still lands, with its marker. The existing lock-contract regex is updated to the new call shape.

## 3. Secrets tab described the files wrongly

`SecretsTab.svelte:107` said "Encrypted key files under knowledge/secrets/". They are **plaintext, 0600**, and `listSecretFiles` spans **two** trees (`knowledge/secrets/` and `private/secrets/`) — wrong twice over, on a panel whose whole job is telling the operator what they are handling. Now: "Plaintext credential files (0600) in knowledge/secrets/ and private/secrets/".

## Verification

- `bun test packages/lib` 1544 pass / 0 fail; guardian + cli + portals + scripts 875 pass / 0 fail (includes the two rewritten/added guardian cache tests).
- `packages/ui` server-project vitest for `api/host/stack/`: 28 pass (3 files, including the new ordering test). Full UI vitest: 2159 pass, with the same 2 pre-existing chromium focus-outline failures that fail identically on `main` in this container.
- `bun run check` 0 errors; CLI `tsc --noEmit` clean; `bun run lint` only the pre-existing `install.ts:385` warning.

**Not run here** (no Docker daemon in this container): the rootless smokes and e2e lane — CI runs them. The rotation fix's end-to-end proof (rotate in the tab, next request uses the new key, no recreate) needs a live stack; the unit tests cover the cache-invalidation contract that was the actual defect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AqFsC3UuCwXL7S7oY1gTho

---
_Generated by [Claude Code](https://claude.ai/code/session_01AqFsC3UuCwXL7S7oY1gTho)_