### PR TITLE
fix: truthful akm boot state, the state.db cutover remedy, and container-correct config writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,25 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **Preferred-model saves from the admin UI now persist — and clearing one
+  actually clears it.** Three defects in the `opencode.json` write path
+  (`packages/ui/src/lib/server/opencode/config.ts`), found together. First:
+  the admin UI co-process runs inside the assistant container, where the
+  entrypoint deliberately injects no `OP_HOME` — but `configPath()` resolved
+  `OP_HOME ?? ''` into a RELATIVE `config/assistant/opencode.json` against the
+  server's cwd, so a preferred-model save either errored outright or landed in
+  a phantom file the assistant never reads, while the best-effort live PATCH
+  made it look saved until the next restart dropped it. The path now falls
+  back to the container's real file, the read-write bind mount at
+  `~/.config/opencode/opencode.json`. Second: clearing a model never
+  persisted — `patchConfig` starts its merge from what is on disk, so a key
+  the caller deleted from its in-memory copy was resurrected by the spread;
+  removals are now explicit. Third: `setMainModel` round-tripped the full
+  `getCurrentConfig()`, whose fallback is OpenCode's live `/config`, so a save
+  against an unreadable disk file would have baked the entire runtime-merged
+  config into the operator's file; saves are now deltas merged over the disk
+  state.
+
 - **The host akm import now rewrites loopback endpoints for the container.**
   `config/akm/config.json` is container-view by contract: the setup wizard
   rewrites a loopback provider URL to `host.docker.internal` at the moment it

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,51 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- **`openpalm-akm-state-upgrade` — a working remedy for akm's deliberate
+  state.db cutover, and a boot marker that names it.** akm never applies a
+  state.db migration it classifies `historical-destructive` (0.9.6/0.9.7 ship one:
+  `018-drop-dead-lane-schema`) during an ordinary open: `akm health` exits 78
+  on every boot and every state.db surface — events, proposals, task history,
+  improve ledgers, workflow runs — fails to open until the cutover runs. The
+  remedy akm's own error names, `akm upgrade --force`, is the package
+  SELF-UPDATER and cannot work inside the container: it needs GitHub egress,
+  runs `npm install -g akm-cli@latest` (forbidden by the image-baked model and
+  EACCES for the container user anyway), and only reaches the state.db step
+  after that install succeeds — verified against the 0.9.6 sources, byte-
+  identical in 0.9.7, which expose the state step
+  (`upgradeHistoricalStateDatabase`) to the self-updater alone. The image now bakes a helper that drives that machinery directly:
+  a verified sibling safety copy first (`VACUUM INTO` + `quick_check` + ledger
+  check), then the pending migrations; idempotent and fully offline, rehearsed
+  end-to-end on the built image. Boot recognizes the refusal in `akm health`'s
+  output, records `health 78 state-upgrade-pending` in the boot marker, and
+  logs the helper's name — and deliberately never runs it: akm reserves this
+  migration class for explicit intent, and a boot that granted that intent
+  automatically would extend it to every future destructive migration an image
+  bump ships. Operator docs cover the upgrade-time symptom and the remedy,
+  including a fallback invocation for 0.13.0 images that predate the helper.
+
+### Fixed
+
+- **Boot no longer misreports a pending task-file migration as "current".**
+  `akm migrate status` (akm-cli 0.9.6/0.9.7) exits 0 for both of its clean plan
+  states — "current" and "ready", where ready means operator task files that
+  `akm migrate apply` would convert to task source v4 — and only a "blocked"
+  plan exits 1. The assistant entrypoint read exit 0 as "migration state is
+  current", so a home with an operator-authored `version: 2` task recorded
+  `migrate 0 current` in the boot marker on every boot while akm itself warned
+  "run `akm migrate apply`" on every read of that file — the marker
+  contradicted the logs forever. The entrypoint now parses the plan's `status`
+  field and records the truth, `migrate 0 ready operator-apply-pending`, with
+  a boot log line naming the remedy. Deliberately unchanged: boot still never
+  runs `akm migrate apply` over a "ready" plan. By that point the only
+  convertible files left are operator-authored (`retirePreV4SeededTasks`
+  already rewrote the shipped set during the upgrade), and the docs promise
+  those files are never rewritten behind the operator's back — converting them
+  stays an explicit operator action (`akm migrate apply`, or editing the file
+  to `version: 4`).
+
 ## [0.13.0] - 2026-08-31
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,24 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **The host akm import now rewrites loopback endpoints for the container.**
+  `config/akm/config.json` is container-view by contract: the setup wizard
+  rewrites a loopback provider URL to `host.docker.internal` at the moment it
+  persists one (W10), and the host-side akm runner translates that hostname
+  back to loopback when it reads the same file. The manual host-config import
+  (`importHostAkmConfig`, the providers "use my local configuration" flow) was
+  the one writer that skipped the rewrite: a host LM Studio/Ollama engine or
+  embedding endpoint spelled `http://localhost:1234/...` was persisted
+  verbatim, loaded fine — so the import's load-validation kept it — and then
+  every LLM call dialed the assistant container's own loopback instead of the
+  host, failing with a connection error nothing attributed to the import. The
+  import now applies the same loopback → `host.docker.internal` rewrite to the
+  host's values before the merge (host values only — an endpoint the operator
+  set in the assistant's own config is never touched), which is
+  container-reachable on Linux, macOS, and Windows alike because
+  core.compose.yml ships `host.docker.internal:host-gateway` on the assistant
+  unconditionally.
+
 - **Boot no longer misreports a pending task-file migration as "current".**
   `akm migrate status` (akm-cli 0.9.6/0.9.7) exits 0 for both of its clean plan
   states — "current" and "ready", where ready means operator task files that

--- a/containers/assistant/Dockerfile
+++ b/containers/assistant/Dockerfile
@@ -289,6 +289,13 @@ RUN mkdir -p /opt/openpalm/local-artifacts \
 COPY containers/assistant/entrypoint.sh /usr/local/bin/opencode-entrypoint.sh
 RUN chmod +x /usr/local/bin/opencode-entrypoint.sh
 
+# Operator remedy for akm's deliberate state.db schema cutover (`akm health`
+# exit 78 / boot marker `health 78 state-upgrade-pending`). Baked beside the
+# exact akm-cli it drives so the two can never drift; boot only points here,
+# it never runs this (see run_akm_migration_check).
+COPY containers/assistant/akm-state-upgrade.sh /usr/local/bin/openpalm-akm-state-upgrade
+RUN chmod +x /usr/local/bin/openpalm-akm-state-upgrade
+
 WORKDIR /work
 
 # Point Bun's user-writable paths at the opencode user's home, under

