### PR TITLE
fix(control-plane): heal akm SQLite WAL residue host-side ("database is locked" every boot on macOS/Windows)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- **akm can open its SQLite stores again on a macOS/Windows home that ever ran
+  a pre-0.9.6 akm.** akm >= 0.9.6 correctly refuses WAL journal mode over the
+  VM file-sharing layer (virtiofs/gRPC-FUSE) that every Docker Desktop/OrbStack
+  bind mount crosses — but a home carrying WAL residue from an older akm
+  (un-checkpointed `-wal` sidecars under `data/akm/data/`; observed live: a
+  4 KB `state.db` whose entire content sat in a 1.1 MB `state.db-wal`) made
+  SQLite engage the WAL machinery before akm could ask for DELETE mode, so
+  every in-container open failed `database is locked`: the boot health step
+  exited 78 on every boot and `akm workflow list --active` never answered,
+  while the host opened the same files fine. Home reconciliation
+  (install/update/desktop launch — `applyHomeAssets`) now sweeps the akm data
+  roots host-side, where WAL and POSIX locking work natively, and runs
+  `PRAGMA wal_checkpoint(TRUNCATE)` + `PRAGMA journal_mode=DELETE` on any
+  SQLite store carrying WAL residue — checkpoint first, so no `-wal` content
+  is ever discarded; orphaned `-wal` files are reported and never deleted.
+  No-op on native Linux, where in-container WAL is legitimate and possibly
+  live. Operators stuck on 0.13.0 have a manual command in
+  `docs/operations/upgrade-0.12-to-0.13.md` §8.
+
 ## [0.13.0] - 2026-08-31
 
 ### Changed

--- a/docs/operations/upgrade-0.12-to-0.13.md
+++ b/docs/operations/upgrade-0.12-to-0.13.md
@@ -914,6 +914,49 @@ changed secret. Do not keep editing a partially migrated tree hoping it settles;
 if the conflict is not obvious, restore the archive and report it with every
 secret value redacted.
 
+### akm reports `database is locked` on every boot (macOS / Windows)
+
+The stack is up and healthy, but the assistant's akm boot status is degraded on
+every boot — the `health` step exits 78, `akm workflow list --active` fails, and
+the assistant's logs carry `database is locked` for `state.db` or `workflow.db`
+— while the same files open fine from the host.
+
+This is WAL residue meeting a correct new refusal. On macOS and Windows every
+bind mount crosses the VM file-sharing layer (virtiofs / gRPC-FUSE), where
+SQLite's WAL locking cannot work; akm >= 0.9.6 (the 0.13.0 pin) therefore opens
+its stores in DELETE journal mode there. But 0.12.x ran an older akm that used
+WAL over that same mount, and it can leave `-wal` sidecar files under
+`$OP_HOME/data/akm/data/` holding **months of un-checkpointed state** — a 4 KB
+`state.db` next to a 1.1 MB `state.db-wal` is this failure, not corruption.
+SQLite engages the WAL machinery for any database with a `-wal` sidecar before
+a client can ask for a different mode, so the in-container akm never gets to
+open the file at all.
+
+Releases after 0.13.0 heal this automatically: install, update and desktop
+launch checkpoint the residue from the host before the stack starts. On 0.13.0
+itself, fold the WAL back in by hand — from the **host**, where WAL works. The
+stack may stay up; the affected files are exactly the ones the container cannot
+hold open:
+
+```bash
+for db in "$OP_HOME"/data/akm/data/*.db; do
+  sqlite3 "$db" 'PRAGMA wal_checkpoint(TRUNCATE); PRAGMA journal_mode=DELETE;'
+done
+```
+
+Then restart the assistant (`docker compose -p <project> restart assistant`,
+project name from section 1) and re-check `akm migrate status` per section 5.
+macOS ships `sqlite3`; on Windows run the same loop with any sqlite3 build
+against `%OP_HOME%\data\akm\data\*.db`. The same command applies to the one
+shape the automatic heal deliberately skips: Docker Desktop **for Linux**,
+which is VM-mediated like macOS but indistinguishable from native Linux (where
+in-container WAL is legitimate and must not be touched) without asking Docker.
+
+**Never delete a `-wal` file to make the error go away.** The sidecar can hold
+the entire database — checkpointing folds it back into the `.db`; deletion
+destroys it. The checkpoint above leaves every row in place and removes the
+sidecars itself.
+
 ## 9. Rollback
 
 Restore the step-1 archive in full, to the same parent directory `OP_HOME` points

