### PR TITLE
fix(assistant): retry the supercronic download past transient 5xx

### DIFF
--- a/containers/assistant/Dockerfile
+++ b/containers/assistant/Dockerfile
@@ -134,7 +134,7 @@ RUN set -eux; \
       arm64) supercronic_sha=50ae8755e04fa72812d0a1bc47a112a856811cc91cce7b6c875c378a850788bc ;; \
       *) echo "unsupported TARGETARCH for supercronic: ${TARGETARCH}" >&2; exit 1 ;; \
     esac; \
-    curl -fsSL -o /usr/local/bin/supercronic \
+    curl -fsSL --retry 5 --retry-delay 2 --retry-all-errors -o /usr/local/bin/supercronic \
       "https://github.com/aptible/supercronic/releases/download/${SUPERCRONIC_VERSION}/supercronic-linux-${TARGETARCH}"; \
     echo "${supercronic_sha}  /usr/local/bin/supercronic" | sha256sum -c -; \
     chmod 0755 /usr/local/bin/supercronic; \


### PR DESCRIPTION
The beta.28 release build failed on the download step I added two commits ago:

```
curl: (22) The requested URL returned error: 503
ERROR: process "/bin/sh -c set -eux; case "${TARGETARCH}" in amd64) supercronic_sha=..."
```

GitHub's release CDN was returning 503s. The same outage had already failed the Linux Electron job minutes earlier, where `setup-bun` couldn't fetch Bun and gave up after two internal retries.

A bare `curl -fsSL` exits 22 on the first 5xx, which made a release-blocking build step depend on a third-party CDN answering on the first try.

## Verification

Against a local server that returns 503 twice, then 200:

| | Result |
|---|---|
| `curl -fsSL` (before) | `curl: (22) ... 503`, **exit 22** — reproduces the CI failure |
| `curl -fsSL --retry 5 --retry-delay 2 --retry-all-errors` | **exit 0, http 200**, correct body |

The real Dockerfile stanza builds, `sha256sum -c` returns OK, and `supercronic -version` prints v0.2.48.

## Not changed

The pre-existing `curl -fsSL https://bun.sh/install` line in the same Dockerfile has identical exposure and would fail the same way. Flagging rather than folding it in, since it's outside this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)