--- a/containers/assistant/akm-state-upgrade.sh
+++ b/containers/assistant/akm-state-upgrade.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# openpalm-akm-state-upgrade — run akm's deliberate, safety-copied state.db
+# schema cutover inside the assistant container.
+#
+# WHY THIS EXISTS: akm refuses to apply a `historical-destructive` state.db
+# migration (0.9.6/0.9.7 ship exactly one: 018-drop-dead-lane-schema) during an
+# ordinary managed open. Until the cutover runs, `akm health` exits 78 and
+# every state.db surface — events, proposals, task history, improve ledgers,
+# workflow runs — fails to open. The remedy akm's own error names,
+# `akm upgrade --force`, is the package SELF-UPDATER: it needs GitHub egress,
+# runs `npm install -g akm-cli@latest` (off-limits in this image-baked
+# install, and EACCES for the container user anyway), and only reaches the
+# state.db step after that install succeeds — so it can never work here.
+# akm-cli 0.9.6/0.9.7 expose the state step to the self-updater alone
+# (dist/commands/sources/self-update.js -> core/state-db.js
+# upgradeHistoricalStateDatabase), so this helper calls it directly against
+# the image-pinned install. Version drift is impossible by construction: this
+# file and that akm-cli tree ship in the same image.
+#
+# WHAT IT DOES (all akm's own machinery, verified against the 0.9.6 sources —
+# byte-identical in 0.9.7 — and rehearsed on the built image):
+#   - no-op when state.db is missing or already current ({"upgraded":false});
+#   - otherwise creates a VERIFIED sibling safety copy first (VACUUM INTO,
+#     PRAGMA quick_check, ledger check, fsync):
+#       state.db.pre-<migration>.<timestamp>.<uuid>.bak
+#     then applies every pending migration. Idempotent, and fully offline.
+#
+# Boot deliberately does NOT run this (see run_akm_migration_check in
+# opencode-entrypoint.sh): akm reserves this migration class for explicit
+# intent, and OpenPalm keeps that intent operator-shaped — the boot marker
+# records `health 78 state-upgrade-pending` to point here instead.
+set -euo pipefail
+
+AKM_CLI_DIST="/opt/openpalm/tools/node_modules/akm-cli/dist"
+if [ ! -f "$AKM_CLI_DIST/core/state-db.js" ]; then
+  echo "openpalm-akm-state-upgrade: $AKM_CLI_DIST/core/state-db.js not found — this image's akm-cli layout changed; refusing to guess." >&2
+  exit 70
+fi
+
+exec env AKM_CLI_DIST="$AKM_CLI_DIST" node --input-type=module -e '
+const { upgradeHistoricalStateDatabase } = await import(`${process.env.AKM_CLI_DIST}/core/state-db.js`);
+console.log(JSON.stringify(upgradeHistoricalStateDatabase()));
+'

--- a/containers/assistant/entrypoint.sh
+++ b/containers/assistant/entrypoint.sh
@@ -429,29 +429,93 @@ record_akm_boot_status() {
 }
 
 run_akm_migration_check() {
-  # akm >= 0.9.0 no longer auto-migrates on open: ordinary commands fail
-  # closed against an un-migrated durable schema and the explicit,
-  # crash-resumable `akm migrate apply` is the only cutover path. Run the
-  # check HERE — as the opencode user, with output surfaced to docker logs —
-  # so any migration happens under the correct uid (root-owned db files in
-  # the bind-mounted data dir are the chown-clobber class of bug) and a
-  # failed migration is visible instead of being swallowed by the silenced
-  # `akm task sync` call below.
+  # `akm migrate` (0.9.6/0.9.7) is the task-file converter: it inspects/rewrites
+  # task-v2 and task-v3 YAML under the stash to task source v4. Run the check
+  # HERE — as the opencode user, with output surfaced to docker logs — so any
+  # rewrite that does happen runs under the correct uid (root-owned files in
+  # the bind-mounted stash are the chown-clobber class of bug) and its outcome
+  # is visible instead of being swallowed by the silenced `akm task sync`
+  # call below.
   # Idempotent (`migrate status` is read-only; `migrate apply` no-ops /
   # resumes to convergence) and non-fatal: a migration hiccup must never
   # block the assistant from starting. (#474)
+  #
+  # Exit-code contract, verified against akm-cli 0.9.6 and byte-identical in
+  # 0.9.7, the 0.13.1 pin (dist/commands/
+  # migrate-cli.js sets a non-zero exit code iff the combined plan status is
+  # "blocked"): exit 0 covers BOTH clean plan states — "current" (nothing to
+  # convert) and "ready" (files pending that `akm migrate apply` would
+  # rewrite) — exit 1 is "blocked", and anything else is a crash or config
+  # error. The exit code alone cannot distinguish "done" from "apply would
+  # change files", so on success parse the plan's `status` field instead of
+  # trusting 0. (Output defaults to JSON; no --format flag, so a flag-parsing
+  # regression can never shunt a healthy status call onto the apply path.)
   if ! command -v akm >/dev/null 2>&1; then return 0; fi
 
-  echo "entrypoint: checking akm durable-state migration (akm migrate status)..." >&2
-  if run_akm_command akm migrate status >&2; then
-    echo "entrypoint: akm migration state is current" >&2
-    record_akm_boot_status migrate 0 current
+  echo "entrypoint: checking akm task-file migration state (akm migrate status)..." >&2
+  local status_json="" status_rc=0 plan_status=""
+  status_json="$(run_akm_command akm migrate status)" || status_rc=$?
+  # The plan used to stream straight to stderr; keep it in docker logs so the
+  # marker line recorded below always has its evidence next to it.
+  [ -z "$status_json" ] || printf '%s\n' "$status_json" >&2
+
+  if [ "$status_rc" = "0" ]; then
+    if [ -z "$status_json" ]; then
+      # Exit 0 with no plan printed is the CLI's "nothing to report" shape.
+      plan_status="current"
+    elif command -v jq >/dev/null 2>&1; then
+      # `tostring` keeps a malformed (non-string) status value on one line so
+      # it cannot smuggle extra lines into the one-line-per-step marker.
+      plan_status="$(printf '%s\n' "$status_json" | jq -r '(.status // "missing-status-key") | tostring' 2>/dev/null)" || plan_status="unparseable"
+      [ -n "$plan_status" ] || plan_status="unparseable"
+      plan_status=${plan_status//$'\n'/ }
+    else
+      # jq is baked into the image (Dockerfile); only reachable off-image.
+      plan_status="unparseable"
+    fi
+    case "$plan_status" in
+      current)
+        echo "entrypoint: akm migration state is current" >&2
+        record_akm_boot_status migrate 0 current
+        ;;
+      ready)
+        # DESIGN DECISION: boot never runs `akm migrate apply` on a "ready"
+        # plan. By boot time the only convertible files left are
+        # operator-authored tasks (`retirePreV4SeededTasks` already rewrote
+        # the shipped set during the upgrade, keeping `.pre-v4` copies), and
+        # the 0.13.0 docs promise those files stay exactly as written until
+        # the OPERATOR converts them — docs/managing-openpalm.md ("Tasks you
+        # wrote yourself are left exactly as they are") and
+        # docs/operations/upgrade-0.12-to-0.13.md ("Your own tasks are not
+        # rewritten", which calls a `ready` status the clean post-upgrade
+        # result). akm reads v2/v3 files by converting them in memory, so the
+        # tasks still run; its per-read stderr warning is the deliberate
+        # nudge toward an operator-initiated `akm migrate apply`. This state
+        # used to be misrecorded as `migrate 0 current`, which hid why that
+        # warning repeated every boot; record the real state instead.
+        echo "entrypoint: akm migrate status is 'ready' — operator task files are pending conversion to task source v4. Boot leaves your files as written (by design); run 'akm migrate apply' in this container to rewrite them permanently, or convert them to version: 4 by hand (docs/managing-openpalm.md, Automations)." >&2
+        record_akm_boot_status migrate 0 "ready operator-apply-pending"
+        ;;
+      *)
+        # Exit 0 promises current-or-ready; anything else here is a violated
+        # contract ("blocked" with exit 0, garbage output, a missing key).
+        # Record it verbatim rather than laundering it into "current", and
+        # touch nothing.
+        echo "entrypoint: akm migrate status exited 0 with unexpected plan status '$plan_status'; leaving task files untouched" >&2
+        record_akm_boot_status migrate 0 "$plan_status"
+        ;;
+    esac
   else
-    # A pending 0.8 → 0.9 cutover (or an interrupted apply) — run the
-    # crash-resumable apply. OpenPalm writes the 0.9-shape config itself, so
-    # no --config is needed; a second apply is harmless when the first one
-    # only staged a generated config. Rebind the scheduler entries afterwards
-    # so installed cron rows re-capture the current binary/spelling.
+    # Non-zero: exit 1 is a "blocked" plan — some file akm refuses to convert
+    # deterministically. Apply is all-or-nothing (akm 0.9.x) and will fail
+    # loudly here, which is correct: a blocked file means one operator task is
+    # silently unscheduled, and `migrate 1 apply-failed` is what surfaces that
+    # as a degraded boot. Any other code is a crash or an interrupted prior
+    # apply, for which the crash-resumable apply is the recovery path.
+    # OpenPalm writes the 0.9-shape config itself, so no --config is needed; a
+    # second apply is harmless when the first one only staged a generated
+    # config. Rebind the scheduler entries afterwards so installed cron rows
+    # re-capture the current binary/spelling.
     echo "entrypoint: akm migration pending — running akm migrate apply..." >&2
     local rc=0
     run_akm_command akm migrate apply >&2 || rc=$?