--- a/packages/lib/src/control-plane/akm-db-journal.test.ts
+++ b/packages/lib/src/control-plane/akm-db-journal.test.ts
@@ -1,0 +1,284 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { Database } from "bun:sqlite";
+import {
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { convertWalDbsToDeleteJournal, reconcileAkmDbJournalMode } from "./akm-db-journal.js";
+import { akmDataRoots } from "./home.js";
+import type { HostRuntime } from "./host-identity.js";
+
+const VM_RUNTIME: HostRuntime = {
+  id: "vm-mediated-darwin",
+  hostUidAuthoritative: false,
+  bindMountsCrossVmFilesystem: true,
+};
+const LINUX_RUNTIME: HostRuntime = {
+  id: "linux-native",
+  hostUidAuthoritative: true,
+  bindMountsCrossVmFilesystem: false,
+};
+
+let dir: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "akm-db-journal-"));
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+/** SQLite main-file header bytes 18/19: 1 = rollback journal, 2 = WAL. */
+function headerVersions(path: string): [number, number] {
+  const buf = readFileSync(path);
+  return [buf[18] as number, buf[19] as number];
+}
+
+function countRows(path: string): number {
+  const db = new Database(path, { readonly: true });
+  try {
+    const row = db.query("SELECT count(*) AS n FROM t;").get() as { n: number };
+    return row.n;
+  } finally {
+    db.close();
+  }
+}
+
+/**
+ * Build `<targetDir>/<name>` as a WAL-mode database whose rows live ONLY in
+ * an un-checkpointed `-wal` sidecar — the shape a pre-0.9.6 in-container akm
+ * leaves behind over virtiofs. The trio is copied while a connection is
+ * still open, because closing the last connection auto-checkpoints and
+ * deletes the `-wal`.
+ */
+function buildUncheckpointedWalDb(targetDir: string, name: string, rows: number): string {
+  const workDir = mkdtempSync(join(tmpdir(), "walsrc-"));
+  const srcPath = join(workDir, "src.db");
+  const db = new Database(srcPath);
+  try {
+    // Create the table BEFORE switching to WAL so the main file has real
+    // pages, then keep every subsequent commit in the WAL.
+    db.exec("CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT);");
+    db.exec("PRAGMA journal_mode = WAL;");
+    db.exec("PRAGMA wal_autocheckpoint = 0;");
+    db.exec("BEGIN;");
+    const insert = db.prepare("INSERT INTO t (v) VALUES (?);");
+    for (let i = 0; i < rows; i++) insert.run(`row-${i}`);
+    db.exec("COMMIT;");
+
+    const target = join(targetDir, name);
+    copyFileSync(srcPath, target);
+    copyFileSync(`${srcPath}-wal`, `${target}-wal`);
+    copyFileSync(`${srcPath}-shm`, `${target}-shm`);
+    return target;
+  } finally {
+    db.close();
+    rmSync(workDir, { recursive: true, force: true });
+  }
+}
+
+describe("convertWalDbsToDeleteJournal", () => {
+  test("checkpoints an un-checkpointed WAL into the main file and flips to DELETE mode, losing no rows", () => {
+    const dbPath = buildUncheckpointedWalDb(dir, "state.db", 250);
+    // Fixture preconditions: the rows exist only in the sidecar.
+    expect(statSync(`${dbPath}-wal`).size).toBeGreaterThan(0);
+
+    const sweep = convertWalDbsToDeleteJournal(dir);
+
+    expect(sweep.entries).toEqual([
+      { dbPath, action: "converted", walBytes: expect.any(Number) },
+    ]);
+    expect(sweep.entries[0]?.walBytes).toBeGreaterThan(0);
+    // SQLite removes the -wal on a successful journal-mode flip; the module
+    // removes the stale -shm the departing connection leaves behind.
+    expect(existsSync(`${dbPath}-wal`)).toBe(false);
+    expect(existsSync(`${dbPath}-shm`)).toBe(false);
+    expect(headerVersions(dbPath)).toEqual([1, 1]);
+    // The WAL's content was folded in, not discarded.
+    expect(countRows(dbPath)).toBe(250);
+  });
+
+  test("recovers the live incident shape: rollback-mode header with the WHOLE database in the sidecar", () => {
+    // Observed on the live home: state.db 4 KB with header bytes 1/1 next to
+    // a 1.1 MB state.db-wal — the header flip to WAL itself was still
+    // un-checkpointed. SQLite opens the WAL for any non-empty db with a
+    // sidecar regardless of header, so conversion must recover every row.
+    const dbPath = buildUncheckpointedWalDb(dir, "state.db", 100);
+    const patched = readFileSync(dbPath);
+    patched[18] = 1;
+    patched[19] = 1;
+    writeFileSync(dbPath, patched);
+    expect(headerVersions(dbPath)).toEqual([1, 1]);
+    expect(existsSync(`${dbPath}-wal`)).toBe(true);
+
+    const sweep = convertWalDbsToDeleteJournal(dir);
+
+    expect(sweep.entries.map((e) => e.action)).toEqual(["converted"]);
+    expect(existsSync(`${dbPath}-wal`)).toBe(false);
+    expect(headerVersions(dbPath)).toEqual([1, 1]);
+    expect(countRows(dbPath)).toBe(100);
+  });
+
+  test("converts a checkpointed WAL database (WAL header, no sidecar left)", () => {
+    // A fully-checkpointed WAL db with its sidecars gone still carries the
+    // WAL header — the next open (in-container) would recreate the WAL
+    // machinery over virtiofs and fail, so this shape needs converting too.
+    const dbPath = join(dir, "workflow.db");
+    const db = new Database(dbPath);
+    db.exec("CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT);");
+    db.exec("PRAGMA journal_mode = WAL;");
+    db.exec("INSERT INTO t (v) VALUES ('x');");
+    db.exec("PRAGMA wal_checkpoint(TRUNCATE);");
+    db.close();
+    // The checkpoint emptied the WAL, so removing the sidecars here loses
+    // nothing — this is fixture setup, not the module's own behavior.
+    rmSync(`${dbPath}-wal`, { force: true });
+    rmSync(`${dbPath}-shm`, { force: true });
+    expect(headerVersions(dbPath)).toEqual([2, 2]);
+
+    const sweep = convertWalDbsToDeleteJournal(dir);
+
+    expect(sweep.entries.map((e) => e.action)).toEqual(["converted"]);
+    expect(sweep.entries[0]?.walBytes).toBe(0);
+    expect(headerVersions(dbPath)).toEqual([1, 1]);
+    expect(countRows(dbPath)).toBe(1);
+  });
+
+  test("leaves a healthy rollback-mode database untouched, byte for byte", () => {
+    const dbPath = join(dir, "index.db");
+    const db = new Database(dbPath);
+    db.exec("CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT);");
+    db.close();
+    const before = readFileSync(dbPath);
+
+    const sweep = convertWalDbsToDeleteJournal(dir);
+
+    expect(sweep.scanned).toBe(1);
+    expect(sweep.entries).toEqual([]);
+    expect(readFileSync(dbPath).equals(before)).toBe(true);
+  });
+
+  test("detects SQLite files by magic, not filename, and skips non-SQLite files", () => {
+    // akm keeps SQLite stores under non-.db names too (e.g. the maintenance
+    // barrier lock file), so detection is by header magic.
+    const lockDb = buildUncheckpointedWalDb(dir, ".maintenance.barrier.lock", 5);
+    writeFileSync(join(dir, "junk.db"), "X".repeat(64)); // .db name, not SQLite
+    writeFileSync(join(dir, "tiny.db"), "short"); // under 20 bytes
+    writeFileSync(join(dir, "empty.db"), ""); // zero bytes
+
+    const sweep = convertWalDbsToDeleteJournal(dir);
+
+    expect(sweep.scanned).toBe(4);
+    expect(sweep.entries).toEqual([
+      { dbPath: lockDb, action: "converted", walBytes: expect.any(Number) },
+    ]);
+    expect(readFileSync(join(dir, "junk.db"), "utf-8")).toBe("X".repeat(64));
+  });
+
+  test("never touches .bak backup snapshots, even ones carrying WAL residue", () => {
+    // The runbook's manual heal leaves state.db.manual-backup-<ts>.bak files;
+    // nothing ever opens a backup, and converting one would mutate it.
+    const bakPath = buildUncheckpointedWalDb(dir, "state.db.manual-backup-20260831T151303.bak", 5);
+    const before = readFileSync(bakPath);
+
+    const sweep = convertWalDbsToDeleteJournal(dir);
+
+    expect(sweep.scanned).toBe(0);
+    expect(sweep.entries).toEqual([]);
+    expect(readFileSync(bakPath).equals(before)).toBe(true);
+    expect(existsSync(`${bakPath}-wal`)).toBe(true);
+  });
+
+  test("reports an orphaned -wal sidecar and never deletes it", () => {
+    const walPath = join(dir, "ghost.db-wal");
+    writeFileSync(walPath, Buffer.alloc(4096, 7));
+
+    const sweep = convertWalDbsToDeleteJournal(dir);
+
+    expect(sweep.entries).toEqual([
+      {
+        dbPath: join(dir, "ghost.db"),
+        action: "orphaned-wal",
+        walBytes: 4096,
+        detail: "-wal sidecar has no companion database file; left in place",
+      },
+    ]);
+    expect(existsSync(walPath)).toBe(true);
+  });
+
+  test("recurses into subdirectories", () => {
+    const nestedDir = join(dir, "maintenance-activities", "act-1");
+    mkdirSync(nestedDir, { recursive: true });
+    const nested = buildUncheckpointedWalDb(nestedDir, "activity.db", 3);
+
+    const sweep = convertWalDbsToDeleteJournal(dir);
+
+    expect(sweep.entries.map((e) => e.dbPath)).toEqual([nested]);
+    expect(countRows(nested)).toBe(3);
+  });
+
+  test("is idempotent: a second sweep finds nothing to do", () => {
+    buildUncheckpointedWalDb(dir, "state.db", 20);
+    expect(convertWalDbsToDeleteJournal(dir).entries.map((e) => e.action)).toEqual(["converted"]);
+
+    const second = convertWalDbsToDeleteJournal(dir);
+    expect(second.entries).toEqual([]);
+    expect(second.scanned).toBe(1);
+  });
+
+  test("returns an empty result for a missing root", () => {
+    const sweep = convertWalDbsToDeleteJournal(join(dir, "does-not-exist"));
+    expect(sweep).toEqual({ root: join(dir, "does-not-exist"), scanned: 0, entries: [] });
+  });
+});
+
+describe("reconcileAkmDbJournalMode", () => {
+  test("sweeps both akm data roots on a VM-mediated runtime", () => {
+    const assistantRoot = join(dir, "data", "akm", "data");
+    mkdirSync(assistantRoot, { recursive: true });
+    const dbPath = buildUncheckpointedWalDb(assistantRoot, "state.db", 40);
+
+    const results = reconcileAkmDbJournalMode({ homeDir: dir }, VM_RUNTIME);
+
+    expect(results.map((r) => r.root)).toEqual([
+      join(dir, "data", "akm", "data"),
+      join(dir, "data", "paperclip-akm", "data"),
+    ]);
+    expect(results[0]?.entries).toEqual([
+      { dbPath, action: "converted", walBytes: expect.any(Number) },
+    ]);
+    // The paperclip root does not exist on this home — still reported, empty.
+    expect(results[1]?.scanned).toBe(0);
+    expect(existsSync(`${dbPath}-wal`)).toBe(false);
+    expect(countRows(dbPath)).toBe(40);
+  });
+
+  test("is a no-op on native Linux, where in-container WAL is legitimate and possibly live", () => {
+    const assistantRoot = join(dir, "data", "akm", "data");
+    mkdirSync(assistantRoot, { recursive: true });
+    const dbPath = buildUncheckpointedWalDb(assistantRoot, "state.db", 4);
+
+    const results = reconcileAkmDbJournalMode({ homeDir: dir }, LINUX_RUNTIME);
+
+    expect(results).toEqual([]);
+    expect(existsSync(`${dbPath}-wal`)).toBe(true);
+  });
+
+  test("sweeps exactly the roots ensureHomeDirs creates for akm data", () => {
+    // Literal strings on purpose: these must track the container mounts in
+    // core.compose.yml / services.compose.yml (/opt/akm/data bind sources).
+    expect(akmDataRoots("/home/op")).toEqual([
+      "/home/op/data/akm/data",
+      "/home/op/data/paperclip-akm/data",
+    ]);
+  });
+});

