### PR TITLE
fix: make akm task scheduling actually work (three-layer fix) + compose error reporting

### DIFF
--- a/containers/assistant/Dockerfile
+++ b/containers/assistant/Dockerfile
@@ -91,17 +91,23 @@ ARG BUN_VERSION=bun-v1.3.10
 # Re-export for runtime introspection.
 ENV BUN_VERSION=${BUN_VERSION}
 
-# Combined OS packages: base tools (tini) + assistant-specific (busybox
-# crond/crontab tooling, python3, jq, gh) + sqlite3 so agents can query
-# SQLite directly. The Postgres client package and the unused GLib runtime
-# library were dropped (IMG-5, 0.13.0): nothing links the latter, and
-# nothing in this image talks to Postgres — its client is one
-# `apt-get install` away on-session for anyone who needs it.
+# Combined OS packages: base tools (tini) + assistant-specific (python3, jq,
+# gh) + sqlite3 so agents can query SQLite directly. The Postgres client
+# package and the unused GLib runtime library were dropped (IMG-5, 0.13.0):
+# nothing links the latter, and nothing in this image talks to Postgres — its
+# client is one `apt-get install` away on-session for anyone who needs it.
+#
+# busybox went with them. It was here only for crond/crontab, and neither can
+# work in this image: busybox crond loads a crontab only when the file is owned
+# by uid 0 (DAEMON_UID in miscutils/crond.c — other files are skipped with no
+# log line at all), and its job children call setgroups/setgid/setuid before
+# exec, which fail as "Operation not permitted" for an unprivileged user. This
+# image runs as uid 1000, so scheduled tasks silently never ran. See the
+# supercronic install below.
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         tini curl git ca-certificates bash unzip \
         libnss-wrapper \
-        busybox \
         python3 jq \
         sqlite3 \
     && curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
@@ -111,6 +117,28 @@ RUN apt-get update \
     && apt-get update \
     && apt-get install -y --no-install-recommends gh \
     && rm -rf /var/lib/apt/lists/*
+
+# supercronic — cron that runs correctly as an unprivileged user. It executes
+# jobs as the invoking user (no setuid, no root-owned-crontab requirement), and
+# `-inotify` reloads the crontab in place when `akm task sync` rewrites it, so
+# the entrypoint needs no restart/signal plumbing. Logs go to stderr, which is
+# how scheduled runs finally become visible in `openpalm logs assistant`.
+#
+# Pinned by version AND per-arch sha256 (upstream publishes no checksum file),
+# verified before the binary is made executable.
+ARG SUPERCRONIC_VERSION=v0.2.48
+ARG TARGETARCH
+RUN set -eux; \
+    case "${TARGETARCH}" in \
+      amd64) supercronic_sha=88c1b66b94c486f972fdd1a4d1f901e3e75ff04f749cddd60c5db573e3a33c6c ;; \
+      arm64) supercronic_sha=50ae8755e04fa72812d0a1bc47a112a856811cc91cce7b6c875c378a850788bc ;; \
+      *) echo "unsupported TARGETARCH for supercronic: ${TARGETARCH}" >&2; exit 1 ;; \
+    esac; \
+    curl -fsSL -o /usr/local/bin/supercronic \
+      "https://github.com/aptible/supercronic/releases/download/${SUPERCRONIC_VERSION}/supercronic-linux-${TARGETARCH}"; \
+    echo "${supercronic_sha}  /usr/local/bin/supercronic" | sha256sum -c -; \
+    chmod 0755 /usr/local/bin/supercronic; \
+    supercronic -version
 
 # Install Bun into /usr/local. Later we override BUN_INSTALL +
 # BUN_INSTALL_CACHE_DIR to per-user paths so unprivileged users can install

--- a/containers/assistant/entrypoint.sh
+++ b/containers/assistant/entrypoint.sh
@@ -647,8 +647,15 @@ CRONTAB_SHIM
     while true; do
       sleep 60
       if command -v akm >/dev/null 2>&1 && [ -d "$tasks_dir" ]; then
-        if ! run_akm_command akm task sync --rebind >&2; then
+        # Capture rather than stream: this runs every 60s and akm prints its
+        # full JSON report plus a --rebind advisory on EVERY sync, changes or
+        # not — ~1440 blobs a day drowning `openpalm logs assistant`. On
+        # failure the captured output is emitted in full, so the detail that
+        # made the original breakage diagnosable is not lost.
+        local sync_out
+        if ! sync_out="$(run_akm_command akm task sync --rebind 2>&1)"; then
           echo "warning: background akm task sync failed; retrying in 60s" >&2
+          printf '%s\n' "$sync_out" >&2
         fi
       fi
     done

--- a/containers/assistant/entrypoint.sh
+++ b/containers/assistant/entrypoint.sh
@@ -556,10 +556,28 @@ start_cron_and_sync_tasks() {
   local preserved_crontab=""
   mkdir -p "$spool_dir" "$wrapper_dir"
   install -m 755 /dev/null "$crontab_wrapper"
-  # NOTE: the format string is single-quoted, so `$@` must NOT be escaped —
-  # bash printf passes `\$` through literally, which would bake the literal
-  # string `$@` into the wrapper and break every crontab invocation.
-  printf '#!/usr/bin/env sh\nexec busybox crontab -c %s "$@"\n' "$spool_dir" > "$crontab_wrapper"
+  # This shim used to `exec busybox crontab -c "$spool_dir" "$@"`, which could
+  # never work here: busybox's crontab applet checks that it is root (or suid)
+  # BEFORE it honours -c, and this container runs as an unprivileged uid. Every
+  # invocation died with "crontab: must be suid to work properly" — including
+  # the two below, whose `2>/dev/null || true` hid it at boot. The visible
+  # symptom was the akm re-sync loop failing every 60s forever while the spool
+  # dir stayed empty, so no scheduled automation ran at all.
+  #
+  # `crond -c` reads plain crontab FILES out of the spool dir, so the shim
+  # writes that file directly and skips the applet (and its root check).
+  {
+    printf '#!/usr/bin/env sh\nf=%s/$(id -un)\n' "$spool_dir"
+    cat <<'CRONTAB_SHIM'
+case "${1:--}" in
+  -l) cat "$f" 2>/dev/null; exit 0 ;;
+  -r) rm -f "$f" ;;
+  -)  cat > "$f" ;;
+  -*) echo "crontab: unsupported option: $1" >&2; exit 1 ;;
+  *)  cat "$1" > "$f" ;;
+esac
+CRONTAB_SHIM
+  } > "$crontab_wrapper"
   export PATH="$wrapper_dir:$PATH"
   # Derive the cron PATH from the boot-time PATH (wrapper dir already first,
   # exported above) so scheduled tasks see the same tools as interactive
@@ -597,8 +615,10 @@ start_cron_and_sync_tasks() {
   fi
 
   # Install the managed preamble before syncing so akm preserves it when it
-  # writes task blocks into the same per-user crontab.
-  crontab "$crontab_file" 2>/dev/null || true
+  # writes task blocks into the same per-user crontab. No `2>/dev/null || true`:
+  # silencing this is what let a shim that could never work ship unnoticed —
+  # boot looked clean while nothing was ever scheduled.
+  crontab "$crontab_file" || echo "warning: could not install the managed crontab preamble" >&2
 
   # Sync automation tasks from the akm bundle into cron, then start cron.
   local tasks_dir="${AKM_BUNDLE_DIR:-/stash}/tasks"

--- a/containers/assistant/entrypoint.sh
+++ b/containers/assistant/entrypoint.sh
@@ -623,7 +623,7 @@ CRONTAB_SHIM
   # Sync automation tasks from the akm bundle into cron, then start cron.
   local tasks_dir="${AKM_BUNDLE_DIR:-/stash}/tasks"
   if command -v akm >/dev/null 2>&1 && [ -d "$tasks_dir" ]; then
-    if ! run_akm_command akm task sync >&2; then
+    if ! run_akm_command akm task sync --rebind >&2; then
       echo "warning: initial akm task sync failed; continuing startup" >&2
     fi
   fi
@@ -640,7 +640,7 @@ CRONTAB_SHIM
     while true; do
       sleep 60
       if command -v akm >/dev/null 2>&1 && [ -d "$tasks_dir" ]; then
-        if ! run_akm_command akm task sync >&2; then
+        if ! run_akm_command akm task sync --rebind >&2; then
           echo "warning: background akm task sync failed; retrying in 60s" >&2
         fi
       fi

--- a/containers/assistant/entrypoint.sh
+++ b/containers/assistant/entrypoint.sh
@@ -598,11 +598,14 @@ CRONTAB_SHIM
   echo "SHELL=/bin/bash" >> "$crontab_file"
   echo "PATH=$cron_path" >> "$crontab_file"
 
-  # Forward selected env vars into cron jobs
+  # Forward selected env vars into cron jobs. Plain `NAME=value` — the crontab
+  # env-assignment syntax. These were written as `export NAME="value"`, which
+  # is shell, not crontab: supercronic rejects the file outright and busybox
+  # crond never applied them, so jobs ran without this env either way.
   for var in HOME AKM_BUNDLE_DIR AKM_CONFIG_DIR AKM_CACHE_DIR AKM_DATA_DIR \
              AKM_STATE_DIR OPENCODE_API_URL OPENCODE_CONFIG_DIR; do
     if [ -n "${!var:-}" ]; then
-      echo "export $var=\"${!var}\"" >> "$crontab_file"
+      echo "$var=${!var}" >> "$crontab_file"
     fi
   done
   echo "# openpalm:cron-preamble END" >> "$crontab_file"
@@ -628,11 +631,15 @@ CRONTAB_SHIM
     fi
   fi
 
-  if [ -f "$crontab_file" ]; then
-    rm -f "$crontab_file"
-    if ! busybox crond -c "$spool_dir" -L /dev/stderr; then
-      echo "warning: busybox crond failed to start; scheduled automations will not run" >&2
-    fi
+  rm -f "$crontab_file"
+
+  # supercronic runs in the foreground and reloads on write, so it is
+  # backgrounded here and needs no signal plumbing: the re-sync loop below
+  # rewrites the same file in place and -inotify picks it up.
+  if command -v supercronic >/dev/null 2>&1; then
+    supercronic -inotify "$spool_dir/$(id -un)" &
+  else
+    echo "warning: supercronic not found; scheduled automations will not run" >&2
   fi
 
   # Background re-sync loop: picks up task file changes without restart

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -144,6 +144,48 @@ For a host model server, a container cannot use the host's `localhost`. Use
 http://host.docker.internal:11434/v1
 ```
 
+## Model List Is Empty / "Unexpected server error" on Reload
+
+`knowledge/secrets/auth.json` holds one entry per connected provider. If it
+holds an entry for a provider OpenCode cannot resolve — one that is absent from
+models.dev and undeclared in any `opencode.json`/`opencode.jsonc` — then
+`Provider.list` throws and **every** provider request fails, not just that one.
+The model picker goes empty and reloads report an unexpected server error.
+
+This happens when a provider you connected is later renamed or dropped from
+OpenCode's catalog: the credential outlives the provider.
+
+Find the orphans:
+
+```bash
+docker exec openpalm-assistant-1 node -e 'const f=require("fs"),h=process.env.HOME,d=JSON.parse(f.readFileSync(h+"/.cache/opencode/models.json","utf8")),a=JSON.parse(f.readFileSync(h+"/.local/share/opencode/auth.json","utf8"));console.log(Object.keys(a).filter(p=>!d[p]))'
+```
+
+Any provider printed that you have not declared yourself under `provider` in
+`config/assistant/opencode.jsonc` is orphaned. Remove it from
+`knowledge/secrets/auth.json` and recreate the assistant.
+
+## Connecting Another OpenCode Client
+
+Point external clients at the **assistant** port, not the UI:
+
+```text
+http://127.0.0.1:3810
+```
+
+Username `opencode`; password is the contents of
+`private/secrets/op_opencode_password`. This is **not** the UI login password —
+that one only signs in to the OpenPalm UI and Opencode will reject it.
+
+Two things that look right but are not:
+
+- `.../oc` is the UI's own same-origin proxy. It authenticates with the browser
+  session cookie only, strips `Authorization`, and answers `405` to `OPTIONS`,
+  so no external client can use it.
+- `localhost` resolves to `::1` first on many systems, while the UI listens on
+  IPv4 `127.0.0.1` only. Clients that do not fall back to IPv4 report "could
+  not connect". Always use the literal `127.0.0.1`.
+
 ## Portal Authentication Fails
 
 For `401` or `403` responses:

--- a/packages/cli/src/commands/admin.test.ts
+++ b/packages/cli/src/commands/admin.test.ts
@@ -32,10 +32,11 @@
  */
 import { afterEach, describe, expect, it, mock } from 'bun:test';
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { createServer as netCreateServer } from 'node:net';
 import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { renderUsage, runCommand, type CommandDef } from 'citty';