@@ -479,14 +543,38 @@ run_akm_migration_check() {
   fi
 
   # Health probe (0 = ok, 4 = health warn) — surfaces db problems loudly at
-  # boot without blocking startup.
-  local hrc=0
-  run_akm_command akm health >&2 || hrc=$?
-  record_akm_boot_status health "$hrc"
+  # boot without blocking startup. Both streams are captured and re-printed
+  # (akm's ok:false envelope goes to stderr), so the one failure with a canned
+  # in-image remedy can be recognized below instead of scrolling by unnamed.
+  local health_out="" hrc=0
+  health_out="$(run_akm_command akm health 2>&1)" || hrc=$?
+  [ -z "$health_out" ] || printf '%s\n' "$health_out" >&2
   if [ "$hrc" = "0" ] || [ "$hrc" = "4" ]; then
     echo "entrypoint: akm health check complete (exit $hrc)" >&2
+    record_akm_boot_status health "$hrc"
   else
     echo "warning: akm health check failed (exit $hrc); continuing startup" >&2
+    if printf '%s\n' "$health_out" | grep -qF 'Run `akm upgrade --force`'; then
+      # akm is refusing to open state.db until its historical-destructive
+      # schema cutover is applied deliberately (exit 78; every state.db
+      # surface — events, proposals, task history, improve ledgers, workflow
+      # runs — is down until then). The advice inside akm's message does NOT
+      # work in this container: `akm upgrade` is the package self-updater
+      # (GitHub egress + `npm install -g`, both off-limits in an image-baked
+      # install), and it only reaches the state step after a successful
+      # package install. The working remedy is the image-pinned helper, which
+      # drives akm's own safety-copied cutover directly.
+      # DESIGN DECISION: boot only reports this state, it never applies it.
+      # akm reserves this migration class for explicit intent — a boot that
+      # granted that intent automatically would extend it to every FUTURE
+      # destructive migration an image bump ships, sight unseen. OpenPalm
+      # keeps the intent operator-shaped, exactly like the operator task-file
+      # rule in the `ready` branch above.
+      echo "entrypoint: akm's state.db is waiting for its one-time deliberate schema cutover — run 'openpalm-akm-state-upgrade' in this container to apply it (a verified sibling safety copy is created first; see docs/operations/upgrade-0.12-to-0.13.md)" >&2
+      record_akm_boot_status health "$hrc" state-upgrade-pending
+    else
+      record_akm_boot_status health "$hrc"
+    fi
   fi
 }
 

--- a/docs/managing-openpalm.md
+++ b/docs/managing-openpalm.md
@@ -208,7 +208,10 @@ of the four on a home upgraded from a released 0.12.x, since
 you wrote yourself are left exactly as they are: akm reads a declared
 `version: 2` or `version: 3` file by converting it in memory and warning, and
 `akm migrate apply` rewrites it permanently when the conversion is
-deterministic. Two cases are not converted — a file with no `version:` key at
+deterministic. The assistant's boot check records this pending state honestly
+— `migrate 0 ready operator-apply-pending` in its boot marker, with a log line
+pointing here — but by design never runs the apply for you: your files stay as
+written until you convert them. Two cases are not converted — a file with no `version:` key at
 all (read as a malformed v4 document) and a v2 shape whose meaning would change
 under v4, such as a `command:` argv array. Either way only that file is
 affected: `akm task sync` excludes it, names it in the run's failures, and
@@ -284,6 +287,30 @@ configuration rather than falling back to the cached images, so a partial or
 mixed-version stack is never left behind. An installed stack continues running
 offline; only the update itself needs the network. See
 [System Requirements → Network requirements](system-requirements.md#network-requirements).
+
+### akm's state database cutover after an update
+
+An update that bumps the bundled akm can leave akm's state database
+(`data/akm/data/state.db` — events, proposals, task history, improve ledgers,
+workflow runs) one deliberate step behind: akm never applies a migration it
+classifies as destructive during an ordinary open. When that happens the
+assistant boots degraded — `akm health` exits 78, the boot marker
+(`/tmp/openpalm-akm-boot.status` inside the assistant) records
+`health 78 state-upgrade-pending`, and the boot log names the fix. Tasks,
+search, and chat keep working; the state.db surfaces above are down until you
+run the cutover:
+
+```bash
+docker compose -p <project> exec assistant openpalm-akm-state-upgrade
+```
+
+This drives akm's own machinery directly (never `akm upgrade`, which is the
+package self-updater and cannot run in the image-baked container): a verified
+sibling safety copy — `state.db.pre-<migration>.<timestamp>.<uuid>.bak` — is
+written first, then the pending migrations apply. It is idempotent and fully
+offline; `{"upgraded":false}` means there was nothing to do. Boot never runs
+this for you: applying a destructive migration stays an explicit operator
+action, the same rule that keeps your task files unrewritten at boot.
 
 ### Desktop app updates
 

--- a/docs/operations/upgrade-0.12-to-0.13.md
+++ b/docs/operations/upgrade-0.12-to-0.13.md
@@ -638,6 +638,49 @@ to `version: 4` — the grammar is under *Automations* in
 `docs/managing-openpalm.md` — or let
 `akm migrate apply` rewrite it where it can.
 
+### akm's state database waits for a deliberate cutover
+
+akm 0.9.7 ships one state.db migration it classifies `historical-destructive`
+(`018-drop-dead-lane-schema`: it drops two dead-lane cache tables and one
+retired column left behind by lanes the 0.9.0 refactor deleted), and it never
+applies that class during an ordinary managed open. On a home whose state.db
+predates it — any 0.12.x home with a used improve pipeline — every boot after
+this upgrade has `akm health` exit 78 with "Unable to open state.db: Refusing
+to apply historical destructive state migration…", and every state.db surface
+(events, proposals, task history, improve ledgers, workflow runs) fails to
+open until the cutover runs. Task files, search, and chat are unaffected. The
+boot marker records it as `health 78` on a 0.13.0 image, and as
+`health 78 state-upgrade-pending` from 0.13.1.
+
+Do not follow the advice inside akm's message. `akm upgrade` is the package
+self-updater: inside the container it needs GitHub egress, runs
+`npm install -g akm-cli@latest` — which the image-baked install forbids and
+the container user cannot write anyway — and only reaches the state.db step
+after that install succeeds. It cannot work here.
+
+Run the cutover deliberately instead, with the project name from section 1:
+
+```bash
+docker compose -p <project> exec assistant openpalm-akm-state-upgrade
+```
+
+That helper ships in images from 0.13.1. On a 0.13.0 image run the same step
+directly against the image's pinned akm:
+
+```bash
+docker compose -p <project> exec assistant node --input-type=module -e 'const m = await import("/opt/openpalm/tools/node_modules/akm-cli/dist/core/state-db.js"); console.log(JSON.stringify(m.upgradeHistoricalStateDatabase()))'
+```
+
+Either way it is akm's own machinery: a verified sibling safety copy is
+written first (`state.db.pre-018-drop-dead-lane-schema.<timestamp>.<uuid>.bak`
+— `VACUUM INTO`, then
+`PRAGMA quick_check` and a ledger check before anything mutates), then the
+pending migrations apply, 018 through the current end of the ledger. The
+command is idempotent — `{"upgraded":false}` means there was nothing to do —
+and fully offline. Verify afterwards:
+`docker compose -p <project> exec assistant akm health` exits 0 (or 4, a
+warning) and its first hard check reports `state-db-schema: pass`.
+
 ### Published host ports move, and it is not opt-out
 
 Nothing about this is opt-in and nothing warns you. `migrateLegacyDefaultPorts`