--- a/packages/lib/src/control-plane/akm-db-journal.ts
+++ b/packages/lib/src/control-plane/akm-db-journal.ts
@@ -1,0 +1,384 @@
+/**
+ * akm SQLite journal-mode reconciliation — host-side WAL-residue heal.
+ *
+ * akm >= 0.9.6 (the pin shipped with 0.13.0) classifies the container's
+ * /opt/akm/data bind mount as a network filesystem on Docker Desktop /
+ * OrbStack (virtiofs) and refuses WAL, opening its stores in DELETE journal
+ * mode. Correct — WAL needs the `-shm` shared-memory index and POSIX locks,
+ * neither of which works across a VM file-sharing layer. But a home that ran
+ * an OLDER akm (or a host-side akm against the same tree, where the mount is
+ * a plain local directory) can carry WAL residue: `-wal` sidecars and/or a
+ * WAL-mode main-file header. SQLite opens the WAL machinery whenever a
+ * non-empty database has a `-wal` sidecar — BEFORE any journal_mode PRAGMA a
+ * client issues — so the in-container akm cannot even get far enough to ask
+ * for DELETE mode: every open fails "database is locked", the boot health
+ * step exits 78 on every boot, and `akm workflow list --active` fails, while
+ * the host opens the same file fine.
+ *
+ * The residue is worse than it looks. Observed live: a 4 KB `state.db` whose
+ * header still said rollback-journal, next to a 1.1 MB `state.db-wal`
+ * untouched for months — the ENTIRE database (schema, rows, even the header
+ * flip to WAL mode) sat in un-checkpointed WAL frames. Deleting a `-wal`
+ * without checkpointing therefore destroys real state; only folding it back
+ * into the main file is safe, and only the host can do that (WAL + POSIX
+ * locking work natively there).
+ *
+ * So: on every home-reconciliation pass (applyHomeAssets — install, update,
+ * desktop launch, CLI supervisor spawn; deliberately NOT plain start/restart,
+ * same reach as the akm config sweeps beside it), sweep the akm data roots
+ * ({@link akmDataRoots} in home.ts — the same list ensureHomeDirs creates)
+ * for SQLite files that carry WAL residue and, from the host, run
+ * `PRAGMA wal_checkpoint(TRUNCATE)` followed by `PRAGMA journal_mode=DELETE`
+ * — after which SQLite itself removes the `-wal` sidecar and the container
+ * can open the store. This is deliberately a RECURRING reconcile and not a
+ * `runHomeMigrations` entry: a schema-stamped home re-acquires the residue
+ * from any host-side akm run against the same tree, so a run-once migration
+ * cannot keep it healed.
+ *
+ * Platform gate: this runs ONLY on VM-mediated container runtimes, read from
+ * describeHostRuntime()'s `bindMountsCrossVmFilesystem` (host-identity.ts —
+ * the single seam that classifies native-Linux vs VM-mediated). There, bind
+ * mounts ALWAYS cross virtiofs/gRPC-FUSE/9p, so a WAL-mode store under an akm
+ * data root is by construction unopenable by the container and converting it
+ * can never contend with a live in-container writer. On native Linux the
+ * opposite holds: akm legitimately uses WAL on the (local) bind mount and may
+ * be writing right now — converting would fight a live writer and akm would
+ * flip it straight back. (Docker Desktop *for Linux* is the one VM-mediated
+ * shape the seam cannot currently see; the upgrade runbook documents the
+ * manual host-side sqlite3 command for it, and a future refinement inside
+ * describeHostRuntime extends this sweep automatically.)
+ *
+ * Detection is by content, not filename: akm's stores are `*.db`
+ * (state/workflow/index/logs) but it also keeps SQLite files under other
+ * names (e.g. `.maintenance.barrier.lock.operations.sensitive`), so every
+ * file under the roots is sniffed for the 16-byte SQLite magic. A store
+ * needs conversion when a `-wal` sidecar sits beside it (the live shape —
+ * the header alone can still claim rollback mode, see above) OR its header
+ * bytes 18/19 mark WAL (a cleanly-closed WAL db keeps those bytes without
+ * any sidecar, and re-creates the sidecar on next open). Healthy
+ * rollback-mode stores are never even opened — the running container may
+ * hold them. `.bak` snapshots are excluded outright: nothing opens them, and
+ * converting one would mutate an operator's backup.
+ *
+ * Failure posture matches its applyHomeAssets neighbours: never throw. A
+ * store that cannot be converted (locked by a concurrent host process,
+ * driver unavailable, sweep lock-wait budget spent) is logged and left
+ * exactly as found; the next lifecycle pass retries. Orphaned `-wal` files
+ * (no companion database) are reported and NEVER deleted.
+ */
+import type { Dirent } from "node:fs";
+import {
+  closeSync,
+  existsSync,
+  openSync,
+  readSync,
+  readdirSync,
+  statSync,
+  unlinkSync,
+} from "node:fs";
+import { join } from "node:path";
+import { createLogger } from "../logger.js";
+import { errMessage } from "./errors.js";
+import { akmDataRoots } from "./home.js";
+import { describeHostRuntime } from "./host-identity.js";
+import type { HostRuntime } from "./host-identity.js";
+// The shared lazy driver seam (see sqlite-driver.ts for the barrel constraint
+// and the node:sqlite fallback this module's Electron call path relies on).
+// Driver-unavailable is non-fatal here: the sweep reports the stores it left
+// behind and the next CLI-driven lifecycle pass (Bun) heals them.
+import { loadSqliteOpen } from "./sqlite-driver.js";
+import type { SqliteConnection, SqliteOpen } from "./sqlite-driver.js";
+import type { ControlPlaneState } from "./types.js";
+
+const logger = createLogger("akm-db-journal");
+
+// ── Header sniffing (never takes a lock) ─────────────────────────────────────
+
+/** First 16 bytes of every SQLite database file: "SQLite format 3" + NUL. */
+const SQLITE_MAGIC = Buffer.from("SQLite format 3\u0000", "latin1");
+
+/**
+ * Read-only 20-byte sniff. Returns header info for a readable SQLite database
+ * file and null for anything else (non-SQLite, too short, unreadable) — the
+ * sweep treats all of those identically: not a conversion candidate.
+ *
+ * `walHeader` is header bytes 18/19 (file-format write/read version): 1 =
+ * rollback journal, 2 = WAL. NOTE: false does not prove the store is WAL-free
+ * — the header flip itself can sit in an un-checkpointed `-wal` (the observed
+ * live shape) — which is why sidecar presence is checked independently.
+ */
+function sniffSqliteHeader(path: string): { walHeader: boolean } | null {
+  let fd: number;
+  try {
+    fd = openSync(path, "r");
+  } catch {
+    return null;
+  }
+  try {
+    const header = Buffer.alloc(20);
+    if (readSync(fd, header, 0, 20, 0) < 20 || !header.subarray(0, 16).equals(SQLITE_MAGIC)) {
+      return null;
+    }
+    return { walHeader: header[18] === 2 || header[19] === 2 };
+  } catch {
+    return null;
+  } finally {
+    closeSync(fd);
+  }
+}
+
+// ── Tree walk ────────────────────────────────────────────────────────────────
+
+/**
+ * All regular files under `root`, recursively. Symlinks are never followed
+ * (the sweep must not reach outside the akm data root), and an unreadable
+ * subtree — including a missing `root` — is skipped rather than aborting the
+ * sweep: container-written subdirectories can be 0700 under a different uid
+ * on some deployments.
+ */
+function walkFiles(root: string, out: string[] = []): string[] {
+  let entries: Dirent[];
+  try {
+    entries = readdirSync(root, { withFileTypes: true });
+  } catch {
+    return out;
+  }
+  for (const entry of entries) {
+    const path = join(root, entry.name);
+    if (entry.isSymbolicLink()) continue;
+    if (entry.isDirectory()) walkFiles(path, out);
+    else if (entry.isFile()) out.push(path);
+  }
+  return out;
+}
+
+function statSizeOrZero(path: string): number {
+  try {
+    return statSync(path).size;
+  } catch {
+    return 0;
+  }
+}
+
+// ── Conversion ───────────────────────────────────────────────────────────────
+
+export type AkmDbJournalAction = "converted" | "failed" | "orphaned-wal";
+
+export interface AkmDbJournalEntry {
+  /**
+   * The affected database file. For `orphaned-wal` it is the missing
+   * companion the sidecar implies; for a root-wide failure (no SQLite driver
+   * in this runtime) it is the sweep root itself.
+   */
+  dbPath: string;
+  action: AkmDbJournalAction;
+  /** Bytes of `-wal` sidecar involved; 0 when the trigger was a WAL header with no sidecar. */
+  walBytes: number;
+  detail?: string;
+}
+
+export interface AkmDbJournalSweepResult {
+  root: string;
+  /** Candidate files inspected under `root` (header sniff — sidecars and `.bak` snapshots excluded). */
+  scanned: number;
+  /**
+   * Noteworthy outcomes only: conversions, failures, orphaned `-wal`s.
+   * Healthy rollback-mode stores and non-SQLite files are counted in
+   * `scanned` and omitted, so this sweep is silent on a healthy home.
+   */
+  entries: AkmDbJournalEntry[];
+}
+
+/**
+ * Checkpoint the WAL into the main file, then flip the store to DELETE
+ * journal mode. Ordering matters: `journal_mode=DELETE` alone silently stays
+ * on "wal" when it cannot take the exclusive lock, and the checkpoint is
+ * what preserves the WAL's content — never delete or bypass a `-wal`.
+ * SQLite removes the `-wal` sidecar itself on a successful flip.
+ */
+function convertDb(
+  open: SqliteOpen,
+  dbPath: string,
+  walBytes: number,
+  busyTimeoutMs: number,
+): AkmDbJournalEntry {
+  const fail = (detail: string): AkmDbJournalEntry => ({
+    dbPath,
+    action: "failed",
+    walBytes,
+    detail,
+  });
+  let conn: SqliteConnection;
+  try {
+    conn = open(dbPath);
+  } catch (error) {
+    return fail(`open failed: ${errMessage(error)}`);
+  }
+  try {
+    // Tolerate a briefly-held host-side lock, within what remains of the
+    // sweep-wide budget — a store wedged longer is left for the next pass.
+    conn.pragmaRow(`busy_timeout = ${busyTimeoutMs}`);
+    const checkpoint = conn.pragmaRow("wal_checkpoint(TRUNCATE)");
+    if (!checkpoint || Number(checkpoint.busy) !== 0) {
+      return fail("wal_checkpoint(TRUNCATE) could not complete (database busy)");
+    }
+    const modeRow = conn.pragmaRow("journal_mode = DELETE");
+    const mode = String(modeRow?.journal_mode ?? "unknown").toLowerCase();
+    if (mode !== "delete") {
+      return fail(`journal_mode is still "${mode}" after PRAGMA journal_mode=DELETE`);
+    }
+  } catch (error) {
+    return fail(errMessage(error));
+  } finally {
+    try {
+      conn.close();
+    } catch {
+      // A close failure must not mask the conversion outcome.
+    }
+  }
+  if (existsSync(`${dbPath}-wal`)) {
+    // Both PRAGMAs reported success but the sidecar survived — treat as not
+    // converted so the next pass retries instead of trusting a half-state.
+    return fail("-wal sidecar still present after conversion");
+  }
+  // A leftover `-shm` is safe to remove once the `-wal` is gone: it is a
+  // rebuildable shared-memory index into the (now checkpointed) WAL, never
+  // durable state — unlike the `-wal`, which this module never deletes. The
+  // connection that just left WAL mode does not clean it up on close.
+  try {
+    unlinkSync(`${dbPath}-shm`);
+  } catch {
+    // Absent or unremovable — either way harmless: rollback-mode opens never
+    // consult the -shm.
+  }
+  return { dbPath, action: "converted", walBytes };
+}
+
+/** SQLite's own sidecar files — never conversion candidates themselves. */
+const SIDECAR_SUFFIX = /-(?:wal|shm|journal)$/;
+
+/**
+ * Backup snapshots (e.g. the runbook's `state.db.manual-backup-<ts>.bak`):
+ * SQLite content nothing ever opens. Converting one would mutate an
+ * operator's backup, so they are excluded before the sniff.
+ */
+const BACKUP_SUFFIX = /\.bak$/;
+
+/**
+ * Approximate lock-wait budget for one whole sweep, not per store. An
+ * incident-shape tree can carry dozens of candidates, and this runs
+ * synchronously on the install/update/launch path — a per-store timeout
+ * would let one lock contender stall the pass for minutes. Whatever the
+ * budget cannot cover is reported and retried on the next pass.
+ */
+const SWEEP_BUSY_BUDGET_MS = 5000;
+
+/**
+ * Sweep one directory tree for SQLite stores carrying WAL residue and
+ * convert each to DELETE journal mode via checkpoint-first. Unconditional —
+ * the runtime/root policy lives in {@link reconcileAkmDbJournalMode}.
+ * Never throws.
+ */
+export function convertWalDbsToDeleteJournal(root: string): AkmDbJournalSweepResult {
+  const result: AkmDbJournalSweepResult = { root, scanned: 0, entries: [] };
+  const files = walkFiles(root);
+  const fileSet = new Set(files);
+
+  const candidates: Array<{ dbPath: string; walBytes: number }> = [];
+  for (const file of files) {
+    if (SIDECAR_SUFFIX.test(file) || BACKUP_SUFFIX.test(file)) continue;
+    result.scanned += 1;
+    const info = sniffSqliteHeader(file);
+    if (!info) continue;
+    const hasWal = fileSet.has(`${file}-wal`);
+    // Healthy rollback-mode store — never even opened (a live container may hold it).
+    if (!hasWal && !info.walHeader) continue;
+    candidates.push({ dbPath: file, walBytes: hasWal ? statSizeOrZero(`${file}-wal`) : 0 });
+  }
+
+  if (candidates.length > 0) {
+    const open = loadSqliteOpen();
+    if (!open) {
+      // One aggregate entry, not one per store: a runtime with no SQLite
+      // driver hits this on every launch, and per-store entries would warn
+      // dozens of times for one unfixable cause.
+      result.entries.push({
+        dbPath: root,
+        action: "failed",
+        walBytes: candidates.reduce((sum, c) => sum + c.walBytes, 0),
+        detail: `no SQLite driver available in this runtime (tried bun:sqlite, node:sqlite); ${candidates.length} store(s) need conversion`,
+      });
+    } else {
+      const deadline = Date.now() + SWEEP_BUSY_BUDGET_MS;
+      for (const candidate of candidates) {
+        const remainingMs = deadline - Date.now();
+        if (remainingMs <= 0) {
+          result.entries.push({
+            ...candidate,
+            action: "failed",
+            detail: "sweep lock-wait budget exhausted; retrying on the next lifecycle pass",
+          });
+          continue;
+        }
+        result.entries.push(convertDb(open, candidate.dbPath, candidate.walBytes, remainingMs));
+      }
+    }
+  }
+
+  // A `-wal` with no companion database cannot be checkpointed, and a WAL can
+  // hold real state — report it and leave it exactly where it is.
+  for (const file of files) {
+    if (!file.endsWith("-wal")) continue;
+    const base = file.slice(0, -"-wal".length);
+    if (fileSet.has(base)) continue;
+    result.entries.push({
+      dbPath: base,
+      action: "orphaned-wal",
+      walBytes: statSizeOrZero(file),
+      detail: "-wal sidecar has no companion database file; left in place",
+    });
+  }
+  return result;
+}
+
+// ── Lifecycle wiring ─────────────────────────────────────────────────────────
+
+/**
+ * Heal WAL residue under every akm data root ({@link akmDataRoots}),
+ * host-side, before the stack starts. No-op on native Linux, where
+ * in-container WAL is legitimate and possibly live — the classification is
+ * read from {@link describeHostRuntime}, the one seam that owns it. Never
+ * throws — failures are logged and retried on the next lifecycle pass.
+ * `runtime` is injectable for tests only.
+ */
+export function reconcileAkmDbJournalMode(
+  state: Pick<ControlPlaneState, "homeDir">,
+  runtime: HostRuntime = describeHostRuntime(),
+): AkmDbJournalSweepResult[] {
+  if (!runtime.bindMountsCrossVmFilesystem) return [];
+  const results: AkmDbJournalSweepResult[] = [];
+  for (const root of akmDataRoots(state.homeDir)) {
+    try {
+      const sweep = convertWalDbsToDeleteJournal(root);
+      for (const entry of sweep.entries) {
+        const fields = { dbPath: entry.dbPath, walBytes: entry.walBytes, detail: entry.detail };
+        if (entry.action === "converted") {
+          logger.info("converted akm SQLite store out of WAL mode for container access", fields);
+        } else if (entry.action === "orphaned-wal") {
+          logger.warn("orphaned SQLite -wal sidecar under akm data root (left in place)", fields);
+        } else {
+          logger.warn(
+            "could not convert akm SQLite store out of WAL mode; the in-container akm may fail to open it",
+            fields,
+          );
+        }
+      }
+      results.push(sweep);
+    } catch (error) {
+      // convertWalDbsToDeleteJournal is written not to throw; this is the
+      // never-break-applyHomeAssets backstop.
+      logger.warn("akm SQLite WAL sweep failed", { root, error: errMessage(error) });
+    }
+  }
+  return results;
+}

