### PR TITLE
fix: stop benign compose output and a bad voice tag from failing updates

### DIFF
--- a/packages/lib/src/control-plane/compose-errors.test.ts
+++ b/packages/lib/src/control-plane/compose-errors.test.ts
@@ -62,6 +62,33 @@ describe("summarizeComposeStderr", () => {
     );
   });
 
+  // Real failure from a 0.13.0-beta.27 update: paperclip and paperclip-locale
+  // share one image, so compose skips the duplicate pull and says so. The
+  // operator was shown that sentence as the reason their update failed.
+  it("skips a Skipped line that carries trailing detail", () => {
+    const stderr = [
+      'paperclip-locale Skipped - Image is already being pulled by paperclip',
+      ' paperclip Pulling',
+      ' paperclip Pulled',
+    ].join('\n');
+    expect(summarizeComposeStderr(stderr)).toBe("");
+  });
+
+  // The summary is the FIRST unmatched line, so a status line that slips
+  // through does not merely read badly — it hides the real error behind it.
+  it("does not let a status line mask the real error below it", () => {
+    const stderr = [
+      'paperclip-locale Skipped - Image is already being pulled by paperclip',
+      'Error response from daemon: manifest unknown',
+    ].join('\n');
+    expect(summarizeComposeStderr(stderr)).toBe("Error response from daemon: manifest unknown");
+  });
+
+  // Compose appends detail after lifecycle verbs too.
+  it("skips lifecycle lines with trailing detail", () => {
+    expect(summarizeComposeStderr('Container splinter-voice-1  Started  0.4s')).toBe("");
+  });
+
   it("returns empty when stderr is nothing but progress", () => {
     // Honest emptiness: the caller's own fallback (the exit code) then wins,
     // instead of a progress line masquerading as a diagnosis.

--- a/packages/lib/src/control-plane/compose-errors.ts
+++ b/packages/lib/src/control-plane/compose-errors.ts
@@ -48,14 +48,22 @@ const NETWORK_ERROR_RE = /(?:dial tcp|connection reset by peer|EOF|i\/o timeout|
  * operator, and recorded in the log envelope, as `voice Pulling`: a message
  * that names no problem and reads like the operation is still running.
  *
- * Case-SENSITIVE and anchored to end-of-line, because compose emits Title-Case
- * verbs with nothing after them but a progress bar. Both constraints matter —
- * `error pulling image: dial tcp: ... i/o timeout` is a genuine failure whose
- * second word is "pulling", and a loose match swallowed it. `Error`/`Warning`
- * are absent by design: `voice Error manifest unknown` is what we want.
+ * Case-SENSITIVITY is what makes this safe, not anchoring: compose emits
+ * Title-Case status verbs, while `error pulling image: dial tcp: ... i/o
+ * timeout` is a genuine failure whose second word is lowercase "pulling".
+ * `Error`/`Warning` are absent from the list by design, so
+ * `voice Error manifest unknown` still surfaces.
+ *
+ * An earlier version of this anchored to end-of-line, which looked tighter and
+ * was wrong: compose appends detail after the verb. A real update failed with
+ * `paperclip-locale Skipped - Image is already being pulled by paperclip` —
+ * two services sharing one image, which is ordinary — and the anchor let that
+ * line through as the operator-facing error. Worse, because the summary is the
+ * FIRST unmatched line, a status line surviving the filter can mask the real
+ * error further down the same stderr.
  */
 const COMPOSE_PROGRESS_RE =
-  /^(?:\S+\s+){0,2}(?:Pulling fs layer|Pulling|Pulled|Waiting|Downloading|Download complete|Verifying Checksum|Extracting|Pull complete|Already exists|Creating|Created|Starting|Started|Healthy|Stopping|Stopped|Removing|Removed|Recreated)(?:\s+\[[^\]]*\].*)?\s*$/;
+  /^(?:\S+\s+){0,2}(?:Pulling fs layer|Pulling|Pulled|Waiting|Downloading|Download complete|Verifying Checksum|Extracting|Pull complete|Already exists|Creating|Created|Starting|Started|Healthy|Stopping|Stopped|Removing|Removed|Recreated|Skipped)\b/;
 
 /**
  * Summarise compose stderr in a single short line, suitable for log

--- a/packages/lib/src/control-plane/versions.test.ts
+++ b/packages/lib/src/control-plane/versions.test.ts
@@ -121,6 +121,30 @@ describe('version configuration', () => {
 		expect(versions.OP_VOICE_VERSION).toBe('latest');
 	});
 
+	// The compose services append `-cpu` / `-cu121` / `-rocm6` themselves, so
+	// this key holds the base tag. Pasting the tag you can see on a running
+	// container ("latest-cpu") produced voice:latest-cpu-cpu — an image that
+	// cannot exist — and every later update failed on the unresolvable
+	// reference with nothing pointing back at this field.
+	it('rejects a voice version that already carries an accelerator suffix', () => {
+		for (const bad of ['latest-cpu', '0.13.0-cu121', '1.2.3-rocm6', 'latest-CPU']) {
+			expect(() => writeVersions(home.state, { OP_VOICE_VERSION: bad })).toThrow(
+				/base image tag/i
+			);
+		}
+	});
+
+	it('names the corrected value in the rejection', () => {
+		expect(() => writeVersions(home.state, { OP_VOICE_VERSION: 'latest-cpu' })).toThrow(
+			/Use "latest" instead of "latest-cpu"/
+		);
+	});
+
+	it('still accepts a bare voice tag', () => {
+		writeVersions(home.state, { OP_VOICE_VERSION: 'latest' });
+		expect(readVersions(home.state).OP_VOICE_VERSION).toBe('latest');
+	});
+
 	it('preserves an operator-selected exact pin', () => {
 		ensureVersionDefaults(home.state);
 		writeVersions(home.state, { OP_ASSISTANT_VERSION: '0.12.0' });

--- a/packages/lib/src/control-plane/versions.ts
+++ b/packages/lib/src/control-plane/versions.ts
@@ -181,6 +181,19 @@ export function writeManagedVersions(state: ControlPlaneState, updates: Record<s
 	writeVersionEntries(state, updates, (value) => value);
 }
 
+/**
+ * The voice services append the accelerator variant themselves —
+ * `voice:${OP_VOICE_VERSION}-cpu`, `-cu121`, `-rocm6` — so OP_VOICE_VERSION
+ * holds the BASE tag only.
+ *
+ * Nothing used to enforce that. An operator who read `openpalm/voice:latest-cpu`
+ * off their running container and pasted it into the Updates tab's "Voice
+ * image" field got `voice:latest-cpu-cpu`, an image that cannot exist. Every
+ * later update then failed on an unresolvable reference, and nothing connected
+ * that failure back to the field that caused it.
+ */
+const VOICE_VARIANT_SUFFIX_RE = /-(?:cpu|cu\d+|rocm\d+)$/i;
+
 function writeVersionEntries(
 	state: ControlPlaneState,
 	updates: Record<string, string>,
@@ -192,6 +205,11 @@ function writeVersionEntries(
 			throw new Error(`Refusing to write unknown version key: ${key}`);
 		}
 		const trimmed = (value ?? '').trim();
+		if (key === 'OP_VOICE_VERSION' && VOICE_VARIANT_SUFFIX_RE.test(trimmed)) {
+			throw new Error(
+				`OP_VOICE_VERSION is the base image tag; Compose appends the accelerator suffix itself. Use "${trimmed.replace(VOICE_VARIANT_SUFFIX_RE, '')}" instead of "${trimmed}", or the image resolves to a tag that does not exist.`
+			);
+		}
 		accepted[key] = trimmed;
 		accepted[MANAGED_VERSION_MARKERS[key]] = markerValue(trimmed);
 	}


### PR DESCRIPTION
Both found from a real 0.13.0-beta.27 update that failed twice on a live machine.

## 1. `Skipped` lines reported as the failure

```
update failed: paperclip-locale Skipped - Image is already being pulled by paperclip
```

paperclip and paperclip-locale share one image, so compose skips the duplicate pull and says so. That ordinary line was shown to the operator as the reason their update failed.

This is a **gap in the progress-line filter I added two commits ago**. Two mistakes: `Skipped` was dropped from the verb list while trimming the pattern, and the pattern was anchored to end-of-line — so any status line with trailing detail slipped through. The anchor looked tighter and was wrong; compose routinely appends detail after the verb.

Case-sensitivity is what actually makes the filter safe, not anchoring: `error pulling image: dial tcp: ... i/o timeout` is a genuine failure whose second word is lowercase `pulling`, and an existing fixture covers it. Anchor removed, `Skipped` restored.

Because the summary is the **first unmatched line**, a status line that survives doesn't just read badly — it masks whatever real error follows it in the same stderr. There's a test for that now.

## 2. A voice tag that cannot resolve

```
update failed: voice Error failed to resolve reference "docker.io/openpalm/voice:latest-cpu-cpu"
```

The compose services append the accelerator variant themselves (`voice:${OP_VOICE_VERSION}-cpu`), so `OP_VOICE_VERSION` holds the **base** tag. Nothing enforced that.

An operator who reads `openpalm/voice:latest-cpu` off a running container and pastes it into the Updates tab's "Voice image" field gets `voice:latest-cpu-cpu` — an image that cannot exist. Every later update then fails on the unresolvable reference, with nothing connecting the failure back to the field that caused it.

`writeVersionEntries` — the choke point both `writeVersions` and `writeManagedVersions` pass through — now rejects it and names the corrected value (`Use "latest" instead of "latest-cpu"`). The message reaches the Updates tab via the existing error path.

## Verification

Full suite 2434 pass / 0 fail, typecheck 1324 files 0 errors, lint green. The exact failing line from the logs now filters to `""` through the real code path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)