### PR TITLE
build(assistant): take bun and uv from official images, not install scripts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -253,14 +253,17 @@ jobs:
             exit 1
           fi
           errors=0
-          for df in containers/guardian/Dockerfile containers/portal/Dockerfile; do
+          # The assistant is in this loop too: it now COPYs bun out of
+          # `FROM oven/bun:<tag>` rather than running the install script, so its
+          # own image tag can drift from the BUN_VERSION ARG right above it.
+          for df in containers/assistant/Dockerfile containers/guardian/Dockerfile containers/portal/Dockerfile; do
             TAG=$(grep -oP '^FROM oven/bun:\K[^ ]+' "$df" || true)
             if [ -z "$TAG" ]; then
               echo "::error file=$df::Could not extract oven/bun image tag"
               errors=$((errors + 1))
               continue
             fi
-            TAG_MM=$(echo "$TAG" | sed -E 's/-.*//')
+            TAG_MM=$(echo "$TAG" | sed -E 's/-.*//; s/^([0-9]+\.[0-9]+).*/\1/')
             if [ "$TAG_MM" != "$ASSISTANT_MM" ]; then
               echo "::error file=$df::Bun version mismatch: image tag $TAG (major.minor=$TAG_MM) vs assistant BUN_VERSION major.minor=$ASSISTANT_MM — bump together"
               errors=$((errors + 1))

--- a/containers/assistant/Dockerfile
+++ b/containers/assistant/Dockerfile
@@ -37,6 +37,21 @@
 ARG ASSISTANT_MODELS_IMAGE=openpalm/assistant-models:v1
 FROM --platform=$BUILDPLATFORM ${ASSISTANT_MODELS_IMAGE} AS modelfetch
 
+# ── Prebuilt tool binaries ────────────────────────────────────────────────────
+# bun and uv are COPY'd out of their publishers' official images instead of
+# being fetched by an install script at build time. Both scripts pulled from
+# GitHub's release CDN, which is exactly the dependency that broke a release:
+# a 503 there failed the image build, and the same outage independently failed
+# setup-bun and electron-builder in other jobs. Docker Hub / GHCR is a
+# different path, buildx caches these layers, and a COPY cannot half-succeed.
+#
+# This also makes the assistant match guardian and portal, which already build
+# `FROM oven/bun:<tag>` — the assistant was the only one still curling.
+#
+# Tags are literal, not ARGs: the BUN_VERSION sync check in ci.yml greps them.
+FROM oven/bun:1.3.10 AS bunsrc
+FROM ghcr.io/astral-sh/uv:0.12.3 AS uvsrc
+
 # ── Tool builder stage ────────────────────────────────────────────────────────
 # Install the tool packages from the single exact-pinned manifest (edit +
 # rebuild the image to change a version — no runtime override, E2/S2), prune
@@ -140,12 +155,11 @@ RUN set -eux; \
     chmod 0755 /usr/local/bin/supercronic; \
     supercronic -version
 
-# Install Bun into /usr/local. Later we override BUN_INSTALL +
-# BUN_INSTALL_CACHE_DIR to per-user paths so unprivileged users can install
-# additional packages at runtime.
-ENV BUN_INSTALL=/usr/local
-RUN curl -fsSL https://bun.sh/install | bash -s -- "$BUN_VERSION"
-ENV BUN_INSTALL=
+# Bun at /usr/local/bin. BUN_INSTALL + BUN_INSTALL_CACHE_DIR are set to
+# per-user paths further down so unprivileged users can install packages at
+# runtime; they are not needed here now that the binary is copied in place
+# rather than placed by an installer that reads them.
+COPY --from=bunsrc /usr/local/bin/bun /usr/local/bin/bun
 
 # Bake default tool packages at /opt/openpalm/tools, assembled from the toolbuild
 # stage as THREE COPY layers (g1, g2, and the remainder) so no single blob is the
@@ -189,10 +203,9 @@ RUN cd /opt/openpalm/tools/node_modules \
 RUN mkdir -p /home/opencode \
     && chown node:node /home/opencode
 