--- a/packages/lib/src/control-plane/home.ts
+++ b/packages/lib/src/control-plane/home.ts
@@ -308,6 +308,18 @@ export function resolveRollbackDir(): string {
   return `${resolveDataDir()}/rollback`;
 }
 
+/**
+ * The akm durable-data roots — one per akm-bearing service, each bind-mounted
+ * into its container at /opt/akm/data (core.compose.yml, services.compose.yml).
+ * Every SQLite store akm owns lives under one of these. Defined ONCE, consumed
+ * by BOTH {@link ensureHomeDirs} (creation) and the WAL-residue sweep
+ * (akm-db-journal.ts), so a new akm-bearing service cannot be added to the
+ * tree without also being swept.
+ */
+export function akmDataRoots(home: string): string[] {
+  return [`${home}/data/akm/data`, `${home}/data/paperclip-akm/data`];
+}
+
 // ── Directory Setup ──────────────────────────────────────────────────
 
 /**
@@ -359,11 +371,10 @@ export function ensureHomeDirs(home: string = resolveOpenPalmHome()): void {
     `${home}/data/paperclip/.config/opencode`, // nested read-only user-config mountpoint
     `${home}/data/tunnel`,         // remote addon: persistent tailnet node identity (see remoteTunnelStateDir)
     `${home}/data/akm/cache`,      // akm cache
-    `${home}/data/akm/data`,       // akm durable data
+    ...akmDataRoots(home),         // akm durable data (assistant + Paperclip; also WAL-swept, see akmDataRoots)
     `${home}/data/akm/data/state`, // akm task-scheduler state (AKM_STATE_DIR, akm >= 0.9.0)
     `${home}/data/akm/empty-host-stash`, // always-present /host-stash fallback when host AKM is absent
     `${home}/data/paperclip-akm/cache`, // Paperclip AKM cache
-    `${home}/data/paperclip-akm/data`, // Paperclip AKM durable data
     `${home}/data/paperclip-akm/data/state`, // Paperclip AKM scheduler state
     `${home}/data/logs`,           // service logs and audit files
     `${home}/data/ui`,             // materialized UI build (CLI-embedded, or bundled/repo-resolved)

--- a/packages/lib/src/control-plane/host-identity.test.ts
+++ b/packages/lib/src/control-plane/host-identity.test.ts
@@ -21,24 +21,27 @@ describe('describeHostRuntime (Docker Desktop seam)', () => {
   const setPlatform = (value: NodeJS.Platform) =>
     Object.defineProperty(process, 'platform', { value, configurable: true });
 
-  test('native Linux is host-uid authoritative', () => {
+  test('native Linux is host-uid authoritative with native bind mounts', () => {
     setPlatform('linux');
     const runtime = describeHostRuntime();
     expect(runtime.hostUidAuthoritative).toBe(true);
+    expect(runtime.bindMountsCrossVmFilesystem).toBe(false);
     expect(runtime.id).toBe('linux-native');
   });
 
-  test('macOS (Docker Desktop VM) is not host-uid authoritative', () => {
+  test('macOS (Docker Desktop VM) is not host-uid authoritative and bind mounts cross the VM', () => {
     setPlatform('darwin');
     const runtime = describeHostRuntime();
     expect(runtime.hostUidAuthoritative).toBe(false);
+    expect(runtime.bindMountsCrossVmFilesystem).toBe(true);
     expect(runtime.id).toContain('darwin');
   });
 
-  test('Windows (Docker Desktop VM) is not host-uid authoritative', () => {
+  test('Windows (Docker Desktop VM) is not host-uid authoritative and bind mounts cross the VM', () => {
     setPlatform('win32');
     const runtime = describeHostRuntime();
     expect(runtime.hostUidAuthoritative).toBe(false);
+    expect(runtime.bindMountsCrossVmFilesystem).toBe(true);
     expect(runtime.id).toContain('win32');
   });
 });

--- a/packages/lib/src/control-plane/host-identity.ts
+++ b/packages/lib/src/control-plane/host-identity.ts
@@ -30,6 +30,18 @@ export type HostRuntime = {
    * the VM's own uid namespace.
    */
   hostUidAuthoritative: boolean;