+import { type CommandDef, renderUsage, runCommand } from 'citty';
 import * as realLib from '../../../lib/src/index.ts';
 import type { UIServerOptions } from '../lib/ui-server.ts';
 
@@ -51,14 +52,14 @@ const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../../../..')
 const ESC = String.fromCharCode(27);
 /** Strip ANSI color codes from citty usage output. */
 function stripAnsi(s: string): string {
-  return s.replace(new RegExp(`${ESC}\\[[0-9;]*m`, 'g'), '');
+	return s.replace(new RegExp(`${ESC}\\[[0-9;]*m`, 'g'), '');
 }
 
 // ── Serve harness ────────────────────────────────────────────────────────────
 
 interface CapturedSpawn {
-  argv: string[];
-  env: Record<string, string | undefined> | undefined;
+	argv: string[];
+	env: Record<string, string | undefined> | undefined;
 }
 
 const originalBunSpawn = Bun.spawn;
@@ -66,91 +67,91 @@ const originalFetch = globalThis.fetch;
 const originalLog = console.log;
 const originalWarn = console.warn;
 const SAVED_ENV_KEYS = [
-  'OP_HOME',
-  'OP_ENABLE_ADMIN',
-  'OP_ALLOW_REMOTE_SETUP',
-  'OP_HOST_UI_PORT',
-  'OPENPALM_REPO_ROOT',
-  'OPENPALM_SKELETON_DIR',
-  'OP_ASSISTANT_PORT'
+	'OP_HOME',
+	'OP_ENABLE_ADMIN',
+	'OP_ALLOW_REMOTE_SETUP',
+	'OP_HOST_UI_PORT',
+	'OPENPALM_REPO_ROOT',
+	'OPENPALM_SKELETON_DIR',
+	'OP_ASSISTANT_PORT'
 ] as const;
 const savedEnv: Record<string, string | undefined> = {};
 for (const key of SAVED_ENV_KEYS) savedEnv[key] = process.env[key];
 const tmpDirs: string[] = [];
 
 afterEach(() => {
-  mock.restore();
-  restoreOpenPalmLib();
-  Bun.spawn = originalBunSpawn;
-  globalThis.fetch = originalFetch;
-  console.log = originalLog;
-  console.warn = originalWarn;
-  for (const key of SAVED_ENV_KEYS) {
-    if (savedEnv[key] === undefined) delete process.env[key];
-    else process.env[key] = savedEnv[key];
-  }
-  for (const dir of tmpDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+	mock.restore();
+	restoreOpenPalmLib();
+	Bun.spawn = originalBunSpawn;
+	globalThis.fetch = originalFetch;
+	console.log = originalLog;
+	console.warn = originalWarn;
+	for (const key of SAVED_ENV_KEYS) {
+		if (savedEnv[key] === undefined) delete process.env[key];
+		else process.env[key] = savedEnv[key];
+	}
+	for (const dir of tmpDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
 });
 
 function restoreOpenPalmLib(): void {
-  mock.restore();
-  mock.module('@openpalm/lib', () => ({ ...realLib }));
-  mock.module(cliStateModuleUrl, () => ({
-    ensureValidState: () => {
-      const state = realLib.createState();
-      if (realLib.classifyLocalInstall(state.stackDir, state.homeDir) === 'not_installed') {
-        throw new Error('OpenPalm is not installed in this OP_HOME yet. Run `openpalm install` first.');
-      }
-      state.artifacts = realLib.resolveRuntimeFiles();
-      return state;
-    },
-    resolveServeState: () => {
-      const state = realLib.createState();
-      if (realLib.classifyLocalInstall(state.stackDir, state.homeDir) === 'not_installed') return state;
-      state.artifacts = realLib.resolveRuntimeFiles();
-      return state;
-    },
-    migrateBestEffort: () => {},
-  }));
+	mock.restore();
+	mock.module('@openpalm/lib', () => ({ ...realLib }));
+	mock.module(cliStateModuleUrl, () => ({
+		ensureValidState: () => {
+			const state = realLib.createState();
+			if (realLib.classifyLocalInstall(state.stackDir, state.homeDir) === 'not_installed') {
+				throw new Error(
+					'OpenPalm is not installed in this OP_HOME yet. Run `openpalm install` first.'
+				);
+			}
+			state.artifacts = realLib.resolveRuntimeFiles();
+			return state;
+		},
+		resolveServeState: () => {
+			const state = realLib.createState();
+			if (realLib.classifyLocalInstall(state.stackDir, state.homeDir) === 'not_installed')
+				return state;
+			state.artifacts = realLib.resolveRuntimeFiles();
+			return state;
+		},
+		migrateBestEffort: () => {}
+	}));
 }
 
 /** Capture every Bun.spawn call; no real process is ever launched. */
 function captureSpawns(): CapturedSpawn[] {
-  const calls: CapturedSpawn[] = [];
-  Bun.spawn = ((
-    argv: readonly string[],
-    opts?: { env?: Record<string, string | undefined> }
-  ) => {
-    calls.push({ argv: [...argv], env: opts?.env });
-    return {
-      pid: 0,
-      exited: new Promise<number>(() => {}), // stays "alive"
-      exitCode: null,
-      signalCode: null,
-      killed: false,
-      stdin: null,
-      stdout: null,
-      stderr: null,
-      kill: () => {},
-      ref: () => {},
-      unref: () => {},
-      [Symbol.asyncDispose]: async () => {},
-      resourceUsage: () => undefined
-    };
-  }) as unknown as typeof Bun.spawn;
-  return calls;
+	const calls: CapturedSpawn[] = [];
+	Bun.spawn = ((argv: readonly string[], opts?: { env?: Record<string, string | undefined> }) => {
+		calls.push({ argv: [...argv], env: opts?.env });
+		return {
+			pid: 0,
+			exited: new Promise<number>(() => {}), // stays "alive"
+			exitCode: null,
+			signalCode: null,
+			killed: false,
+			stdin: null,
+			stdout: null,
+			stderr: null,
+			kill: () => {},
+			ref: () => {},
+			unref: () => {},
+			[Symbol.asyncDispose]: async () => {},
+			resourceUsage: () => undefined
+		};
+	}) as unknown as typeof Bun.spawn;
+	return calls;
 }
 
 /** Capture console.log/console.warn lines (startUIServer prints the URL there). */
 function captureLogs(): string[] {
-  const lines: string[] = [];
-  console.log = ((...args: unknown[]) => {
-    lines.push(args.map(String).join(' '));
-  }) as typeof console.log;
-  console.warn = ((...args: unknown[]) => {
-    lines.push(args.map(String).join(' '));
-  }) as typeof console.warn;
-  return lines;
+	const lines: string[] = [];
+	console.log = ((...args: unknown[]) => {
+		lines.push(args.map(String).join(' '));
+	}) as typeof console.log;
+	console.warn = ((...args: unknown[]) => {
+		lines.push(args.map(String).join(' '));
+	}) as typeof console.warn;
+	return lines;
 }
 
 /**
@@ -164,31 +165,31 @@ function captureLogs(): string[] {
  * checkAndUpdate* self-update helpers absorb non-fatally by design.
  */
 function seedServeHome(opts: { installed: boolean }): string {
-  const home = mkdtempSync(join(tmpdir(), 'openpalm-admin-red-'));
-  tmpDirs.push(home);
-  mkdirSync(join(home, 'data', 'ui'), { recursive: true });
-  writeFileSync(join(home, 'data', 'ui', 'index.js'), '// stub adapter-node entry\n');
-  if (opts.installed) {
-    mkdirSync(join(home, 'system', 'stack'), { recursive: true });
-    writeFileSync(join(home, 'system', 'stack', 'core.compose.yml'), 'services: {}\n');
-    mkdirSync(join(home, 'state'), { recursive: true });
-    writeFileSync(join(home, 'state', 'stack.env'), 'OP_SETUP_COMPLETE=true\n');
-  }
-  process.env.OP_HOME = home;
-  // Make sure nothing ambient can fake an admin-mode pass (spawnUiChild
-  // spreads process.env into the child env).
-  delete process.env.OP_ENABLE_ADMIN;
-  delete process.env.OP_ALLOW_REMOTE_SETUP;
-  delete process.env.OP_HOST_UI_PORT;
-  delete process.env.OPENPALM_SKELETON_DIR;
-  delete process.env.OP_ASSISTANT_PORT;
-  process.env.OPENPALM_REPO_ROOT = repoRoot;
-  globalThis.fetch = (async (input: string | URL | Request) => {
-    const url = String(input instanceof Request ? input.url : input);
-    if (url.endsWith('/health')) return new Response('ok', { status: 200 });
-    throw new TypeError('fetch failed');
-  }) as unknown as typeof fetch;
-  return home;
+	const home = mkdtempSync(join(tmpdir(), 'openpalm-admin-red-'));
+	tmpDirs.push(home);
+	mkdirSync(join(home, 'data', 'ui'), { recursive: true });
+	writeFileSync(join(home, 'data', 'ui', 'index.js'), '// stub adapter-node entry\n');
+	if (opts.installed) {
+		mkdirSync(join(home, 'system', 'stack'), { recursive: true });
+		writeFileSync(join(home, 'system', 'stack', 'core.compose.yml'), 'services: {}\n');
+		mkdirSync(join(home, 'state'), { recursive: true });
+		writeFileSync(join(home, 'state', 'stack.env'), 'OP_SETUP_COMPLETE=true\n');
+	}
+	process.env.OP_HOME = home;
+	// Make sure nothing ambient can fake an admin-mode pass (spawnUiChild
+	// spreads process.env into the child env).
+	delete process.env.OP_ENABLE_ADMIN;
+	delete process.env.OP_ALLOW_REMOTE_SETUP;
+	delete process.env.OP_HOST_UI_PORT;
+	delete process.env.OPENPALM_SKELETON_DIR;
+	delete process.env.OP_ASSISTANT_PORT;
+	process.env.OPENPALM_REPO_ROOT = repoRoot;
+	globalThis.fetch = (async (input: string | URL | Request) => {
+		const url = String(input instanceof Request ? input.url : input);
+		if (url.endsWith('/health')) return new Response('ok', { status: 200 });
+		throw new TypeError('fetch failed');
+	}) as unknown as typeof fetch;
+	return home;
 }
 
 /**
@@ -196,32 +197,32 @@ function seedServeHome(opts: { installed: boolean }): string {
  * rejection instead of a misleading timeout.
  */
 async function waitFor<T>(
-  get: () => T | undefined,
-  what: string,
-  failed?: () => unknown,
-  timeoutMs = 5000
+	get: () => T | undefined,
+	what: string,
+	failed?: () => unknown,
+	timeoutMs = 5000
 ): Promise<T> {
-  const deadline = Date.now() + timeoutMs;
-  for (;;) {
-    const err = failed?.();
-    if (err !== undefined) {
-      throw new Error(`${what}: command rejected first: ${String(err)}`);
-    }
-    const value = get();
-    if (value !== undefined) return value;
-    if (Date.now() > deadline) throw new Error(`timed out waiting for ${what}`);
-    await new Promise((resolve) => setTimeout(resolve, 10));
-  }
+	const deadline = Date.now() + timeoutMs;
+	for (;;) {
+		const err = failed?.();
+		if (err !== undefined) {
+			throw new Error(`${what}: command rejected first: ${String(err)}`);
+		}
+		const value = get();
+		if (value !== undefined) return value;
+		if (Date.now() > deadline) throw new Error(`timed out waiting for ${what}`);
+		await new Promise((resolve) => setTimeout(resolve, 10));
+	}
 }
 
 /** The spawned UI child is the only capture that carries PORT in its env. */
 function uiChildSpawn(calls: CapturedSpawn[], port: number): CapturedSpawn | undefined {
-  return calls.find((c) => c.env?.PORT === String(port));
+	return calls.find((c) => c.env?.PORT === String(port));
 }
 
 /** openBrowser spawns the platform opener with the URL and NO env option. */
 function browserSpawn(calls: CapturedSpawn[], port: number): CapturedSpawn | undefined {
-  return calls.find((c) => c.env === undefined && c.argv.some((a) => a.includes(`:${port}`)));
+	return calls.find((c) => c.env === undefined && c.argv.some((a) => a.includes(`:${port}`)));
 }
 
 /**
@@ -230,313 +231,328 @@ function browserSpawn(calls: CapturedSpawn[], port: number): CapturedSpawn | und
  * until SIGINT/SIGTERM, so the returned promise never resolves on success.
  */
 async function runAdmin(rawArgs: string[]): Promise<{ error?: unknown }> {
-  restoreOpenPalmLib();
-  const state: { error?: unknown } = {};
-  const mod = (await import(`${adminModuleUrl}?t=${Math.random()}`)) as { default: CommandDef };
-  void runCommand(mod.default, { rawArgs }).catch((e: unknown) => {
-    state.error = e ?? new Error('admin command rejected');
-  });
-  return state;
+	restoreOpenPalmLib();
+	const state: { error?: unknown } = {};
+	const mod = (await import(`${adminModuleUrl}?t=${Math.random()}`)) as { default: CommandDef };
+	void runCommand(mod.default, { rawArgs }).catch((e: unknown) => {
+		state.error = e ?? new Error('admin command rejected');
+	});
+	return state;
 }
 
 // ── Registration + help (#556) ───────────────────────────────────────────────
 
 describe('admin subcommand registration (#556)', () => {
-  it('registers `admin` in the main subCommands map', async () => {
-    restoreOpenPalmLib();
-    const { mainCommand } = await import(`${mainModuleUrl}?t=${Math.random()}`) as { mainCommand: CommandDef };
-    const sub = (mainCommand.subCommands as Record<string, () => Promise<unknown>>).admin;
-    expect(typeof sub).toBe('function');
-    const cmd = (await sub()) as { meta?: { name?: string; description?: string } };
-    expect(cmd.meta?.name).toBe('admin');
-    // A non-empty description so `openpalm --help` renders a useful COMMANDS row.
-    expect(cmd.meta?.description ?? '').not.toBe('');
-  });
+	it('registers `admin` in the main subCommands map', async () => {
+		restoreOpenPalmLib();
+		const { mainCommand } = (await import(`${mainModuleUrl}?t=${Math.random()}`)) as {
+			mainCommand: CommandDef;
+		};
+		const sub = (mainCommand.subCommands as Record<string, () => Promise<unknown>>).admin;
+		expect(typeof sub).toBe('function');
+		const cmd = (await sub()) as { meta?: { name?: string; description?: string } };
+		expect(cmd.meta?.name).toBe('admin');
+		// A non-empty description so `openpalm --help` renders a useful COMMANDS row.
+		expect(cmd.meta?.description ?? '').not.toBe('');
+	});
 
-  it('lists `admin` in the CLI help output', async () => {
-    restoreOpenPalmLib();
-    const { mainCommand } = await import(`${mainModuleUrl}?t=${Math.random()}`) as { mainCommand: CommandDef };
-    const usage = stripAnsi(await renderUsage(mainCommand));
-    // The COMMANDS table renders each entry as "  <name>  <description>".
-    expect(usage).toMatch(/^\s*admin\b/m);
-  });
+	it('lists `admin` in the CLI help output', async () => {
+		restoreOpenPalmLib();
+		const { mainCommand } = (await import(`${mainModuleUrl}?t=${Math.random()}`)) as {
+			mainCommand: CommandDef;
+		};
+		const usage = stripAnsi(await renderUsage(mainCommand));
+		// The COMMANDS table renders each entry as "  <name>  <description>".
+		expect(usage).toMatch(/^\s*admin\b/m);
+	});
 });
+
+/**
+ * A port nothing else on the machine owns.
+ *
+ * This suite used to hardcode 4611. `runAdmin` performs a REAL preflight
+ * (`checkExistingUiInstance`), so any unrelated process holding that number
+ * fails the test with "Port 4611 is already in use by another program" — and
+ * because `bun test` runs files in order, that aborts the whole non-UI suite,
+ * not just this file. It happened: a leftover dev server from an unrelated
+ * project sat on 4611 for days and silently skipped this gate on every local
+ * run. A test must not depend on a magic number being free.
+ */
+async function freeLoopbackPort(): Promise<number> {
+	const server = netCreateServer();
+	const port = await new Promise<number>((resolve, reject) => {
+		server.once('error', reject);
+		server.listen(0, '127.0.0.1', () => {
+			const address = server.address();
+			resolve(typeof address === 'object' && address ? address.port : 0);
+		});
+	});
+	await new Promise<void>((resolve) => server.close(() => resolve()));
+	if (!port) throw new Error('could not reserve an ephemeral port');
+	return port;
+}
 
 // ── Serve mode: admin env + loopback enforcement (#556) ─────────────────────
 
 describe('openpalm admin serve mode (#556)', () => {
-  it(
-    'spawns the UI child with the admin capability env, prints the URL, opens the browser',
-    async () => {
-      seedServeHome({ installed: true });
-      const calls = captureSpawns();
-      const logs = captureLogs();
+	it('spawns the UI child with the admin capability env, prints the URL, opens the browser', async () => {
+		seedServeHome({ installed: true });
+		const calls = captureSpawns();
+		const logs = captureLogs();
 
-      const run = await runAdmin(['--port', '4611']);
+		const servePort = await freeLoopbackPort();
+		const run = await runAdmin(['--port', String(servePort)]);
 
-      const child = await waitFor(
-        () => uiChildSpawn(calls, 4611),
-        'admin UI child spawn',
-        () => run.error
-      );
-      // Admin capability enabled in the spawned UI server env.
-      expect(child.env?.OP_ENABLE_ADMIN).toBe('1');
-      // Loopback-only bind with a pinned loopback origin.
-      expect(child.env?.HOST).toBe('127.0.0.1');
-      expect(child.env?.PORT).toBe('4611');
-      expect(child.env?.ORIGIN).toBe('http://127.0.0.1:4611');
-      expect(child.env?.HOST_HEADER).toBeUndefined();
-      expect(child.env?.PROTOCOL_HEADER).toBeUndefined();
+		const child = await waitFor(
+			() => uiChildSpawn(calls, servePort),
+			'admin UI child spawn',
+			() => run.error
+		);
+		// Admin capability enabled in the spawned UI server env.
+		expect(child.env?.OP_ENABLE_ADMIN).toBe('1');
+		// Loopback-only bind with a pinned loopback origin.
+		expect(child.env?.HOST).toBe('127.0.0.1');
+		expect(child.env?.PORT).toBe(String(servePort));
+		expect(child.env?.ORIGIN).toBe(`http://127.0.0.1:${servePort}`);
+		expect(child.env?.HOST_HEADER).toBeUndefined();
+		expect(child.env?.PROTOCOL_HEADER).toBeUndefined();
 
-      // Prints the URL…
-      await waitFor(
-        () => (logs.some((l) => /http:\/\/(localhost|127\.0\.0\.1):4611/.test(l)) ? true : undefined),
-        'admin URL printed',
-        () => run.error
-      );
-      // …and it must be the `/host` URL, not the root (which the landing guard
-      // resolves to `/chat` on a healthy install) — A3. The "UI server running
-      // at ..." log (ui-server.ts) previously printed the root URL even in
-      // admin mode; only the browser-open call was fixed.
-      expect(
-        logs.some((l) => /UI server running at http:\/\/(localhost|127\.0\.0\.1):4611\/host\b/.test(l))
-      ).toBe(true);
-      // …and opens the browser by default (existing open-browser helper).
-      const browser = await waitFor(
-        () => browserSpawn(calls, 4611),
-        'browser opener spawn',
-        () => run.error
-      );
-      expect(browser.argv).toContain('http://127.0.0.1:4611/host');
-    },
-    15000
-  );
+		// Prints the URL…
+		await waitFor(
+			() =>
+				logs.some((l) => new RegExp(`http://(localhost|127\\.0\\.0\\.1):${servePort}`).test(l))
+					? true
+					: undefined,
+			'admin URL printed',
+			() => run.error
+		);
+		// …and it must be the `/host` URL, not the root (which the landing guard
+		// resolves to `/chat` on a healthy install) — A3. The "UI server running
+		// at ..." log (ui-server.ts) previously printed the root URL even in
+		// admin mode; only the browser-open call was fixed.
+		expect(
+			logs.some((l) =>
+				new RegExp(
+					`UI server running at http://(localhost|127\\.0\\.0\\.1):${servePort}/host\\b`
+				).test(l)
+			)
+		).toBe(true);
+		// …and opens the browser by default (existing open-browser helper).
+		const browser = await waitFor(
+			() => browserSpawn(calls, servePort),
+			'browser opener spawn',
+			() => run.error
+		);
+		expect(browser.argv).toContain(`http://127.0.0.1:${servePort}/host`);
+	}, 15000);
 
-  it(
-    'prints the /host URL on the reuse path too, when a matching instance is already running (A3 reuse)',
-    async () => {
-      seedServeHome({ installed: true });
-      // A different (or a previous) `openpalm admin` invocation is already
-      // listening on this port and reports admin=true — checkExistingUiInstance
-      // should call this a 'match' and skip spawning a second UI child.
-      globalThis.fetch = (async (input: string | URL | Request) => {
-        const url = String(input instanceof Request ? input.url : input);
-        if (url.endsWith('/api/runtime')) {
-          return new Response(JSON.stringify({ admin: true }), {
-            status: 200,
-            headers: { 'content-type': 'application/json' },
-          });
-        }
-        if (url.endsWith('/health')) return new Response('ok', { status: 200 });
-        throw new TypeError('fetch failed');
-      }) as unknown as typeof fetch;
-      const calls = captureSpawns();
-      const logs = captureLogs();
+	it('prints the /host URL on the reuse path too, when a matching instance is already running (A3 reuse)', async () => {
+		seedServeHome({ installed: true });
+		// A different (or a previous) `openpalm admin` invocation is already
+		// listening on this port and reports admin=true — checkExistingUiInstance
+		// should call this a 'match' and skip spawning a second UI child.
+		globalThis.fetch = (async (input: string | URL | Request) => {
+			const url = String(input instanceof Request ? input.url : input);
+			if (url.endsWith('/api/runtime')) {
+				return new Response(JSON.stringify({ admin: true }), {
+					status: 200,
+					headers: { 'content-type': 'application/json' }
+				});
+			}
+			if (url.endsWith('/health')) return new Response('ok', { status: 200 });
+			throw new TypeError('fetch failed');
+		}) as unknown as typeof fetch;
+		const calls = captureSpawns();
+		const logs = captureLogs();
 
-      const run = await runAdmin(['--port', '4616']);
+		const run = await runAdmin(['--port', '4616']);
 
-      await waitFor(
-        () => (logs.some((l) => l.startsWith('Reusing already-running UI server at')) ? true : undefined),
-        'reuse-path log line',
-        () => run.error
-      );
-      const reuseLine = logs.find((l) => l.startsWith('Reusing already-running UI server at'));
-      expect(reuseLine).toContain('http://127.0.0.1:4616/host');
+		await waitFor(
+			() =>
+				logs.some((l) => l.startsWith('Reusing already-running UI server at')) ? true : undefined,
+			'reuse-path log line',
+			() => run.error
+		);
+		const reuseLine = logs.find((l) => l.startsWith('Reusing already-running UI server at'));
+		expect(reuseLine).toContain('http://127.0.0.1:4616/host');
 
-      // Reuse means no second UI child is spawned for this port.
-      expect(uiChildSpawn(calls, 4616)).toBeUndefined();
+		// Reuse means no second UI child is spawned for this port.
+		expect(uiChildSpawn(calls, 4616)).toBeUndefined();
 
-      const browser = await waitFor(
-        () => browserSpawn(calls, 4616),
-        'browser opener spawn (reuse path)',
-        () => run.error
-      );
-      expect(browser.argv).toContain('http://127.0.0.1:4616/host');
-    },
-    15000
-  );
+		const browser = await waitFor(
+			() => browserSpawn(calls, 4616),
+			'browser opener spawn (reuse path)',
+			() => run.error
+		);
+		expect(browser.argv).toContain('http://127.0.0.1:4616/host');
+	}, 15000);
 
-  it(
-    'refuses a non-loopback bind config: OP_ALLOW_REMOTE_SETUP is ignored and neutralized',
-    async () => {
-      seedServeHome({ installed: true });
-      // Operator has the remote-setup escape hatch enabled — admin mode must
-      // stay loopback-only anyway ("refuse non-loopback binds").
-      process.env.OP_ALLOW_REMOTE_SETUP = '1';
-      const calls = captureSpawns();
-      const logs = captureLogs();
+	it('refuses a non-loopback bind config: OP_ALLOW_REMOTE_SETUP is ignored and neutralized', async () => {
+		seedServeHome({ installed: true });
+		// Operator has the remote-setup escape hatch enabled — admin mode must
+		// stay loopback-only anyway ("refuse non-loopback binds").
+		process.env.OP_ALLOW_REMOTE_SETUP = '1';
+		const calls = captureSpawns();
+		const logs = captureLogs();
 
-      const run = await runAdmin(['--port', '4612', '--no-open']);
+		const run = await runAdmin(['--port', '4612', '--no-open']);
 
-      const child = await waitFor(
-        () => uiChildSpawn(calls, 4612),
-        'admin UI child spawn',
-        () => run.error
-      );
-      expect(child.env?.OP_ENABLE_ADMIN).toBe('1');
-      // NOT the remote bind (0.0.0.0 + Host-header origin) — loopback, pinned.
-      expect(child.env?.HOST).toBe('127.0.0.1');
-      expect(child.env?.ORIGIN).toBe('http://127.0.0.1:4612');
-      expect(child.env?.HOST_HEADER).toBeUndefined();
-      expect(child.env?.PROTOCOL_HEADER).toBeUndefined();
-      // The flag itself must be neutralized in the child env: the `openpalm ui`
-      // respawn and the UI server's own OP_ALLOW_REMOTE_SETUP relaxations
-      // (Host/Origin allowlist, setup gate) must not see it enabled.
-      expect(realLib.isRemoteSetupAllowed(child.env ?? {})).toBe(false);
+		const child = await waitFor(
+			() => uiChildSpawn(calls, 4612),
+			'admin UI child spawn',
+			() => run.error
+		);
+		expect(child.env?.OP_ENABLE_ADMIN).toBe('1');
+		// NOT the remote bind (0.0.0.0 + Host-header origin) — loopback, pinned.
+		expect(child.env?.HOST).toBe('127.0.0.1');
+		expect(child.env?.ORIGIN).toBe('http://127.0.0.1:4612');
+		expect(child.env?.HOST_HEADER).toBeUndefined();
+		expect(child.env?.PROTOCOL_HEADER).toBeUndefined();
+		// The flag itself must be neutralized in the child env: the `openpalm ui`
+		// respawn and the UI server's own OP_ALLOW_REMOTE_SETUP relaxations
+		// (Host/Origin allowlist, setup gate) must not see it enabled.
+		expect(realLib.isRemoteSetupAllowed(child.env ?? {})).toBe(false);
 
-      // --no-open: URL is printed but no browser opener is spawned.
-      await waitFor(
-        () => (logs.some((l) => /http:\/\/(localhost|127\.0\.0\.1):4612/.test(l)) ? true : undefined),
-        'admin URL printed',
-        () => run.error
-      );
-      await new Promise((resolve) => setTimeout(resolve, 50));
-      expect(browserSpawn(calls, 4612)).toBeUndefined();
-    },
-    15000
-  );
+		// --no-open: URL is printed but no browser opener is spawned.
+		await waitFor(
+			() => (logs.some((l) => /http:\/\/(localhost|127\.0\.0\.1):4612/.test(l)) ? true : undefined),
+			'admin URL printed',
+			() => run.error
+		);
+		await new Promise((resolve) => setTimeout(resolve, 50));
+		expect(browserSpawn(calls, 4612)).toBeUndefined();
+	}, 15000);
 
-  it(
-    'serves without an install through root/bootstrap with no fake local connection',
-    async () => {
-      // Empty OP_HOME: classifyLocalInstall() → not_installed. The command must
-      // still bring the UI up (admin-enabled, loopback) instead of demanding
-      // `openpalm install` — the UI's existing guard redirects to /setup.
-      seedServeHome({ installed: false });
-      const calls = captureSpawns();
-      const logs = captureLogs();
+	it('serves without an install through root/bootstrap with no fake local connection', async () => {
+		// Empty OP_HOME: classifyLocalInstall() → not_installed. The command must
+		// still bring the UI up (admin-enabled, loopback) instead of demanding
+		// `openpalm install` — the UI's existing guard redirects to /setup.
+		seedServeHome({ installed: false });
+		const calls = captureSpawns();
+		const logs = captureLogs();
 
-      const run = await runAdmin(['--port', '4613', '--no-open']);
+		const run = await runAdmin(['--port', '4613', '--no-open']);
 
-      const child = await waitFor(
-        () => uiChildSpawn(calls, 4613),
-        'admin UI child spawn (no install)',
-        () => run.error
-      );
-      expect(child.env?.OP_ENABLE_ADMIN).toBe('1');
-      expect(child.env?.HOST).toBe('127.0.0.1');
-      expect(child.env?.ORIGIN).toBe('http://127.0.0.1:4613');
-      const runtimeConfig = realLib.parseUiRuntimeConfigJson(
-        child.env?.[realLib.UI_RUNTIME_CONFIG_ENV],
-      );
-      expect(runtimeConfig.status).toBe('valid');
-      expect(runtimeConfig.status === 'valid' ? runtimeConfig.config.connections : []).toEqual([]);
-      expect(logs.some((line) => line === 'Checking for skeleton update...')).toBe(false);
+		const child = await waitFor(
+			() => uiChildSpawn(calls, 4613),
+			'admin UI child spawn (no install)',
+			() => run.error
+		);
+		expect(child.env?.OP_ENABLE_ADMIN).toBe('1');
+		expect(child.env?.HOST).toBe('127.0.0.1');
+		expect(child.env?.ORIGIN).toBe('http://127.0.0.1:4613');
+		const runtimeConfig = realLib.parseUiRuntimeConfigJson(
+			child.env?.[realLib.UI_RUNTIME_CONFIG_ENV]
+		);
+		expect(runtimeConfig.status).toBe('valid');
+		expect(runtimeConfig.status === 'valid' ? runtimeConfig.config.connections : []).toEqual([]);
+		expect(logs.some((line) => line === 'Checking for skeleton update...')).toBe(false);
 
-      await waitFor(
-        () => (logs.some((l) => /UI server running at http:\/\/127\.0\.0\.1:4613\/?$/.test(l)) ? true : undefined),
-        'fresh admin root URL printed',
-        () => run.error,
-      );
-    },
-    15000
-  );
+		await waitFor(
+			() =>
+				logs.some((l) => /UI server running at http:\/\/127\.0\.0\.1:4613\/?$/.test(l))
+					? true
+					: undefined,
+			'fresh admin root URL printed',
+			() => run.error
+		);
+	}, 15000);
 });
 
 // ── --port validation ────────────────────────────────────────────────────────
 
 describe('openpalm admin --port validation', () => {
-  it('hard-errors on a malformed --port instead of silently serving on the default port', async () => {
-    // lib's resolveEnvPort discards a non-finite explicit port, so
-    // `admin --port banana` used to quietly serve on the persisted/default
-    // port with no indication the flag was ignored.
-    seedServeHome({ installed: true });
-    const calls = captureSpawns();
-    captureLogs();
+	it('hard-errors on a malformed --port instead of silently serving on the default port', async () => {
+		// lib's resolveEnvPort discards a non-finite explicit port, so
+		// `admin --port banana` used to quietly serve on the persisted/default
+		// port with no indication the flag was ignored.
+		seedServeHome({ installed: true });
+		const calls = captureSpawns();
+		captureLogs();
 
-    const run = await runAdmin(['--port', 'banana', '--no-open']);
+		const run = await runAdmin(['--port', 'banana', '--no-open']);
 
-    const err = await waitFor(() => run.error, 'admin --port rejection');
-    expect(String(err)).toContain('Invalid --port value "banana"');
-    // Rejected before startUIServer — no UI child (or anything else) spawned.
-    expect(calls.length).toBe(0);
-  });
+		const err = await waitFor(() => run.error, 'admin --port rejection');
+		expect(String(err)).toContain('Invalid --port value "banana"');
+		// Rejected before startUIServer — no UI child (or anything else) spawned.
+		expect(calls.length).toBe(0);
+	});
 
-  it('hard-errors on an out-of-range --port', async () => {
-    seedServeHome({ installed: true });
-    captureSpawns();
-    captureLogs();
+	it('hard-errors on an out-of-range --port', async () => {
+		seedServeHome({ installed: true });
+		captureSpawns();
+		captureLogs();
 
-    const run = await runAdmin(['--port', '70000', '--no-open']);
+		const run = await runAdmin(['--port', '70000', '--no-open']);
 
-    const err = await waitFor(() => run.error, 'admin --port rejection');
-    expect(String(err)).toContain('Invalid --port value "70000"');
-  });
+		const err = await waitFor(() => run.error, 'admin --port rejection');
+		expect(String(err)).toContain('Invalid --port value "70000"');
+	});
 });
 
 // ── Spawn-env policy for the bare normal serve path ──────────────────────────
 
 describe('bare serve path spawn env', () => {
-  it(
-    'binds IPv4 loopback with a matching ORIGIN and does NOT enable admin',
-    async () => {
-      seedServeHome({ installed: true });
-      const calls = captureSpawns();
-      captureLogs();
+	it('binds IPv4 loopback with a matching ORIGIN and does NOT enable admin', async () => {
+		seedServeHome({ installed: true });
+		const calls = captureSpawns();
+		captureLogs();
 
-      const failure: { error?: unknown } = {};
-      restoreOpenPalmLib();
-      const { startUIServer } = await import(`${uiServerModuleUrl}?t=${Math.random()}`) as {
-        startUIServer: (opts?: UIServerOptions) => Promise<void>;
-      };
-      void startUIServer({ port: 4614, open: false } satisfies UIServerOptions).catch(
-        (e: unknown) => {
-          failure.error = e ?? new Error('startUIServer rejected');
-        }
-      );
+		const failure: { error?: unknown } = {};
+		restoreOpenPalmLib();
+		const { startUIServer } = (await import(`${uiServerModuleUrl}?t=${Math.random()}`)) as {
+			startUIServer: (opts?: UIServerOptions) => Promise<void>;
+		};
+		void startUIServer({ port: 4614, open: false } satisfies UIServerOptions).catch(
+			(e: unknown) => {
+				failure.error = e ?? new Error('startUIServer rejected');
+			}
+		);
 
-      const child = await waitFor(
-        () => uiChildSpawn(calls, 4614),
-        'bare-serve UI child spawn',
-        () => failure.error
-      );
-      expect(child.env?.HOST).toBe('127.0.0.1');
-      // ONE loopback spelling everywhere: `openpalm` used to pin
-      // http://localhost while admin/Electron pinned http://127.0.0.1, which
-      // split the cookie jar between them.
-      expect(child.env?.ORIGIN).toBe('http://127.0.0.1:4614');
-      expect(child.env?.HOST_HEADER).toBeUndefined();
-      // Bare serve is NOT the admin surface: no admin env is introduced.
-      expect(child.env?.OP_ENABLE_ADMIN).toBeUndefined();
-    },
-    15000
-  );
+		const child = await waitFor(
+			() => uiChildSpawn(calls, 4614),
+			'bare-serve UI child spawn',
+			() => failure.error
+		);
+		expect(child.env?.HOST).toBe('127.0.0.1');
+		// ONE loopback spelling everywhere: `openpalm` used to pin
+		// http://localhost while admin/Electron pinned http://127.0.0.1, which
+		// split the cookie jar between them.
+		expect(child.env?.ORIGIN).toBe('http://127.0.0.1:4614');
+		expect(child.env?.HOST_HEADER).toBeUndefined();
+		// Bare serve is NOT the admin surface: no admin env is introduced.
+		expect(child.env?.OP_ENABLE_ADMIN).toBeUndefined();
+	}, 15000);
 
-  it(
-    'restores the explicit remote-setup bind while the parent URL stays loopback',
-    async () => {
-      seedServeHome({ installed: true });
-      process.env.OP_ALLOW_REMOTE_SETUP = '1';
-      const calls = captureSpawns();
-      captureLogs();
+	it('restores the explicit remote-setup bind while the parent URL stays loopback', async () => {
+		seedServeHome({ installed: true });
+		process.env.OP_ALLOW_REMOTE_SETUP = '1';
+		const calls = captureSpawns();
+		captureLogs();
 
-      const failure: { error?: unknown } = {};
-      restoreOpenPalmLib();
-      const { startUIServer } = await import(`${uiServerModuleUrl}?t=${Math.random()}`) as {
-        startUIServer: (opts?: UIServerOptions) => Promise<void>;
-      };
-      void startUIServer({ port: 4615, open: true } satisfies UIServerOptions).catch(
-        (e: unknown) => {
-          failure.error = e ?? new Error('startUIServer rejected');
-        }
-      );
+		const failure: { error?: unknown } = {};
+		restoreOpenPalmLib();
+		const { startUIServer } = (await import(`${uiServerModuleUrl}?t=${Math.random()}`)) as {
+			startUIServer: (opts?: UIServerOptions) => Promise<void>;
+		};
+		void startUIServer({ port: 4615, open: true } satisfies UIServerOptions).catch((e: unknown) => {
+			failure.error = e ?? new Error('startUIServer rejected');
+		});
 
-      const child = await waitFor(
-        () => uiChildSpawn(calls, 4615),
-        'bare-serve remote UI child spawn',
-        () => failure.error
-      );
-      expect(child.env?.HOST).toBe('0.0.0.0');
-      expect(child.env?.HOST_HEADER).toBe('host');
-      expect(child.env?.PROTOCOL_HEADER).toBe('x-forwarded-proto');
-      expect(child.env?.ORIGIN).toBeUndefined();
-      const browser = await waitFor(
-        () => browserSpawn(calls, 4615),
-        'remote-setup parent browser open',
-        () => failure.error,
-      );
-      expect(browser.argv).toContain('http://127.0.0.1:4615');
-    },
-    15000
-  );
+		const child = await waitFor(
+			() => uiChildSpawn(calls, 4615),
+			'bare-serve remote UI child spawn',
+			() => failure.error
+		);
+		expect(child.env?.HOST).toBe('0.0.0.0');
+		expect(child.env?.HOST_HEADER).toBe('host');
+		expect(child.env?.PROTOCOL_HEADER).toBe('x-forwarded-proto');
+		expect(child.env?.ORIGIN).toBeUndefined();
+		const browser = await waitFor(
+			() => browserSpawn(calls, 4615),
+			'remote-setup parent browser open',
+			() => failure.error
+		);
+		expect(browser.argv).toContain('http://127.0.0.1:4615');
+	}, 15000);
 });

--- a/packages/lib/src/control-plane/compose-errors.test.ts
+++ b/packages/lib/src/control-plane/compose-errors.test.ts
@@ -22,6 +22,51 @@ describe("summarizeComposeStderr", () => {
   it("returns empty string for empty input", () => {
     expect(summarizeComposeStderr("")).toBe("");
   });
+
+  // Regression: a real update failed and reported itself as "voice Pulling" —
+  // compose streams progress to stderr, so the first line is a status update,
+  // not the failure. The operator saw a message that named no problem, and an
+  // automatic rollback they could not explain.
+  it("skips compose progress lines and reports the real error", () => {
+    const stderr = [
+      "voice Pulling",
+      " 8a1e25ce7c4f Pulling fs layer",
+      " 8a1e25ce7c4f Downloading [==>                ]  1.2MB/24MB",
+      " 8a1e25ce7c4f Download complete",
+      "Error response from daemon: manifest for openpalm/voice:0.13.0 not found",
+    ].join("\n");
+    expect(summarizeComposeStderr(stderr)).toBe(
+      "Error response from daemon: manifest for openpalm/voice:0.13.0 not found",
+    );
+  });
+
+  it("skips container/network/volume lifecycle progress too", () => {
+    const stderr = [
+      "Network splinter_default  Creating",
+      "Network splinter_default  Created",
+      "Container splinter-voice-1  Creating",
+      "Container splinter-voice-1  Created",
+      "Container splinter-voice-1  Starting",
+      "Error response from daemon: driver failed programming external connectivity",
+    ].join("\n");
+    expect(summarizeComposeStderr(stderr)).toBe(
+      "Error response from daemon: driver failed programming external connectivity",
+    );
+  });
+
+  // `Error` and `Warning` must NOT be treated as progress — a per-service
+  // error line is exactly what we want to surface.
+  it("keeps a per-service Error line", () => {
+    expect(summarizeComposeStderr("voice Pulling\nvoice Error manifest unknown")).toBe(
+      "voice Error manifest unknown",
+    );
+  });
+
+  it("returns empty when stderr is nothing but progress", () => {
+    // Honest emptiness: the caller's own fallback (the exit code) then wins,
+    // instead of a progress line masquerading as a diagnosis.
+    expect(summarizeComposeStderr("voice Pulling\nvoice Pulled\n")).toBe("");
+  });
 });
 
 describe("mapDockerError", () => {

--- a/packages/lib/src/control-plane/compose-errors.ts
+++ b/packages/lib/src/control-plane/compose-errors.ts
@@ -42,16 +42,36 @@ const MANIFEST_UNKNOWN_RE = /manifest\s+(?:unknown|for\s+([^\s]+)\s+not found)/i
 const NETWORK_ERROR_RE = /(?:dial tcp|connection reset by peer|EOF|i\/o timeout|TLS handshake timeout|no route to host)/i;
 
 /**
+ * Compose writes its PROGRESS to stderr, not stdout — `voice Pulling`,
+ * per-layer `Downloading [===>   ]`, `Container x Started`. So "the first
+ * stderr line" is almost never the failure. A real update was reported to the
+ * operator, and recorded in the log envelope, as `voice Pulling`: a message
+ * that names no problem and reads like the operation is still running.
+ *
+ * Case-SENSITIVE and anchored to end-of-line, because compose emits Title-Case
+ * verbs with nothing after them but a progress bar. Both constraints matter —
+ * `error pulling image: dial tcp: ... i/o timeout` is a genuine failure whose
+ * second word is "pulling", and a loose match swallowed it. `Error`/`Warning`
+ * are absent by design: `voice Error manifest unknown` is what we want.
+ */
+const COMPOSE_PROGRESS_RE =
+  /^(?:\S+\s+){0,2}(?:Pulling fs layer|Pulling|Pulled|Waiting|Downloading|Download complete|Verifying Checksum|Extracting|Pull complete|Already exists|Creating|Created|Starting|Started|Healthy|Stopping|Stopped|Removing|Removed|Recreated)(?:\s+\[[^\]]*\].*)?\s*$/;
+
+/**
  * Summarise compose stderr in a single short line, suitable for log
  * envelopes / API error messages when no per-service parse succeeded.
- * Returns the first non-empty stderr line, capped.
+ *
+ * Returns the first non-empty line that is not compose progress noise, capped.
+ * When stderr is nothing but progress, returns "" so the caller's own fallback
+ * (or {@link mapDockerError}'s generic message) wins — an empty summary is far
+ * more honest than a confident-sounding progress line.
  */
 export function summarizeComposeStderr(stderr: string, maxLen = 500): string {
   if (!stderr) return "";
   const first = stderr
     .split(/\r?\n/)
     .map((l) => l.trim())
-    .find((l) => l.length > 0) ?? "";
+    .find((l) => l.length > 0 && !COMPOSE_PROGRESS_RE.test(l)) ?? "";
   return first.length > maxLen ? `${first.slice(0, maxLen - 1)}…` : first;
 }
 

--- a/packages/lib/src/control-plane/docker.ts
+++ b/packages/lib/src/control-plane/docker.ts
@@ -1042,7 +1042,13 @@ export async function applyStack(
       env: envOverrides,
     });
     if (!pullResult.ok) {
-      const mapped = mapDockerError(pullResult.stderr || `docker compose pull exited with code ${pullResult.code}`);
+      // Append the exit code rather than using it only when stderr is empty:
+      // compose pull stderr is never empty (it streams progress there), so the
+      // old `||` fallback could not fire, and summarizeComposeStderr now
+      // discards progress-only stderr. This keeps one real line either way.
+      const mapped = mapDockerError(
+        `${pullResult.stderr ?? ""}\ndocker compose pull exited with code ${pullResult.code}`,
+      );
       return {
         ok: false,
         started: [],
@@ -1089,7 +1095,9 @@ export async function applyStack(
     const rows = psResult.ok ? parseComposePsRows(psResult.stdout) : [];
     if (rows.length === 0) {
       // ps itself gave us nothing to work with — map the full stderr (§6).
-      const mapped = mapDockerError(upResult.stderr || `docker compose exited with code ${upResult.code}`);
+      const mapped = mapDockerError(
+        `${upResult.stderr ?? ""}\ndocker compose exited with code ${upResult.code}`,
+      );
       return {
         ok: false,
         started: [],

--- a/packages/lib/src/control-plane/image-baked-contract.test.ts
+++ b/packages/lib/src/control-plane/image-baked-contract.test.ts
@@ -81,6 +81,22 @@ describe('the assistant crontab shim does not need root', () => {
     );
     expect(offenders).toEqual([]);
   });
+
+  // akm refuses to write scheduler entries from a "package-local" invocation
+  // unless --rebind is passed: it only trusts an npm-global or standalone
+  // install, because a package-local one is normally mutable. Ours is baked
+  // into the image (E2/S2 above — no runtime installs, nothing mounted over
+  // the artifact paths), so that concern does not apply and --rebind is the
+  // correct binding. The migration path already passed it; the two sync call
+  // sites did not, so every task silently failed to install. Keep them aligned.
+  it('every akm task sync passes --rebind', () => {
+    // Anchor on the invocation helper, not the bare phrase: the warning
+    // strings next to these calls also contain "akm task sync".
+    const offenders = codeLines(read('containers/assistant/entrypoint.sh')).filter(
+      (l) => /run_akm_command\s+akm task sync\b/.test(l) && !/--rebind\b/.test(l),
+    );
+    expect(offenders).toEqual([]);
+  });
 });
 
 describe('official images assemble platform code locally', () => {

--- a/packages/lib/src/control-plane/image-baked-contract.test.ts
+++ b/packages/lib/src/control-plane/image-baked-contract.test.ts
@@ -56,23 +56,43 @@ describe('entrypoints do not install packages at boot', () => {
   }
 });
 
-describe('the assistant crontab shim does not need root', () => {
-  // busybox's `crontab` applet checks that it is root (or suid) BEFORE it
-  // honours `-c <spooldir>`, and the assistant runs as an unprivileged uid. A
-  // shim that shelled out to it therefore failed on every invocation with
-  // "crontab: must be suid to work properly" — and because both call sites
-  // wrote `2>/dev/null || true`, boot looked clean while the spool dir stayed
-  // empty and NOTHING was ever scheduled. It surfaced only as akm's task-sync
-  // loop failing every 60s, forever.
-  it('writes the spool file directly instead of invoking the root-only applet', () => {
-    // NOT codeLines(): it strips from the first `#`, and the offending line
+describe('assistant task scheduling works unprivileged', () => {
+  // Everything here is one bug with three layers, all of which shipped silent.
+  // busybox cannot schedule anything in this image: `crontab` checks for root
+  // BEFORE honouring -c, and `crond` both refuses crontabs not owned by uid 0
+  // (skipping them with no log line) and calls setgroups/setgid/setuid in the
+  // job child, which fail for an unprivileged user. The assistant runs as uid
+  // 1000, so tasks were written and never ran. supercronic replaces it.
+  const entrypointCode = () =>
+    // NOT codeLines(): it strips from the first `#`, and the original offender
     // built the shim with `printf '#!/usr/bin/env sh\nexec busybox crontab …'`
     // — the shebang inside the string hid the rest of the line from it. Drop
     // whole-line shell comments only, so prose stays exempt but code does not.
-    const offenders = read('containers/assistant/entrypoint.sh')
+    read('containers/assistant/entrypoint.sh')
       .split('\n')
-      .filter((l) => !/^\s*#/.test(l) && /busybox\s+crontab/.test(l));
+      .filter((l) => !/^\s*#/.test(l));
+
+  it('never invokes busybox for cron', () => {
+    expect(entrypointCode().filter((l) => /busybox\s+cron(tab|d)/.test(l))).toEqual([]);
+  });
+
+  // supercronic exits fatal on `export NAME="value"` — that is shell syntax,
+  // not crontab env-assignment syntax. busybox crond silently ignored those
+  // lines, so jobs never received this env under either scheduler.
+  it('writes crontab env assignments, not shell exports', () => {
+    const offenders = entrypointCode().filter((l) => /^\s*echo\s+"export /.test(l));
     expect(offenders).toEqual([]);
+  });
+
+  // Pinned by sha256 for every arch the release workflow builds, because
+  // upstream publishes no checksum file alongside the release binaries.
+  it('pins supercronic by version and per-arch sha256', () => {
+    const dockerfile = read('containers/assistant/Dockerfile');
+    expect(dockerfile).toMatch(/ARG SUPERCRONIC_VERSION=v\d+\.\d+\.\d+/);
+    expect(dockerfile).toMatch(/sha256sum -c -/);
+    for (const arch of ['amd64', 'arm64']) {
+      expect(dockerfile).toMatch(new RegExp(`${arch}\\) supercronic_sha=[0-9a-f]{64}`));
+    }
   });
 
   it('does not silence the crontab install', () => {

--- a/packages/lib/src/control-plane/image-baked-contract.test.ts
+++ b/packages/lib/src/control-plane/image-baked-contract.test.ts
@@ -56,6 +56,33 @@ describe('entrypoints do not install packages at boot', () => {
   }
 });
 
+describe('the assistant crontab shim does not need root', () => {
+  // busybox's `crontab` applet checks that it is root (or suid) BEFORE it
+  // honours `-c <spooldir>`, and the assistant runs as an unprivileged uid. A
+  // shim that shelled out to it therefore failed on every invocation with
+  // "crontab: must be suid to work properly" — and because both call sites
+  // wrote `2>/dev/null || true`, boot looked clean while the spool dir stayed
+  // empty and NOTHING was ever scheduled. It surfaced only as akm's task-sync
+  // loop failing every 60s, forever.
+  it('writes the spool file directly instead of invoking the root-only applet', () => {
+    // NOT codeLines(): it strips from the first `#`, and the offending line
+    // built the shim with `printf '#!/usr/bin/env sh\nexec busybox crontab …'`
+    // — the shebang inside the string hid the rest of the line from it. Drop
+    // whole-line shell comments only, so prose stays exempt but code does not.
+    const offenders = read('containers/assistant/entrypoint.sh')
+      .split('\n')
+      .filter((l) => !/^\s*#/.test(l) && /busybox\s+crontab/.test(l));
+    expect(offenders).toEqual([]);
+  });
+
+  it('does not silence the crontab install', () => {
+    const offenders = codeLines(read('containers/assistant/entrypoint.sh')).filter((l) =>
+      /^\s*crontab\b.*2>\/dev\/null\s*\|\|\s*true/.test(l),
+    );
+    expect(offenders).toEqual([]);
+  });
+});
+
 describe('official images assemble platform code locally', () => {
   it('does not resolve public OpenPalm packages in the Assistant image', () => {
     const dockerfile = read('containers/assistant/Dockerfile');


### PR DESCRIPTION
## Summary

Diagnosed from a user report that akm task scheduling has never worked. It had **three independent layers**, each of which had to be fixed before anything ran — and all three failed silently.

1. **The crontab shim could never run.** It shelled out to `busybox crontab`, whose applet checks for root *before* honouring `-c`. The assistant runs as uid 1000, so every call died with `must be suid to work properly`. Both call sites wrote `2>/dev/null || true`, so boot looked clean while the spool dir stayed empty.

2. **akm refused every task.** With the shim working, akm rejected each one as an *"ineligible package-local invocation"* — it only writes scheduler entries for npm-global or standalone installs. Ours is baked into the image and nothing mounts over it (E2/S2), so `--rebind` is the correct binding. The post-migration sync already passed it; the two real sync call sites did not.

3. **busybox `crond` cannot execute jobs unprivileged.** Two independent blockers, both proven against a live assistant:
   - It loads a crontab only when the file is owned by uid 0 (`#define DAEMON_UID 0`), skipping others with **no log line at all** — which is why crond had logged nothing, ever.
   - Working around that (root-owned but writable spool file) gets it to parse and fork; the child then dies at `can't set groups: Operation not permitted`, because `change_user()` calls setgroups/setgid/setuid before exec.

   Replaced with **supercronic**, which runs jobs as the invoking user and reloads via `-inotify` when the 60s re-sync rewrites the crontab. busybox is dropped — cron was its only consumer.

Also fixed, found along the way:

- **Compose progress reported as the failure.** `summarizeComposeStderr` returned the first stderr line, but compose streams progress there — so a failed update was reported to the operator, and recorded in the log envelope, as `voice Pulling`. The automatic rollback that followed was equally unexplained.
- **A hardcoded test port (4611)** aborted the whole CLI lane whenever any unrelated process held it — 218 tests were running instead of 228.
- **60s log flooding**: akm prints a full JSON report on every sync, changed or not.

## Verification

Built the real assistant image and booted it as uid 1000, network-isolated, with a throwaway stash:

- Task fired at `04:50:00`, `job succeeded`, and actually executed.
- A task added **after boot** triggered inotify reload at `04:50:43` and fired at `04:51:00` — no restart.
- Both tasks then fired every minute for three consecutive minutes.
- Log noise dropped from one JSON blob per minute to one at boot.
- `sha256sum -c` **OK**, `supercronic -version` v0.2.48 in-image, unsupported-arch branch exits 1.

supercronic is pinned by version and per-arch sha256 (upstream ships no checksum file). arm64 could not be built locally (no qemu for the base image's apt step); its checksum is verified against the published asset.

Six ratchet tests, each confirmed to fail against the pre-fix tree. Full suite 2428 pass / 0 fail; lint green.

## Note

`update-containers` and `discord-report` have been dormant since Aug 4 and will resume on the first cycle after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)