-# uv (Python package manager for apprise venv).
-RUN curl -LsSf https://astral.sh/uv/install.sh | env INSTALLER_NO_MODIFY_PATH=1 sh \
-    && mv /root/.local/bin/uv /usr/local/bin/ \
-    && mv /root/.local/bin/uvx /usr/local/bin/
+# uv (Python package manager for the apprise venv). Static musl binaries from
+# Astral's official image — no installer, no PATH mutation to undo.
+COPY --from=uvsrc /uv /uvx /usr/local/bin/
 
 # apprise — isolated venv via uv (avoids pip --break-system-packages).
 # Used by the `notify` akm skill (apprise-backed).

--- a/packages/lib/src/control-plane/image-content-reduction.test.ts
+++ b/packages/lib/src/control-plane/image-content-reduction.test.ts
@@ -152,7 +152,18 @@ describe('IMG-5 — speculative CLI tooling trimmed', () => {
   });
 
   test('uv is still installed', () => {
-    expect(dockerfile).toContain('astral.sh/uv/install.sh');
+    // COPY'd from Astral's official image rather than fetched by the install
+    // script: that script pulled from GitHub's release CDN, whose 503s failed
+    // a release build. Assert the binaries land, not how they got here.
+    expect(dockerfile).toMatch(/COPY --from=uvsrc \/uv \/uvx \/usr\/local\/bin\//);
+  });
+
+  test('no tool is fetched by a piped install script at build time', () => {
+    const piped = dockerfile
+      .split('\n')
+      .filter((l) => !/^\s*#/.test(l))
+      .filter((l) => /curl[^|]*\|\s*(bash|sh)\b/.test(l));
+    expect(piped).toEqual([]);
   });
 });
 


### PR DESCRIPTION
## Why

A GitHub release-CDN outage failed **five consecutive runs** today, across four different jobs and three different fetchers — `setup-bun`, `electron-builder`'s NSIS download, and the assistant image's own tool downloads. Retries cover blips, not a sustained outage.

## What

bun and uv both publish official images, so the fetch is **deleted** rather than hardened:

```dockerfile
COPY --from=oven/bun:1.3.10             /usr/local/bin/bun /usr/local/bin/bun
COPY --from=ghcr.io/astral-sh/uv:0.12.3 /uv /uvx /usr/local/bin/
```

Two piped install scripts removed. Pulls land on Docker Hub / GHCR instead of GitHub's release CDN, buildx caches the layers, and a `COPY` cannot half-succeed.

It also makes the assistant consistent with guardian and portal, which already build `FROM oven/bun:<tag>` — the assistant was the only one still curling.

The `BUN_INSTALL` env pair around the old install goes too: it existed only to tell the installer where to write. The real runtime value further down is unchanged.

## Guardrails

Two pins can now drift, so:

- `ci.yml`'s BUN_VERSION sync check now covers the **assistant** Dockerfile as well, and normalises a patch-level tag (`1.3.10`) alongside a suffixed one (`1.3-slim`). Verified against the working tree — all three resolve to `1.3`.
- A new test fails on any `curl … | bash|sh` in the Dockerfile, so the pattern can't return unnoticed.

Both new tests were confirmed to fail against the previous Dockerfile.

## Verification

Built the real assistant image. Tool versions identical to the previous build:

| | |
|---|---|
| bun | 1.3.10 |
| uv / uvx | 0.12.3 |
| supercronic | v0.2.48 |
| apprise | 1.12.0 (venv built by the new uv) |
| opencode / akm | 1.18.9 / 0.9.0 |

uv is now the musl static build rather than gnu — if anything more portable on this base.

Full suite 2435 pass / 0 fail, typecheck 1324 files 0 errors, lint green.

## Not in this PR

`supercronic` still fetches from GitHub releases (with the retries added earlier). It has no official image, so removing that fetch needs a published bundle of our own following the `openpalm/assistant-models` pattern — left for a follow-up because the bundle has to be published before it can be consumed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)