--- a/packages/lib/src/control-plane/akm-migrate-boot.test.ts
+++ b/packages/lib/src/control-plane/akm-migrate-boot.test.ts
@@ -1,0 +1,255 @@
+/**
+ * The assistant boot must report akm's task-file migration state truthfully —
+ * and must never rewrite operator task files while doing it.
+ *
+ * `akm migrate status` (akm-cli 0.9.6; byte-identical in 0.9.7) exits 0 for BOTH of its clean plan
+ * states: "current" (nothing to convert) and "ready" (task files pending that
+ * `akm migrate apply` would rewrite). Only a "blocked" plan earns exit 1
+ * (dist/commands/migrate-cli.js sets the exit code iff the combined status is
+ * "blocked"). The entrypoint used to read exit 0 as "current" unconditionally,
+ * so a home with an operator-authored `version: 2` task recorded
+ * `migrate 0 current` every boot while akm itself warned "run `akm migrate
+ * apply`" every time it read the file — the marker contradicted the logs
+ * forever.
+ *
+ * The fix parses the plan's `status` field. The one thing it must NOT do is
+ * auto-apply: by boot time the only convertible files left are
+ * operator-authored (`retirePreV4SeededTasks` already rewrote the shipped set
+ * during the upgrade), and docs/managing-openpalm.md plus
+ * docs/operations/upgrade-0.12-to-0.13.md ("Your own tasks are not rewritten")
+ * promise those files stay as written until the operator converts them. These
+ * tests execute the real entrypoint functions against a fake `akm`, so the
+ * promise is pinned by behavior, not by prose.
+ *
+ * The second describe covers the health step's sibling contract: recognizing
+ * akm's deliberate state.db cutover refusal (exit 78) and pointing at the
+ * image-pinned `openpalm-akm-state-upgrade` helper — again reporting only,
+ * never remediating at boot.
+ */
+import { describe, expect, it } from 'bun:test';
+import { spawnSync } from 'node:child_process';
+import { chmodSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const repoRoot = join(import.meta.dir, '..', '..', '..', '..');
+const entrypoint = readFileSync(join(repoRoot, 'containers/assistant/entrypoint.sh'), 'utf8');
+
+/** Pull one `name() { … }` definition out of the entrypoint, verbatim. */
+function extractShellFunction(name: string): string {
+  const match = entrypoint.match(new RegExp(`^${name}\\(\\) \\{[\\s\\S]*?^\\}`, 'm'));
+  if (!match) throw new Error(`entrypoint.sh no longer defines ${name}()`);
+  return match[0];
+}
+
+const FAKE_AKM = `#!/usr/bin/env bash
+printf 'akm %s\\n' "$*" >> "$AKM_CALL_LOG"
+case "$1 \${2:-}" in
+  "migrate status")
+    [ -n "\${FAKE_STATUS_JSON:-}" ] && printf '%s\\n' "$FAKE_STATUS_JSON"
+    exit "\${FAKE_STATUS_RC:-0}"
+    ;;
+  "migrate apply") exit "\${FAKE_APPLY_RC:-0}" ;;
+  "task sync") exit 0 ;;
+  "health ")
+    [ -n "\${FAKE_HEALTH_ERR:-}" ] && printf '%s\\n' "$FAKE_HEALTH_ERR" >&2
+    exit "\${FAKE_HEALTH_RC:-0}"
+    ;;
+  *) echo "fake akm: unexpected argv: $*" >&2; exit 99 ;;
+esac
+`;
+
+type BootRun = { marker: string; calls: string[]; stderr: string };
+
+/**
+ * Run the REAL run_akm_migration_check (plus the helpers it calls) under the
+ * entrypoint's own shell options, against a fake `akm` whose status plan and
+ * exit codes the caller controls.
+ */
+function runMigrationCheck(env: {
+  statusJson?: string;
+  statusRc?: number;
+  applyRc?: number;
+  healthRc?: number;
+  healthErr?: string;
+}): BootRun {
+  const dir = mkdtempSync(join(tmpdir(), 'akm-migrate-boot-'));
+  const akmPath = join(dir, 'akm');
+  const marker = join(dir, 'boot.status');
+  const callLog = join(dir, 'calls.log');
+  writeFileSync(akmPath, FAKE_AKM);
+  chmodSync(akmPath, 0o755);
+  writeFileSync(marker, '');
+  writeFileSync(callLog, '');
+
+  const script = [
+    'set -euo pipefail',
+    extractShellFunction('run_akm_command'),
+    extractShellFunction('record_akm_boot_status'),
+    extractShellFunction('run_akm_migration_check'),
+    'run_akm_migration_check',
+  ].join('\n');
+
+  const result = spawnSync('bash', ['-c', script], {
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      PATH: `${dir}:${process.env.PATH ?? ''}`,
+      AKM_BOOT_STATUS_FILE: marker,
+      AKM_CALL_LOG: callLog,
+      FAKE_STATUS_JSON: env.statusJson ?? '',
+      FAKE_STATUS_RC: String(env.statusRc ?? 0),
+      FAKE_APPLY_RC: String(env.applyRc ?? 0),
+      FAKE_HEALTH_RC: String(env.healthRc ?? 0),
+      FAKE_HEALTH_ERR: env.healthErr ?? '',
+    },
+  });
+  // The check is deliberately non-fatal (#474): whatever akm reports, the
+  // function must return 0 so the assistant keeps booting.
+  expect(result.status, result.stderr).toBe(0);
+  const calls = readFileSync(callLog, 'utf8').split('\n').filter(Boolean);
+  return { marker: readFileSync(marker, 'utf8'), calls, stderr: result.stderr };
+}
+
+const READY_PLAN = JSON.stringify({
+  schemaVersion: 1,
+  status: 'ready',
+  blockers: [],
+  taskV3Migration: { changed: 1, skipped: 4, blocked: 0 },
+  taskV4Migration: { changed: 0, skipped: 5, blocked: 0 },
+});
+
+describe('assistant entrypoint — akm migrate boot check', () => {
+  it('records `ready` truthfully and NEVER auto-applies over operator task files', () => {
+    const run = runMigrationCheck({ statusJson: READY_PLAN, statusRc: 0 });
+    expect(run.marker).toBe('migrate 0 ready operator-apply-pending\nhealth 0\n');
+    expect(run.calls).toEqual(['akm migrate status', 'akm health']);
+    // The log line must hand the operator the remedy the marker points at.
+    expect(run.stderr).toContain("run 'akm migrate apply'");
+  });
+
+  it('records `current` when the plan says current', () => {
+    const run = runMigrationCheck({
+      statusJson: JSON.stringify({ schemaVersion: 1, status: 'current', blockers: [] }),
+      statusRc: 0,
+    });
+    expect(run.marker).toBe('migrate 0 current\nhealth 0\n');
+    expect(run.calls).toEqual(['akm migrate status', 'akm health']);
+  });
+
+  it('treats exit 0 with no plan as current (the CLI prints nothing when both generations have nothing to report)', () => {
+    const run = runMigrationCheck({ statusJson: '', statusRc: 0 });
+    expect(run.marker).toBe('migrate 0 current\nhealth 0\n');
+  });
+
+  it('records an unexpected exit-0 status verbatim instead of laundering it into current', () => {
+    const run = runMigrationCheck({
+      statusJson: JSON.stringify({ schemaVersion: 1, status: 'blocked' }),
+      statusRc: 0,
+    });
+    expect(run.marker).toBe('migrate 0 blocked\nhealth 0\n');
+    expect(run.calls).toEqual(['akm migrate status', 'akm health']);
+  });
+
+  it('records unparseable exit-0 output without touching anything', () => {
+    const run = runMigrationCheck({ statusJson: 'not json at all', statusRc: 0 });
+    expect(run.marker).toBe('migrate 0 unparseable\nhealth 0\n');
+    expect(run.calls).toEqual(['akm migrate status', 'akm health']);
+  });
+
+  it('still runs the crash-resumable apply on a non-zero status exit', () => {
+    const run = runMigrationCheck({ statusJson: '', statusRc: 1, applyRc: 0 });
+    expect(run.marker).toBe('migrate 0 applied\ntask-sync 0\nhealth 0\n');
+    expect(run.calls).toEqual([
+      'akm migrate status',
+      'akm migrate apply',
+      'akm task sync --rebind',
+      'akm health',
+    ]);
+  });
+
+  it('records a failed apply as degraded (exit code preserved) and keeps booting', () => {
+    const run = runMigrationCheck({ statusJson: '', statusRc: 1, applyRc: 7 });
+    expect(run.marker).toBe('migrate 7 apply-failed\nhealth 0\n');
+    // Retried once, never synced tasks, still probed health: boot went on.
+    expect(run.calls).toEqual([
+      'akm migrate status',
+      'akm migrate apply',
+      'akm migrate apply',
+      'akm health',
+    ]);
+  });
+
+  it('the boot flow actually invokes the function these cases model', () => {
+    expect(entrypoint).toMatch(/^run_akm_migration_check$/m);
+  });
+});
+
+/**
+ * The health step's one canned remedy: akm refusing to open state.db until its
+ * historical-destructive schema cutover is applied deliberately (`akm health`
+ * exit 78). The advice inside akm's own message — `akm upgrade --force` — is
+ * the package SELF-UPDATER and cannot work in the image-baked container
+ * (GitHub egress + `npm install -g`), so boot must (a) recognize the refusal,
+ * (b) point at the image-pinned helper that drives akm's cutover directly, and
+ * (c) NEVER run the cutover itself: akm reserves this migration class for
+ * explicit intent, and boot granting it automatically would extend that grant
+ * to every future destructive migration an image bump ships.
+ */
+const STATE_UPGRADE_REFUSAL = JSON.stringify({
+  ok: false,
+  error:
+    'Unable to open state.db: Refusing to apply historical destructive state migration ' +
+    '018-drop-dead-lane-schema during an ordinary managed open. Run `akm upgrade --force` ' +
+    'to create a sibling state.db safety copy and apply it deliberately.',
+  code: 'INVALID_CONFIG_FILE',
+});
+
+describe('assistant entrypoint — akm health state-upgrade detection', () => {
+  const CURRENT_PLAN = JSON.stringify({ schemaVersion: 1, status: 'current', blockers: [] });
+
+  it('marks the pending deliberate cutover and points at the helper — without running it', () => {
+    const run = runMigrationCheck({
+      statusJson: CURRENT_PLAN,
+      statusRc: 0,
+      healthRc: 78,
+      healthErr: STATE_UPGRADE_REFUSAL,
+    });
+    expect(run.marker).toBe('migrate 0 current\nhealth 78 state-upgrade-pending\n');
+    // No remediation call of any kind — reporting only.
+    expect(run.calls).toEqual(['akm migrate status', 'akm health']);
+    expect(run.stderr).toContain('openpalm-akm-state-upgrade');
+  });
+
+  it('leaves other health failures undecorated', () => {
+    const run = runMigrationCheck({
+      statusJson: CURRENT_PLAN,
+      statusRc: 0,
+      healthRc: 70,
+      healthErr: '{"ok": false, "error": "something else entirely"}',
+    });
+    expect(run.marker).toBe('migrate 0 current\nhealth 70\n');
+    expect(run.stderr).not.toContain('openpalm-akm-state-upgrade');
+  });
+
+  it('the image bakes the helper the boot log names', () => {
+    const dockerfile = readFileSync(join(repoRoot, 'containers/assistant/Dockerfile'), 'utf8');
+    expect(dockerfile).toContain(
+      'COPY containers/assistant/akm-state-upgrade.sh /usr/local/bin/openpalm-akm-state-upgrade',
+    );
+    expect(dockerfile).toContain('chmod +x /usr/local/bin/openpalm-akm-state-upgrade');
+  });
+
+  it('the helper drives akm state machinery directly and never the self-updater', () => {
+    const helper = readFileSync(
+      join(repoRoot, 'containers/assistant/akm-state-upgrade.sh'),
+      'utf8',
+    );
+    expect(helper).toContain('upgradeHistoricalStateDatabase');
+    // Comments may (and do) explain why `akm upgrade` is wrong; code must
+    // never invoke it. Whole-line comment stripping mirrors the ratchet style
+    // in image-baked-contract.test.ts.
+    const codeLines = helper.split('\n').filter((l) => !/^\s*#/.test(l));
+    expect(codeLines.filter((l) => /\bakm upgrade\b/.test(l))).toEqual([]);
+  });
+});

--- a/packages/lib/src/control-plane/akm-sources.test.ts
+++ b/packages/lib/src/control-plane/akm-sources.test.ts
@@ -537,6 +537,58 @@ describe("importHostAkmConfig (manual host akm import)", () => {
     expect(readFileSync(hostCfg(), "utf-8")).toBe(original);
   });
 
+  it("rewrites loopback endpoints to host.docker.internal — the persisted file is container-view (W10)", () => {
+    // The real report: a host LM Studio config imported verbatim. It loaded
+    // fine, so validation kept it — and every LLM call then dialed the
+    // assistant container's OWN loopback instead of the host.
+    seedHost({
+      engines: {
+        lmstudio: { kind: "llm", endpoint: "http://localhost:1234/v1/chat/completions", model: "qwen" },
+        dotted: { kind: "llm", endpoint: "https://127.0.0.1:8443/v1", model: "m" },
+        v6: { kind: "llm", endpoint: "http://[::1]:11434/api", model: "m" },
+      },
+      embedding: { endpoint: "http://localhost:1234/v1/embeddings", model: "nomic", dimension: 768 },
+    });
+    writeFileSync(opConfigPath, "{}");
+
+    const { imported } = importHostAkmConfig(state, hostCfg());
+
+    expect(imported).toEqual(expect.arrayContaining(["engines", "embedding"]));
+    const cfg = readJson(opConfigPath);
+    const engines = cfg.engines as Record<string, Record<string, unknown>>;
+    expect(engines.lmstudio.endpoint).toBe("http://host.docker.internal:1234/v1/chat/completions");
+    expect(engines.dotted.endpoint).toBe("https://host.docker.internal:8443/v1");
+    expect(engines.v6.endpoint).toBe("http://host.docker.internal:11434/api");
+    // Non-URL strings are never touched.
+    expect(engines.lmstudio.model).toBe("qwen");
+    expect((cfg.embedding as Record<string, unknown>).endpoint).toBe(
+      "http://host.docker.internal:1234/v1/embeddings",
+    );
+  });
+
+  it("leaves non-loopback endpoints and the operator's own values alone", () => {
+    seedHost({
+      engines: {
+        lan: { kind: "llm", endpoint: "http://192.168.1.50:1234/v1", model: "m" },
+        remote: { kind: "llm", endpoint: "https://api.openai.com/v1", model: "m" },
+      },
+    });
+    // A loopback endpoint the operator set in the ASSISTANT's own config
+    // (e.g. an in-container sidecar) is theirs: the import must not rewrite
+    // anything it was not asked to add.
+    writeFileSync(opConfigPath, JSON.stringify({
+      configVersion: "0.9.0",
+      engines: { sidecar: { kind: "llm", endpoint: "http://localhost:8080/v1", model: "m" } },
+    }, null, 2));
+
+    importHostAkmConfig(state, hostCfg());
+
+    const engines = readJson(opConfigPath).engines as Record<string, Record<string, unknown>>;
+    expect(engines.lan.endpoint).toBe("http://192.168.1.50:1234/v1");
+    expect(engines.remote.endpoint).toBe("https://api.openai.com/v1");
+    expect(engines.sidecar.endpoint).toBe("http://localhost:8080/v1");
+  });
+
   it("imports nothing when the host config is absent", () => {
     writeFileSync(opConfigPath, "{}");
     expect(importHostAkmConfig(state, hostCfg()).imported).toEqual([]);

--- a/packages/lib/src/control-plane/akm-sources.ts
+++ b/packages/lib/src/control-plane/akm-sources.ts
@@ -521,7 +521,51 @@ function stripRetiredKeysAt(configPath: string): boolean {
 }
 
 /**
+ * W10, applied to the host-config import: `config/akm/config.json` is
+ * CONTAINER-VIEW by contract. The setup wizard already rewrites loopback
+ * provider URLs to `host.docker.internal` at the exact point they are
+ * persisted for container consumption (ui setup/payload.ts,
+ * toContainerReachableUrl — same regex), and akm-user-env.ts translates that
+ * hostname BACK to loopback whenever a HOST-side akm process reads this same
+ * file. The host's own ~/.config/akm/config.json is host-view: a local
+ * LM Studio/Ollama engine or embedding endpoint is spelled
+ * `http://localhost:1234/...`, and inside the assistant container that
+ * loopback is the container itself. Importing it verbatim produced a config
+ * that LOADED fine — so the import route's load-validation kept it — and
+ * then failed every LLM call at use time with a connection error nothing
+ * attributed to the import. core.compose.yml ships
+ * `host.docker.internal:host-gateway` on the assistant unconditionally, so
+ * the rewrite is container-reachable on Linux, macOS, and Windows alike.
+ *
+ * Deep walk over every string leaf, mirroring akm-user-env.ts's
+ * rewriteHostDockerInternalDeep (the exact reverse direction) for the same
+ * reason it gives: any endpoint-shaped field — present or added later, in
+ * any engine — gets the fix without this code tracking akm's config schema.
+ * Safe because only strings that BEGIN with a loopback http(s) origin are
+ * touched; engine names, model ids, and genuinely remote URLs never match.
+ */
+const LOOPBACK_HOST_RE = /^(https?:\/\/)(localhost|127(?:\.\d{1,3}){3}|\[?::1\]?)(?=[:/]|$)/i;
+
+function toContainerReachableDeep<T>(value: T): T {
+  if (typeof value === "string")
+    return value.replace(LOOPBACK_HOST_RE, "$1host.docker.internal") as unknown as T;
+  if (Array.isArray(value)) return value.map((v) => toContainerReachableDeep(v)) as unknown as T;
+  if (value && typeof value === "object") {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+      out[k] = toContainerReachableDeep(v);
+    }
+    return out as T;
+  }
+  return value;
+}
+
+/**
  * Copy the host's akm engine/embedding configuration into the assistant's.
+ *
+ * Loopback endpoints are rewritten to `host.docker.internal` on the way in —
+ * host values only, never anything the operator already set here (see
+ * {@link toContainerReachableDeep}).
  *
  * MANUAL ONLY. Nothing calls this on install, on upgrade, or as a side effect
  * of any toggle — it runs when an operator explicitly asks for it, the same
@@ -554,6 +598,10 @@ export function importHostAkmConfig(
 ): { imported: string[] } {
   const host = readHostConfigBestEffort(hostConfigPath);
   if (!host) return { imported: [] };
+  // Container-view translation BEFORE the merge, host values only — see
+  // toContainerReachableDeep. The read stays strictly read-only: the walk
+  // builds a rewritten copy and never touches the host's file.
+  const hostView = toContainerReachableDeep(host);
 
   const opPath = openpalmConfigPath(state);
   const op = readConfigTolerant(opPath);
@@ -568,9 +616,9 @@ export function importHostAkmConfig(
   // engines (akm 0.9.0 config-schema EnginesSchema).
   const opEngines = isObj(op.engines) ? (op.engines as Record<string, unknown>) : {};
   let engines = opEngines;
-  if (isObj(host.engines)) {
+  if (isObj(hostView.engines)) {
     // host first, existing last → existing wins; only host-only engine names are added.
-    const merged: Record<string, unknown> = { ...(host.engines as Record<string, unknown>), ...opEngines };
+    const merged: Record<string, unknown> = { ...(hostView.engines as Record<string, unknown>), ...opEngines };
     if (Object.keys(merged).length > Object.keys(opEngines).length) {
       engines = merged;
       imported.push("engines");
@@ -579,7 +627,7 @@ export function importHostAkmConfig(
 
   // defaults.engine / defaults.llmEngine / defaults.improveStrategy — only
   // adopt a host selection when OpenPalm has none.
-  const hostDefaults = isObj(host.defaults) ? (host.defaults as Record<string, unknown>) : {};
+  const hostDefaults = isObj(hostView.defaults) ? (hostView.defaults as Record<string, unknown>) : {};
   const opDefaults = isObj(op.defaults) ? { ...(op.defaults as Record<string, unknown>) } : {};
   for (const key of ["engine", "llmEngine", "improveStrategy"] as const) {
     if (typeof hostDefaults[key] === "string" && typeof opDefaults[key] !== "string") {
@@ -589,7 +637,7 @@ export function importHostAkmConfig(
   }
 
   // improve.strategies — additive by strategy name.
-  const hostImprove = isObj(host.improve) ? (host.improve as Record<string, unknown>) : {};
+  const hostImprove = isObj(hostView.improve) ? (hostView.improve as Record<string, unknown>) : {};
   const opImprove = isObj(op.improve) ? { ...(op.improve as Record<string, unknown>) } : {};
   let improveChanged = false;
   if (isObj(hostImprove.strategies)) {
@@ -605,9 +653,9 @@ export function importHostAkmConfig(
   // Top-level embedding connection. Per-field additive: existing OpenPalm
   // fields win; host fills only missing fields.
   let embedding: Record<string, unknown> | undefined;
-  if (isObj(host.embedding)) {
+  if (isObj(hostView.embedding)) {
     const existing = isObj(op.embedding) ? (op.embedding as Record<string, unknown>) : {};
-    const merged: Record<string, unknown> = { ...(host.embedding as Record<string, unknown>), ...existing };
+    const merged: Record<string, unknown> = { ...(hostView.embedding as Record<string, unknown>), ...existing };
     if (Object.keys(merged).length > Object.keys(existing).length) {
       embedding = merged;
       imported.push("embedding");

--- a/packages/ui/src/lib/server/opencode/config.ts
+++ b/packages/ui/src/lib/server/opencode/config.ts
@@ -1,12 +1,13 @@
 /**
  * OpenCode config read/write + small mutation helpers.
  *
- * Reads/writes `OP_HOME/config/assistant/opencode.json` directly because the
- * container mount is read-only and OpenCode's PATCH /config does not persist
- * to disk. We still call PATCH afterwards (best-effort) so the live process
- * picks up the change without a restart.
+ * Writes the operator's `opencode.json` directly, because OpenCode's
+ * PATCH /config mutates only the live process and persists nothing. We still
+ * call PATCH afterwards (best-effort) so the running assistant picks up the
+ * change without a restart.
  */
 import { readFileSync, writeFileSync } from 'node:fs';
+import { homedir } from 'node:os';
 import { join } from 'node:path';
 import { asRecord } from '../coercion.js';
 import { opencodeFetch } from './http.js';
@@ -22,8 +23,23 @@ export type RawConfig = JsonRecord & {
 };
 
 function configPath(): string {
-	const opHome = process.env.OP_HOME ?? '';
-	return join(opHome, 'config', 'assistant', 'opencode.json');
+	// This module serves two deployments of the same routes:
+	//  - HOST-SERVED surfaces (setup wizard, desktop shell) run with OP_HOME
+	//    set and no container mounts: the file is
+	//    `$OP_HOME/config/assistant/opencode.json`.
+	//  - The ADMIN UI co-process runs INSIDE the assistant container, where
+	//    the entrypoint deliberately injects no OP_HOME (no host path may leak
+	//    into the container). There the SAME file is the read-write bind mount
+	//    at `~/.config/opencode/opencode.json` (core.compose.yml mounts
+	//    `config/assistant` on `/home/opencode/.config/opencode`).
+	// The old `OP_HOME ?? ''` resolved to a RELATIVE `config/assistant/…`
+	// against the UI server's cwd in the container, so every preferred-model
+	// save either errored (missing cwd subdirs) or landed in a phantom file
+	// the assistant never reads, while the best-effort live PATCH made it look
+	// saved — until the next restart dropped it.
+	const opHome = process.env.OP_HOME;
+	if (opHome) return join(opHome, 'config', 'assistant', 'opencode.json');
+	return join(homedir(), '.config', 'opencode', 'opencode.json');
 }
 
 export async function getCurrentConfig(): Promise<RawConfig> {
@@ -36,7 +52,7 @@ export async function getCurrentConfig(): Promise<RawConfig> {
 	}
 }
 
-export async function patchConfig(config: RawConfig): Promise<RawConfig> {
+export async function patchConfig(config: RawConfig, removeKeys: readonly string[] = []): Promise<RawConfig> {
 	let existing: Record<string, unknown> = {};
 	try {
 		existing = JSON.parse(readFileSync(configPath(), 'utf-8'));
@@ -52,10 +68,17 @@ export async function patchConfig(config: RawConfig): Promise<RawConfig> {
 			...(config.provider as Record<string, unknown>),
 		};
 	}
+	// Deletions must be explicit: `merged` starts from what is ON DISK, so a
+	// key a caller removed from its own in-memory copy silently resurrects in
+	// the spread above (that is how "clear model" never actually cleared).
+	for (const key of removeKeys) {
+		delete (merged as Record<string, unknown>)[key];
+	}
 
 	writeFileSync(configPath(), `${JSON.stringify(merged, null, 2)}\n`);
 
-	// Also notify OpenCode to reload (best-effort)
+	// Also notify OpenCode to reload (best-effort). PATCH cannot express a
+	// removal, so an unset key reaches the live process on its next restart.
 	await opencodeFetch<RawConfig>('/config', {
 		method: 'PATCH',
 		body: JSON.stringify(config),
@@ -163,20 +186,24 @@ export async function registerProvider(
 	return { alreadyExists: false };
 }
 
-/** Set the main model (or small model) in opencode.json. */
+/**
+ * Set the main model (or small model) in opencode.json.
+ *
+ * Deliberately a DELTA, not a read-modify-write of getCurrentConfig():
+ * getCurrentConfig falls back to OpenCode's live /config when the disk file
+ * is unreadable, and persisting that snapshot would bake every runtime-merged
+ * value into the operator's file. patchConfig merges the delta over what is
+ * actually on disk.
+ */
 export async function setMainModel(
 	providerId: string,
 	modelId: string,
 	target: 'model' | 'small_model',
 ): Promise<void> {
-	const config = await getCurrentConfig();
-	config[target] = `${providerId}/${modelId}`;
-	await patchConfig(config);
+	await patchConfig({ [target]: `${providerId}/${modelId}` });
 }
 
 /** Clear the main model (or small model) in opencode.json. */
 export async function unsetMainModel(target: 'model' | 'small_model'): Promise<void> {
-	const config = await getCurrentConfig();
-	delete (config as Record<string, unknown>)[target];
-	await patchConfig(config);
+	await patchConfig({}, [target]);
 }

--- a/packages/ui/src/lib/server/opencode/config.vitest.ts
+++ b/packages/ui/src/lib/server/opencode/config.vitest.ts
@@ -1,0 +1,124 @@
+/**
+ * Preferred-model persistence (`opencode.json`) — three ways it used to lie.
+ *
+ * 1. The admin UI co-process runs INSIDE the assistant container, where the
+ *    entrypoint deliberately injects no OP_HOME. `configPath()` resolved
+ *    `OP_HOME ?? ''` to a RELATIVE path against the server's cwd, so a
+ *    preferred-model save either threw (missing cwd subdirs) or wrote a
+ *    phantom file the assistant never reads — while the best-effort live
+ *    PATCH made the save look successful until the next restart dropped it.
+ *    The container-side file is the RW bind mount at
+ *    `~/.config/opencode/opencode.json`.
+ * 2. Clearing a model never persisted: patchConfig starts its merge from what
+ *    is ON DISK, so a key the caller deleted from its in-memory copy was
+ *    resurrected by the spread. Removals are now explicit (`removeKeys`).
+ * 3. setMainModel round-tripped the FULL getCurrentConfig() — which falls
+ *    back to OpenCode's live /config when the disk file is unreadable — so a
+ *    save could bake the whole runtime-merged config into the operator's
+ *    file. Saves are now deltas merged over the disk state.
+ */
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+vi.mock('./http.js', () => ({ opencodeFetch: vi.fn() }));
+
+import { opencodeFetch } from './http.js';
+import { setMainModel, unsetMainModel } from './config.js';
+
+const mockedFetch = vi.mocked(opencodeFetch);
+
+let root: string;
+let savedOpHome: string | undefined;
+let savedHome: string | undefined;
+
+function opConfigPath(): string {
+	return join(root, 'config', 'assistant', 'opencode.json');
+}
+
+function seed(config: Record<string, unknown>): void {
+	mkdirSync(join(root, 'config', 'assistant'), { recursive: true });
+	writeFileSync(opConfigPath(), `${JSON.stringify(config, null, 2)}\n`);
+}
+
+function readDisk(path: string): Record<string, unknown> {
+	return JSON.parse(readFileSync(path, 'utf-8')) as Record<string, unknown>;
+}
+
+beforeEach(() => {
+	root = mkdtempSync(join(tmpdir(), 'opencode-config-'));
+	savedOpHome = process.env.OP_HOME;
+	savedHome = process.env.HOME;
+	process.env.OP_HOME = root;
+	mockedFetch.mockResolvedValue({} as never);
+});
+
+afterEach(() => {
+	if (savedOpHome === undefined) delete process.env.OP_HOME;
+	else process.env.OP_HOME = savedOpHome;
+	if (savedHome === undefined) delete process.env.HOME;
+	else process.env.HOME = savedHome;
+	rmSync(root, { recursive: true, force: true });
+	vi.clearAllMocks();
+});
+
+describe('setMainModel', () => {
+	test('persists the preference without clobbering unrelated keys, and PATCHes the live process', async () => {
+		seed({
+			model: 'openai/old',
+			provider: { lmstudio: { options: { baseURL: 'http://192.168.1.175:1234' } } },
+			disabled_providers: [],
+		});
+
+		await setMainModel('openai', 'gpt-5.3-codex-spark', 'model');
+
+		const disk = readDisk(opConfigPath());
+		expect(disk.model).toBe('openai/gpt-5.3-codex-spark');
+		expect(disk.provider).toEqual({ lmstudio: { options: { baseURL: 'http://192.168.1.175:1234' } } });
+		expect(disk.disabled_providers).toEqual([]);
+		expect(mockedFetch).toHaveBeenCalledWith('/config', {
+			method: 'PATCH',
+			body: JSON.stringify({ model: 'openai/gpt-5.3-codex-spark' }),
+		});
+	});
+
+	test('writes only the delta when the disk file is missing — never the live-config fallback', async () => {
+		mkdirSync(join(root, 'config', 'assistant'), { recursive: true });
+		// If the save still round-tripped getCurrentConfig(), THIS runtime
+		// snapshot is what would land in the operator's file.
+		mockedFetch.mockResolvedValue({ model: 'live/runtime', agent: { build: {} } } as never);
+
+		await setMainModel('openai', 'gpt', 'small_model');
+
+		expect(readDisk(opConfigPath())).toEqual({ small_model: 'openai/gpt' });
+	});
+
+	test('resolves the container mount (~/.config/opencode) when OP_HOME is absent', async () => {
+		delete process.env.OP_HOME;
+		process.env.HOME = root; // the container's HOME=/home/opencode analogue
+		const mountPath = join(root, '.config', 'opencode', 'opencode.json');
+		mkdirSync(join(root, '.config', 'opencode'), { recursive: true });
+		writeFileSync(mountPath, `${JSON.stringify({ small_model: 'openai/tiny' }, null, 2)}\n`);
+
+		await setMainModel('openai', 'gpt-5.6-luna', 'model');
+
+		const disk = readDisk(mountPath);
+		expect(disk.model).toBe('openai/gpt-5.6-luna');
+		expect(disk.small_model).toBe('openai/tiny');
+		// And nothing appeared at the old relative phantom location.
+		expect(existsSync(join(process.cwd(), 'config', 'assistant', 'opencode.json'))).toBe(false);
+	});
+});
+
+describe('unsetMainModel', () => {
+	test('actually removes the key from disk (the merge used to resurrect it)', async () => {
+		seed({ model: 'openai/keep', small_model: 'openai/clear-me' });
+
+		await unsetMainModel('small_model');
+
+		const disk = readDisk(opConfigPath());
+		expect(disk.small_model).toBeUndefined();
+		expect(disk.model).toBe('openai/keep');
+	});
+});


### PR DESCRIPTION
Two boot-time truths the 0.13.0 assistant gets wrong, one cause: akm-cli 0.9.x's exit codes promise less than the entrypoint assumed. Both were found live on a 0.12.x → 0.13.0 upgraded home and verified against the 0.9.6 dist sources.

## 1. `akm migrate status` exit 0 ≠ "current"

The CLI exits 0 for **both** clean plan states — `current` and `ready` (operator task files that `akm migrate apply` would rewrite to task source v4); only `blocked` exits 1 (`dist/commands/migrate-cli.js` sets the exit code iff the combined status is `blocked`). The entrypoint read exit 0 as "current", so a home with an operator-authored `version: 2` task recorded `migrate 0 current` on every boot while akm itself warned "run `akm migrate apply`" on every read of that file — the marker contradicted the logs forever.

**Fix:** boot parses the plan's `status` field and records `migrate 0 ready operator-apply-pending`, with a log line naming the operator remedy. **Deliberately unchanged:** boot still never applies. By boot time the only convertible files left are operator-authored (`retirePreV4SeededTasks` already rewrote the shipped set during the upgrade), and both `docs/managing-openpalm.md` and the 0.12→0.13 upgrade doc promise those files are never rewritten behind the operator's back.

## 2. `akm health` exit 78: the state.db cutover, and why akm's own advice can't work here

akm never applies a state.db migration it classifies `historical-destructive` (0.9.6/0.9.7 ship one: `018-drop-dead-lane-schema`) during an ordinary open. On a home whose state.db predates it, every boot has `akm health` exit 78 and **every state.db surface — events, proposals, task history, improve ledgers, workflow runs — fails to open** until the cutover runs.

The remedy akm's error names, `akm upgrade --force`, is the package **self-updater**: it needs GitHub egress, runs `npm install -g akm-cli@latest` (forbidden by the image-baked model, EACCES for the container user anyway), and only reaches the state.db step after that install succeeds. akm 0.9.6/0.9.7 expose the state step (`upgradeHistoricalStateDatabase`, `dist/core/state-db.js`) to the self-updater alone — no other command, no package export.

**Fix:** the image bakes `openpalm-akm-state-upgrade`, driving akm's own machinery directly against the image-pinned akm-cli (no drift possible): verified `VACUUM INTO` sibling safety copy first (`quick_check` + ledger check), then the pending migrations; idempotent and fully offline. Boot recognizes the refusal, records `health 78 state-upgrade-pending`, and names the helper — and **never runs it**: akm reserves this migration class for explicit intent, and a boot that granted it automatically would extend that grant to every future destructive migration an image bump ships.

## 3. The host akm import wrote host-view loopback endpoints into a container-view file

`config/akm/config.json` is container-view by contract — the setup wizard rewrites loopback provider URLs to `host.docker.internal` when persisting (W10), and `akm-user-env.ts` translates that hostname back to loopback for host-side akm runs. The manual host-config import (`importHostAkmConfig`, the providers "use my local configuration" flow) was the one writer that skipped the rewrite: a host LM Studio/Ollama engine or embedding endpoint at `http://localhost:1234/...` imported verbatim, **loaded fine (so the route's validate-then-rollback kept it), then failed every LLM call at use time** — the container dialing its own loopback. Found live: the same host answers HTTP 200 from inside the assistant as `host.docker.internal:1234`.

**Fix:** the import applies the W10 loopback → `host.docker.internal` rewrite to the host's values before the additive merge, with the same deep-walk shape as `akm-user-env.ts`'s reverse translation. Host values only — an endpoint the operator set in the assistant's own config is never touched. Works on Linux/macOS/Windows alike (`host.docker.internal:host-gateway` ships unconditionally in core.compose.yml). Two new tests pin the rewrite (localhost / 127.0.0.1 / `[::1]`, engines + embedding) and the leave-alone rules.

## 4. Preferred-model saves from the admin UI wrote a phantom file — and clears never cleared

Three defects in the `opencode.json` write path (`ui/src/lib/server/opencode/config.ts`):

- The admin UI co-process runs **inside the assistant container**, where the entrypoint deliberately injects no `OP_HOME` — but `configPath()` resolved `OP_HOME ?? ''` into a *relative* `config/assistant/opencode.json` against the server's cwd. A preferred-model save either errored or landed in a phantom file the assistant never reads, while the best-effort live PATCH made it look saved until the next restart dropped it. The path now falls back to the container's real file: the RW bind mount at `~/.config/opencode/opencode.json`. Host-served surfaces (wizard, desktop shell) keep the `OP_HOME` path.
- `patchConfig` merges starting from what is **on disk**, so `unsetMainModel`'s delete on its in-memory copy was resurrected by the spread — clearing a model never persisted. Removals are now explicit (`removeKeys`).
- `setMainModel` round-tripped the full `getCurrentConfig()`, whose fallback is OpenCode's live `/config` — a save against an unreadable disk file would have baked the entire runtime-merged config into the operator's file. Saves are now deltas merged over the disk state.

New `config.vitest.ts` pins all three: persistence without clobbering unrelated keys, delta-only writes (live-config fallback never persisted), the container-side path resolution (and nothing at the old phantom location), and unset actually removing the key.

## Verification

- New `packages/lib/src/control-plane/akm-migrate-boot.test.ts` executes the **real entrypoint functions** against a fake akm: 12 cases pin the marker vocabulary, the no-apply-on-`ready` rule, the state-upgrade detection (report-only), the unchanged non-zero apply/retry paths, and the Dockerfile/helper wiring.
- Helper, detection grep, and the docs fallback one-liner were each rehearsed end-to-end on the built `openpalm/assistant:0.13.0` image (`--network none`) against a pre-018 state.db fabricated with akm's own migration engine: cutover → ledger 024 + `quick_check: ok` + safety copy; second run `{"upgraded":false}`; `akm health` exit 0 with `state-db-schema: pass`.
- Validated on the live deployment that surfaced the bug: cutover applied under virtiofs (akm's DELETE-journal network-FS handling engaged), safety copy created, `akm health` 0, clean boot marker across a restart.
- `bun test` (packages/lib): all pass except 3 pre-existing macOS-only `/var`→`/private/var` realpath failures unrelated to this change; biome lint clean.

## Docs

`docs/operations/upgrade-0.12-to-0.13.md` gains the symptom → remedy section (including a fallback invocation for 0.13.0 images that predate the helper); `docs/managing-openpalm.md` documents both the never-rewritten-at-boot rule and the post-update cutover under Updates and Recovery. CHANGELOG entries under Unreleased for 0.13.1.

**Upstream follow-up worth filing on itlackey/akm:** a first-class, network-free `akm state upgrade` command that runs only the deliberate cutover — then the helper shrinks to a one-line wrapper and downstreams stop reaching into dist internals.


---

**Rebased onto `release/0.13.1`** (which pins akm-cli 0.9.6 → 0.9.7): every surface this change depends on — `migrate-cli.js`, `state-db.js`, `self-update.js`, `state/migrations.js` — is byte-identical between 0.9.6 and 0.9.7 (verified by diffing the published packages), and 0.9.7 adds no `state` subcommand, so all findings and rehearsals carry over unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