+  /**
+   * True on VM-mediated runtimes, where every bind mount crosses the VM
+   * file-sharing layer (virtiofs / gRPC-FUSE / 9p) and SQLite WAL journals —
+   * which need the `-shm` shared-memory index and POSIX locks — cannot work
+   * across the mount. The inverse of native Linux. Kept separate from
+   * `hostUidAuthoritative` (a uid statement) even though both currently derive
+   * from the same classification, so each consumer reads the fact it actually
+   * depends on — and a future refinement (e.g. detecting Docker Desktop *for
+   * Linux*) lands here once and reaches every consumer. Consumed by the akm
+   * WAL-residue sweep (akm-db-journal.ts).
+   */
+  bindMountsCrossVmFilesystem: boolean;
 };
 
 /**
@@ -43,9 +55,13 @@ export type HostRuntime = {
  */
 export function describeHostRuntime(): HostRuntime {
   if (process.platform === 'linux') {
-    return { id: 'linux-native', hostUidAuthoritative: true };
+    return { id: 'linux-native', hostUidAuthoritative: true, bindMountsCrossVmFilesystem: false };
   }
-  return { id: `vm-mediated-${process.platform}`, hostUidAuthoritative: false };
+  return {
+    id: `vm-mediated-${process.platform}`,
+    hostUidAuthoritative: false,
+    bindMountsCrossVmFilesystem: true
+  };
 }
 
 export function detectHostIdentity(homeDir: string): HostIdentity {

--- a/packages/lib/src/control-plane/lifecycle.ts
+++ b/packages/lib/src/control-plane/lifecycle.ts
@@ -49,6 +49,7 @@ import { backupOpenPalmHome, pruneBackupDirs } from './backup.js';
 import { guardianRequired } from './guardian-required.js';
 import { advanceManagedImageVersions, ensureVersionDefaults } from './versions.js';
 import { ensureSystemBundle, reconcileDuplicateBundles, stripRetiredAkmConfigKeys } from './akm-sources.js';
+import { reconcileAkmDbJournalMode } from './akm-db-journal.js';
 import {
 	captureRunningImageIds,
 	restoreRunningImageIds,
@@ -195,6 +196,17 @@ export async function applyHomeAssets(state: ControlPlaneState): Promise<void> {
 	// skills bundle: only setup and install pin it, so without this an upgraded
 	// home gets the :ro /system-stash mount with nothing configured to read it.
 	ensureSystemBundle(state);
+	// The fourth heal covers akm's DATA, not its config: on macOS/Windows the
+	// containers' bind mounts always cross a VM filesystem, where SQLite WAL
+	// cannot work, so akm >= 0.9.6 opens its stores in DELETE journal mode —
+	// but WAL residue left by an older akm (un-checkpointed `-wal` sidecars
+	// under data/akm/data/, holding potentially months of state) makes every
+	// in-container open fail "database is locked" on every boot. Only the host
+	// can checkpoint that WAL back in, and it must happen before the stack
+	// starts. No-op on Linux (native binds — in-container WAL is legitimate
+	// there) and on healthy homes; never throws (failures log and retry on the
+	// next pass).
+	reconcileAkmDbJournalMode(state);
 }
 
 /**
@@ -207,7 +219,8 @@ export async function applyHomeAssets(state: ControlPlaneState): Promise<void> {
  *   • ensureSecrets         — generate any missing service secrets
  *   • applyHomeAssets       — overwrite the managed system/ tree wholesale +
  *                             seed the user/data trees once (skip-existing) +
- *                             heal the akm configs that tree depends on
+ *                             heal the akm configs and SQLite journal modes
+ *                             that tree depends on
  *   • reconcileRemoteAccess — regenerate the `remote` addon's serve config
  *   • ensureOpenCode*       — starter OpenCode config + data dir (seed-if-missing)
  *

--- a/packages/lib/src/control-plane/opencode-db-maintenance.ts
+++ b/packages/lib/src/control-plane/opencode-db-maintenance.ts
@@ -23,7 +23,7 @@
  *     knowledge of table/column names required.
  *
  *  2. WAL **checkpoint** and **VACUUM** operate directly on the sqlite file
- *     via `bun:sqlite`. These are generic sqlite maintenance operations
+ *     via the shared SQLite driver seam (sqlite-driver.ts). These are generic sqlite maintenance operations
  *     (`PRAGMA wal_checkpoint`, `VACUUM`, `PRAGMA page_count`/`freelist_count`)
  *     that need no knowledge of OpenCode's table schema at all, so they carry
  *     no schema-assumption risk the way raw session deletion would.
@@ -35,24 +35,16 @@
  * stale subagent/child trees the incident report calls out, without
  * restricting subagent use going forward.
  */
-import { createRequire } from "node:module";
 import { join } from "node:path";
-import type { Database } from "bun:sqlite";
 import type { OpenCodeSession } from "./opencode-client.js";
-
-// `bun:sqlite` is a Bun built-in and this module only ever runs under the Bun
-// CLI. But it is re-exported from the @openpalm/lib barrel, which Node/Vitest
-// consumers (ui, electron) import — a static value import of `bun:sqlite` would
-// make the whole barrel unloadable under Node (ERR_MODULE_NOT_FOUND). Keep the
-// type import (erased at runtime) and resolve the constructor lazily, so
-// importing this module under Node never touches `bun:sqlite`; only actually
-// calling one of the DB functions (which happens under Bun) resolves it.
-const requireBun = createRequire(import.meta.url);
-let cachedDatabaseCtor: typeof Database | undefined;
-function loadDatabase(): typeof Database {
-  cachedDatabaseCtor ??= (requireBun("bun:sqlite") as typeof import("bun:sqlite")).Database;
-  return cachedDatabaseCtor;
-}
+// SQLite access goes through the shared lazy driver seam (sqlite-driver.ts),
+// which keeps the barrel importable under plain Node (no static `bun:sqlite`
+// import — see that module for the constraint) and adds a `node:sqlite`
+// fallback, so the DB functions below also work from Electron main / Node
+// >= 22. On a runtime with neither driver they throw: every caller here
+// needs a real answer (sizes, a completed checkpoint), not a silent skip.
+import { requireSqliteOpen } from "./sqlite-driver.js";
+import type { SqliteConnection } from "./sqlite-driver.js";
 
 // ── Session retention (pure — no I/O) ───────────────────────────────────────
 
@@ -340,15 +332,14 @@ export interface DbSizeInfo {
   freeRatio: number;
 }
 
-function pragmaNumber(db: Database, pragma: string, column: string): number {
-  const row = db.query(`PRAGMA ${pragma};`).get() as Record<string, unknown> | null;
-  const value = row?.[column];
+function pragmaNumber(conn: SqliteConnection, pragma: string, column: string): number {
+  const value = conn.pragmaRow(pragma)?.[column];
   return typeof value === "number" ? value : 0;
 }
 
 /** Read page/freelist accounting from a sqlite file without locking it for writes. */
 export function getDbSizeInfo(dbPath: string): DbSizeInfo {
-  const db = new (loadDatabase())(dbPath, { readonly: true });
+  const db = requireSqliteOpen()(dbPath, { readonly: true });
   try {
     const pageCount = pragmaNumber(db, "page_count", "page_count");
     const pageSize = pragmaNumber(db, "page_size", "page_size");
@@ -377,7 +368,7 @@ export type WalCheckpointMode = "PASSIVE" | "FULL" | "RESTART" | "TRUNCATE";
  * as "the DB isn't the problem."
  */
 export function checkpointWal(dbPath: string, mode: WalCheckpointMode = "TRUNCATE"): void {
-  const db = new (loadDatabase())(dbPath);
+  const db = requireSqliteOpen()(dbPath);
   try {
     db.exec(`PRAGMA wal_checkpoint(${mode});`);
   } finally {
@@ -399,7 +390,7 @@ export function checkpointWal(dbPath: string, mode: WalCheckpointMode = "TRUNCAT
  * immediately after vacuuming, in the same connection/transaction scope.
  */
 export function vacuumDb(dbPath: string): void {
-  const db = new (loadDatabase())(dbPath);
+  const db = requireSqliteOpen()(dbPath);
   try {
     db.exec("VACUUM;");
     db.exec("PRAGMA wal_checkpoint(TRUNCATE);");

--- a/packages/lib/src/control-plane/sqlite-driver.test.ts
+++ b/packages/lib/src/control-plane/sqlite-driver.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { loadSqliteOpen, requireSqliteOpen } from "./sqlite-driver.js";
+
+describe("sqlite driver seam", () => {
+  test("loads a driver under Bun and memoizes it", () => {
+    const open = loadSqliteOpen();
+    expect(open).not.toBeNull();
+    expect(loadSqliteOpen()).toBe(open);
+    expect(requireSqliteOpen()).toBe(open as NonNullable<typeof open>);
+  });
+
+  test("pragmaRow, exec, and readonly behave as the consumers assume", () => {
+    const dir = mkdtempSync(join(tmpdir(), "sqlite-driver-"));
+    try {
+      const open = requireSqliteOpen();
+      const path = join(dir, "t.db");
+
+      const rw = open(path);
+      rw.exec("CREATE TABLE t (id INTEGER PRIMARY KEY);");
+      rw.exec("INSERT INTO t DEFAULT VALUES;");
+      expect(rw.pragmaRow("page_count")?.page_count).toBeGreaterThan(0);
+      // Unknown pragmas are silently ignored by SQLite: no rows, no error.
+      expect(rw.pragmaRow("no_such_pragma_exists")).toBeNull();
+      rw.close();
+
+      const ro = open(path, { readonly: true });
+      expect(ro.pragmaRow("page_count")?.page_count).toBeGreaterThan(0);
+      expect(() => ro.exec("INSERT INTO t DEFAULT VALUES;")).toThrow();
+      ro.close();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/lib/src/control-plane/sqlite-driver.ts
+++ b/packages/lib/src/control-plane/sqlite-driver.ts
@@ -1,0 +1,100 @@
+/**
+ * Shared lazy SQLite driver seam.
+ *
+ * Control-plane modules that touch SQLite files directly (akm-db-journal.ts,
+ * opencode-db-maintenance.ts) share two constraints, solved once here:
+ *
+ *  1. The barrel must stay importable under plain Node. `bun:sqlite` is a Bun
+ *     built-in, and these modules are re-exported from the @openpalm/lib
+ *     barrel, which Node/Vitest consumers (ui, electron) import — a static
+ *     value import would make the whole barrel unloadable under Node
+ *     (ERR_MODULE_NOT_FOUND). So the driver is resolved lazily, on the first
+ *     actual open.
+ *
+ *  2. Not every caller runs under Bun. applyHomeAssets (and with it the akm
+ *     WAL-residue sweep) also runs in Electron's main process, so after
+ *     `bun:sqlite` this tries `node:sqlite` (Node >= 22). When neither loads,
+ *     {@link loadSqliteOpen} reports that as `null` for callers that can
+ *     degrade (the WAL sweep records the stores it left behind), and
+ *     {@link requireSqliteOpen} throws for callers that need a real answer
+ *     (size accounting, VACUUM).
+ *
+ * The connection surface is deliberately minimal — one-shot PRAGMA reads and
+ * fire-and-forget SQL — because that is all the maintenance-style callers
+ * need. Anything richer (prepared-statement reuse, transactions with bound
+ * parameters) should keep using `bun:sqlite` directly from Bun-only code.
+ */
+import { createRequire } from "node:module";
+
+export interface SqliteOpenOptions {
+  /** Open read-only — reads never risk taking a write lock on a live store. */
+  readonly?: boolean;
+}
+
+export interface SqliteConnection {
+  /** Run `PRAGMA <statement>;` and return its first result row, if any. */
+  pragmaRow(statement: string): Record<string, unknown> | null;
+  /** Execute SQL, discarding any result rows (VACUUM, fire-and-forget PRAGMAs). */
+  exec(sql: string): void;
+  close(): void;
+}
+
+export type SqliteOpen = (path: string, options?: SqliteOpenOptions) => SqliteConnection;
+
+interface SqliteDatabaseCtor {
+  new (path: string, options?: Record<string, unknown>): {
+    prepare(sql: string): { get(): unknown };
+    exec(sql: string): void;
+    close(): void;
+  };
+}
+
+/**
+ * Both drivers expose the same prepare/exec/close surface this seam needs;
+ * they differ only in module/constructor names and the spelling of the
+ * read-only open option (bun: `readonly`, node: `readOnly`).
+ */
+const DRIVER_CANDIDATES = [
+  { moduleName: "bun:sqlite", ctorName: "Database", readonlyKey: "readonly" },
+  { moduleName: "node:sqlite", ctorName: "DatabaseSync", readonlyKey: "readOnly" },
+] as const;
+
+const requireHost = createRequire(import.meta.url);
+let cachedOpen: SqliteOpen | null | undefined;
+
+/** Resolve the first available driver, memoized process-wide (including the "neither" answer). */
+export function loadSqliteOpen(): SqliteOpen | null {
+  if (cachedOpen !== undefined) return cachedOpen;
+  cachedOpen = null;
+  for (const { moduleName, ctorName, readonlyKey } of DRIVER_CANDIDATES) {
+    let Ctor: SqliteDatabaseCtor | undefined;
+    try {
+      Ctor = (requireHost(moduleName) as Record<string, SqliteDatabaseCtor>)[ctorName];
+    } catch {
+      continue; // driver not available in this runtime — try the next
+    }
+    if (!Ctor) continue;
+    const ctor = Ctor;
+    cachedOpen = (path, options) => {
+      const db = new ctor(path, options?.readonly ? { [readonlyKey]: true } : undefined);
+      return {
+        pragmaRow: (statement) =>
+          (db.prepare(`PRAGMA ${statement};`).get() as Record<string, unknown> | undefined) ??
+          null,
+        exec: (sql) => db.exec(sql),
+        close: () => db.close(),
+      };
+    };
+    break;
+  }
+  return cachedOpen;
+}
+
+/** Like {@link loadSqliteOpen}, for callers that cannot degrade — throws when no driver loads. */
+export function requireSqliteOpen(): SqliteOpen {
+  const open = loadSqliteOpen();
+  if (!open) {
+    throw new Error("No SQLite driver available in this runtime (tried bun:sqlite, node:sqlite).");
+  }
+  return open;
+}

--- a/packages/lib/src/index.ts
+++ b/packages/lib/src/index.ts
@@ -119,6 +119,7 @@ export {
   stateEnvDir,
   resolveBackupsDirFor,
   resolveCacheDir,
+  akmDataRoots,
   legacyKnowledgeStackEnvFile,
   legacyStateEnvFile,
 } from "./control-plane/home.js";
@@ -303,6 +304,15 @@ export {
   stripRetiredAkmConfigKeys,
 } from "./control-plane/akm-sources.js";
 export type { HostAkmConfigStatus } from "./control-plane/akm-sources.js";
+export {
+  convertWalDbsToDeleteJournal,
+  reconcileAkmDbJournalMode,
+} from "./control-plane/akm-db-journal.js";
+export type {
+  AkmDbJournalAction,
+  AkmDbJournalEntry,
+  AkmDbJournalSweepResult,
+} from "./control-plane/akm-db-journal.js";
 export type {
   HostAkmSharingStatus,
 } from "./control-plane/host-akm-sharing.js";


### PR DESCRIPTION
## Problem

akm >= 0.9.6 correctly refuses WAL journal mode over the VM file-sharing layer (virtiofs/gRPC-FUSE) that every Docker Desktop / OrbStack bind mount crosses. But a home that ever ran an older akm still carries WAL residue under `data/akm/data/`, and SQLite engages the WAL machinery for any non-empty database with a `-wal` sidecar **before** a client can ask for DELETE mode. The in-container akm then fails every open with `database is locked`: the boot health step exits 78 on every boot and `akm workflow list --active` never answers, while the host opens the same files fine.

Observed on a live upgraded home: a 4 KB `state.db` whose **entire content** — rows, schema, even the header flip to WAL mode — sat in a 1.1 MB un-checkpointed `state.db-wal` untouched for months. Deleting the sidecar would have destroyed that state; only a host-side checkpoint folds it back safely.

## Fix

`applyHomeAssets` (install / update / desktop launch / CLI supervisor spawn) now sweeps the akm data roots host-side, where WAL and POSIX locking work natively: `PRAGMA wal_checkpoint(TRUNCATE)` then `PRAGMA journal_mode=DELETE`, checkpoint first so no WAL content is ever discarded. Orphaned `-wal` files are reported and never deleted. This is a recurring reconcile, deliberately **not** a `runHomeMigrations` entry — any host-side akm run against the same tree re-mints the residue on a schema-stamped home.

Design points:

- **Platform gate through the existing seam**: new `HostRuntime.bindMountsCrossVmFilesystem` field on `describeHostRuntime()` (host-identity.ts). Native Linux is a no-op — in-container WAL is legitimate there and possibly live.
- **Roots from one source**: `akmDataRoots()` in home.ts, consumed by both `ensureHomeDirs` and the sweep, so a future akm-bearing service cannot be created without being swept.
- **Detection by content, not filename**: SQLite magic sniff (akm keeps SQLite stores under non-`.db` names) + sidecar presence + header bytes 18/19. Healthy rollback-mode stores are never opened; `.bak` snapshots are excluded.
- **Bounded and quiet**: sweep-wide 5s lock-wait budget (an incident tree can carry dozens of candidates); one aggregate entry when the runtime has no SQLite driver; never throws — failures log and retry next pass.
- **Shared driver seam** (first commit): `sqlite-driver.ts` extracts the lazy bun:sqlite -> node:sqlite loader; `opencode-db-maintenance.ts` migrates onto it, so `getDbSizeInfo`/`checkpointWal`/`vacuumDb` now also work under Electron main / Node >= 22 instead of hard-failing, with public APIs unchanged.

## Docs

- CHANGELOG entry under `[Unreleased]`.
- `docs/operations/upgrade-0.12-to-0.13.md` section 8: symptom description plus the manual host-side `sqlite3` loop for operators on 0.13.0 exactly (and Docker Desktop for Linux, which the platform gate cannot distinguish from native Linux).

## Verification

- New regression suite `akm-db-journal.test.ts` (12 tests) reproduces the live incident shape exactly — rollback header with the whole database in the sidecar — and asserts every row survives conversion; plus idempotency, orphan preservation, `.bak` exclusion, recursion, magic-based detection, and the Linux no-op. `sqlite-driver.test.ts` pins the seam contract (memoization, pragmaRow, exec, readonly).
- `bun test --cwd packages/lib`: 1661 pass; the only 3 failures are pre-existing environment failures confirmed identical at the clean merge-base on the dev machine (macOS `/private/var` tmpdir realpath, VM-mediated ownership fast-path).
- CLI (228 pass) and Electron (185 pass, vitest under Node — proves the barrel stays importable with no static `bun:sqlite`) suites match their merge-base baselines exactly. `tsc --noEmit` and biome clean.
- Sweep validated against copies of the real incident files before the live home was manually healed, and confirmed a silent no-op (`scanned: 4, entries: []`, `integrity_check: ok`) on the healed shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
