### PR TITLE
fix(assistant): bump akm-opencode to 0.9.1 — 0.9.0 breaks the provider list

### DIFF
--- a/docs/technical/paperclip-addon-design.md
+++ b/docs/technical/paperclip-addon-design.md
@@ -65,7 +65,7 @@ software. Upstream publishes no semver tag, so the digest is the pin and the
 AKM is added through standard OpenCode configuration rather than an image
 layer. Managed `system/paperclip/` contains:
 
-- exact dependencies `akm-opencode@0.9.0` and `akm-cli@0.9.0`;
+- exact dependencies `akm-opencode@0.9.1` and `akm-cli@0.9.0`;
 - `plugins/akm.ts`, which re-exports only the plugin function;
 - `bin/bun`, which sets `BUN_BE_BUN=1` and executes `opencode`, exposing the
   Bun runtime already embedded in Paperclip's OpenCode binary;

--- a/packages/skeleton/system/assistant/opencode.jsonc
+++ b/packages/skeleton/system/assistant/opencode.jsonc
@@ -18,7 +18,7 @@
   // the image-baked-only model removed every other runtime install. Bump this
   // deliberately at release time, same as containers/assistant/tools/package.json.
   "plugin": [
-    "akm-opencode@0.9.0"
+    "akm-opencode@0.9.1"
   ],
   // MCP consume-only example: OpenCode can connect to external MCP servers,
   // but it does not serve MCP itself. Seed-only file: existing installs keep

--- a/packages/skeleton/system/paperclip/package.json
+++ b/packages/skeleton/system/paperclip/package.json
@@ -2,6 +2,6 @@
 	"private": true,
 	"dependencies": {
 		"akm-cli": "0.9.0",
-		"akm-opencode": "0.9.0"
+		"akm-opencode": "0.9.1"
 	}
 }


### PR DESCRIPTION
## The bug

The assistant could not list models. Every provider request returned 500, the model picker was empty, and the embedded UI showed only "Failed to reload — Unexpected server error".

```
TypeError: undefined is not an object (evaluating 'n.provider')
  at Provider.list
```

## Root cause

Isolated by A/B in a throwaway container from the shipped image, varying one thing at a time against identical inputs:

| | Change | Result |
|---|---|---|
| A | `system/assistant/opencode.jsonc` as shipped (`akm-opencode@0.9.0`) | crash |
| B | same file, `"plugin"` entry removed | lists models |
| C | `0.9.0` with the plugin's `__*ForTests` exports removed | **still crashes** |
| D | same file, plugin bumped to `0.9.1` | lists models |

`akm-opencode@0.9.0` leaves an undefined entry in OpenCode's plugin list, so every hook dispatch dereferences it. The same failure surfaces three ways in a single run — `plugin config hook failed: undefined is not an object (evaluating 'N.config')`, the same for `N.dispose`, and `n.provider` inside `Provider.list`, which is the one that reaches the user.

Two hypotheses were tested and **rejected** before landing here: an orphaned `codex` credential in `auth.json` (removing it changed nothing), and the plugin's exported test helpers being initialized as plugin factories (test C).

A further correction worth recording: `/etc/opencode/*` is loaded **unconditionally**, in addition to `OPENCODE_CONFIG_DIR`. Several earlier "reproduces with no config" observations were wrong for that reason — the plugin was always being loaded.

## Scope

paperclip pins the same plugin and has the same bug, so its `package.json` is bumped in lockstep — the paperclip compose contract test enforces that parity.

## Verification

On the live install after the bump: `/config/providers` → **200 with 15 providers** (was 500), zero plugin hook errors, `akm health` → `ok: true`.

Full suite 2428 pass / 0 fail; lint green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)