### PR TITLE
fix: 0.13.1 bugfix set (#645 #643 #641 #642 #639 #636 #635 #644 #632 #633)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,6 +111,7 @@ jobs:
           node scripts/bump-unit.mjs
           UNIT=electron node scripts/bump-unit.mjs
           bun install --lockfile-only
+          node scripts/sync-lockfile-versions.mjs
       - name: Commit and bundle candidate
         id: bundle
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,51 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **`openpalm update` from 0.12.x no longer silently drops the akm LLM
+  engine (#645).** The retired `profiles.llm.*` block is translated into akm
+  0.9 `engines.*` (endpoint, model, provider, and an env-var `apiKey`
+  reference) before the retired keys are stripped; anything untranslatable is
+  named in a warning, and `openpalm validate` now warns when an akm config has
+  zero engines instead of reporting OK.
+- **Port migrations no longer revert an operator's `state/stack.env` port or
+  assign a port another instance already holds (#643).** An explicit
+  `OP_ASSISTANT_PORT`/`OP_UI_PORT` in the consolidated file survives a re-run
+  of the migration chain (which a rollback's restored schema-version
+  triggers), and a fresh default is probed host-wide and steps to the next
+  free port when a sibling install binds it.
+- **Root-owned files in `OP_HOME` no longer abort `openpalm update` (#641,
+  #642).** The backup snapshot skips an unreadable file it does not need and
+  records it in `.backup-complete`, failing loud only for the files
+  `openpalm rollback` restores; a leftover root-owned `.system-previous-*`
+  tree (a pre-0.13.1 guardian's `node_modules`) is warned about instead of
+  failing the already-completed update.
+- **Failed updates can be un-pinned from `rollback-generation-*` image tags
+  (#639).** New `openpalm unpin` command and a Recovery-tab banner with a
+  one-click clear share one lib function that clears only `rollback-`
+  prefixed values, so a deliberate operator pin is never touched.
+- **An older app refuses to manage a newer `OP_HOME` (#636).** Install,
+  update, upgrade, home-asset seeding, and `unpin` compare
+  `.skeleton-version` and `state/schema-version` against the running build
+  and refuse with an actionable message instead of rewriting `system/` or
+  advancing image pins backwards; `status`, `validate`, and `start` keep
+  working.
+- **The desktop self-updater never calls electron-updater's `install()`
+  twice (#635).** A second call after a quit-time install was a silent no-op
+  that jammed every later install for the process; it is now refused, and a
+  failed quit-time install is logged loudly.
+- **Reapply and deploy failures surface the Docker daemon's real error
+  (#644).** The bare `Recreate` Compose progress line is filtered out, and a
+  per-service failure reason now carries the summarized compose stderr
+  instead of a templated "did not become healthy".
+- **A home missing a compose secret file fails before Docker does (#632).**
+  The pre-activation secret audit checks that each resolved secret file
+  exists and names the secret, the path, and the remedy, instead of Docker's
+  opaque bind-mount error after `install --no-start`.
+- **`bun.lock` workspace versions are trued up at release stamp time
+  (#633).** `bun install --lockfile-only` never rewrites a workspace's own
+  version field; the release workflow now patches exactly those fields after
+  the bump.
+
 - **Preferred-model saves from the admin UI now persist — and clearing one
   actually clears it.** Three defects in the `opencode.json` write path
   (`packages/ui/src/lib/server/opencode/config.ts`), found together. First:

--- a/bun.lock
+++ b/bun.lock
@@ -10,7 +10,7 @@
     },
     "packages/cli": {
       "name": "openpalm",
-      "version": "0.13.0-beta.31",
+      "version": "0.13.0",
       "bin": {
         "openpalm": "./bin/openpalm.js",
       },
@@ -25,7 +25,7 @@
     },
     "packages/electron": {
       "name": "@openpalm/electron",
-      "version": "0.13.0-beta.31",
+      "version": "0.13.0",
       "dependencies": {
         "electron-updater": "^6.8.9",
       },
@@ -53,7 +53,7 @@
     },
     "packages/lib": {
       "name": "@openpalm/lib",
-      "version": "0.13.0-beta.31",
+      "version": "0.13.0",
       "dependencies": {
         "dotenv": "^17.4.2",
         "multicast-dns": "^7.2.5",
@@ -99,11 +99,11 @@
     },
     "packages/skeleton": {
       "name": "@openpalm/skeleton",
-      "version": "0.13.0-beta.31",
+      "version": "0.13.0",
     },
     "packages/ui": {
       "name": "@openpalm/ui",
-      "version": "0.13.0-beta.31",
+      "version": "0.13.0",
       "devDependencies": {
         "@axe-core/playwright": "^4.12.1",
         "@eslint/compat": "^2.1.0",

--- a/docs/managing-openpalm.md
+++ b/docs/managing-openpalm.md
@@ -312,6 +312,27 @@ offline; `{"upgraded":false}` means there was nothing to do. Boot never runs
 this for you: applying a destructive migration stays an explicit operator
 action, the same rule that keeps your task files unrewritten at boot.
 
+### A failed update leaves the stack pinned to a rollback image
+
+**A failed update pins your images to a preserved rollback tag, not to
+`latest`.** Before a failed update can mutate anything, OpenPalm retags each
+running image as `<namespace>/<service>:rollback-generation-<id>` and points
+`state/stack.env` at those tags, so the automatic recovery above restarts the
+exact images that were running before — never a `latest` that might not match
+your restored config. If `update` keeps failing, every attempt repeats this,
+so the stack stays correctly pinned to whichever rollback generation is
+newest; it never drifts to a stale one, but the pin also never clears itself.
+Run `openpalm unpin` once the underlying problem is fixed (bad connectivity, a
+bad tag, disk space, …) to release the pin and let the next `update`/`start`
+pull the normal release tag again — it only edits `state/stack.env` and never
+touches a version you set yourself (a value without the `rollback-` prefix),
+so run `update` afterward to actually apply it:
+
+```bash
+openpalm unpin
+openpalm update
+```
+
 ### Desktop app updates
 
 The desktop app updates as one complete application — shell and UI together —

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -272,6 +272,24 @@ openpalm rollback
 Raw copying is incomplete because install/update also generates state, private
 secrets, caches, and runtime files.
 
+### Stuck on a rollback image tag after repeated failed updates
+
+Each failed `update` retags your previous images as
+`rollback-generation-<id>` and pins `state/stack.env` to them so the
+automatic recovery restarts exactly what was running before — but nothing
+clears that pin on its own, so repeated failures just move it to a newer
+generation. Once the update failure itself is fixed, release the pin and
+apply the real release tag:
+
+```bash
+openpalm unpin
+openpalm update
+```
+
+`openpalm unpin` only clears `state/stack.env` keys that are still on a
+`rollback-generation-*` tag; it never touches an image tag you pinned
+yourself.
+
 ## Factory Reset
 
 Back up first. Then remove the stack and all OpenPalm-owned trees:

--- a/packages/cli/src/commands/install.ts
+++ b/packages/cli/src/commands/install.ts
@@ -413,7 +413,7 @@ async function prepareInstallFiles(
 	// runs (deploy happens later from inside the UI), so this explicit seed is
 	// the only one that runs before the wizard comes up.
 	await seedSkeletonFromEmbedded(applyHomeSeed, homeDir, dataDir);
-	runHomeMigrations(homeDir);
+	await runHomeMigrations(homeDir);
 	// Materialize the embedded UI build into data/ui — no network, no backup:
 	// this binary's build wins unconditionally once its stamp differs from
 	// what's already there (a no-op on a repeat install at the same version).

--- a/packages/cli/src/commands/unpin.test.ts
+++ b/packages/cli/src/commands/unpin.test.ts
@@ -1,0 +1,147 @@
+/**
+ * #639 — `openpalm unpin` clears rollback-generation-* pins left behind by a
+ * failed update via the shared clearRollbackPins() lib function, and never
+ * touches a genuine operator pin.
+ *
+ * Harness: real @openpalm/lib + a seeded temp OP_HOME, mirroring
+ * reset-password.test.ts's documented convention (mocking the shared
+ * @openpalm/lib import can leak across files sharing this bun test process,
+ * so the package/cli-state mocks are re-asserted at the START of every test).
+ */
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import * as realLib from '../../../lib/src/index.ts';
+import * as realCliState from '../lib/cli-state.ts';
+
+const cliStateModuleUrl = new URL('../lib/cli-state.ts', import.meta.url).href;
+const unpinModuleUrl = new URL('./unpin.ts', import.meta.url).href;
+const mainModuleUrl = new URL('../main.ts', import.meta.url).href;
+
+const originalHome = process.env.OP_HOME;
+let tempHome: string;
+
+function resetMocks(): void {
+	mock.restore();
+	mock.module('@openpalm/lib', () => ({ ...realLib }));
+	mock.module(cliStateModuleUrl, () => ({
+		...realCliState,
+		ensureValidState: () => {
+			const state = realLib.createState();
+			if (realLib.classifyLocalInstall(state.stackDir, state.homeDir) === 'not_installed') {
+				throw new Error(
+					'OpenPalm is not installed in this OP_HOME yet. Run `openpalm install` first.'
+				);
+			}
+			state.artifacts = realLib.resolveRuntimeFiles();
+			return state;
+		}
+	}));
+}
+
+function stackEnvPath(): string {
+	return join(tempHome, 'state', 'stack.env');
+}
+
+beforeEach(() => {
+	tempHome = mkdtempSync(join(tmpdir(), 'openpalm-unpin-'));
+	process.env.OP_HOME = tempHome;
+
+	// Seed a minimal "installed" OP_HOME so ensureValidState() doesn't refuse.
+	mkdirSync(join(tempHome, 'system', 'stack'), { recursive: true });
+	writeFileSync(join(tempHome, 'system', 'stack', 'core.compose.yml'), 'services: {}\n');
+	mkdirSync(join(tempHome, 'state'), { recursive: true });
+});
+
+afterEach(() => {
+	mock.restore();
+	mock.module('@openpalm/lib', () => ({ ...realLib }));
+	mock.module(cliStateModuleUrl, () => ({ ...realCliState }));
+	if (originalHome === undefined) delete process.env.OP_HOME;
+	else process.env.OP_HOME = originalHome;
+	rmSync(tempHome, { recursive: true, force: true });
+});
+
+describe('runUnpinAction (#639)', () => {
+	test('clears the operator-reported stack.env shape: rollback- values with blank OP_MANAGED_* markers', async () => {
+		writeFileSync(
+			stackEnvPath(),
+			[
+				'OP_ASSISTANT_VERSION=rollback-generation-1788212586188-217761-1',
+				'OP_VOICE_VERSION=rollback-generation-1788212586188-217761-1',
+				'OP_GUARDIAN_VERSION=rollback-generation-1788212586188-217761-1',
+				'OP_PORTAL_VERSION=rollback-generation-1788212586188-217761-1',
+				'OP_MANAGED_ASSISTANT_VERSION=',
+				'OP_MANAGED_GUARDIAN_VERSION=',
+				'OP_MANAGED_PORTAL_VERSION=',
+				'OP_MANAGED_VOICE_VERSION=',
+				''
+			].join('\n')
+		);
+
+		resetMocks();
+		const { runUnpinAction } = await import(`${unpinModuleUrl}?t=${Math.random()}`);
+		await runUnpinAction();
+
+		const versions = realLib.readVersions(realLib.createState());
+		expect(versions.OP_ASSISTANT_VERSION).toBe(realLib.PLATFORM_VERSION);
+		expect(versions.OP_GUARDIAN_VERSION).toBe(realLib.PLATFORM_VERSION);
+		expect(versions.OP_PORTAL_VERSION).toBe(realLib.PLATFORM_VERSION);
+		expect(versions.OP_VOICE_VERSION).toBe('latest');
+		for (const key of realLib.SERVICE_VERSION_KEYS) {
+			expect(versions[key]).not.toMatch(/^rollback-/);
+		}
+	});
+
+	test('never clears a genuine operator pin (no rollback- prefix), even with a blank managed marker', async () => {
+		writeFileSync(
+			stackEnvPath(),
+			[
+				'OP_ASSISTANT_VERSION=rollback-generation-1',
+				'OP_GUARDIAN_VERSION=my-operator-pinned-build',
+				'OP_MANAGED_ASSISTANT_VERSION=',
+				'OP_MANAGED_GUARDIAN_VERSION=',
+				''
+			].join('\n')
+		);
+
+		resetMocks();
+		const { runUnpinAction } = await import(`${unpinModuleUrl}?t=${Math.random()}`);
+		await runUnpinAction();
+
+		const content = readFileSync(stackEnvPath(), 'utf-8');
+		expect(content).toContain('OP_GUARDIAN_VERSION=my-operator-pinned-build');
+		expect(content).not.toContain('OP_ASSISTANT_VERSION=rollback-generation-1\n');
+	});
+
+	test('is a no-op (and says so) when nothing is pinned to a rollback generation', async () => {
+		writeFileSync(stackEnvPath(), 'OP_ASSISTANT_VERSION=0.13.0\n');
+
+		resetMocks();
+		const { runUnpinAction } = await import(`${unpinModuleUrl}?t=${Math.random()}`);
+		await runUnpinAction();
+
+		const content = readFileSync(stackEnvPath(), 'utf-8');
+		expect(content).toContain('OP_ASSISTANT_VERSION=0.13.0');
+	});
+
+	test('refuses on an OP_HOME with no install', async () => {
+		rmSync(join(tempHome, 'system', 'stack', 'core.compose.yml'));
+
+		resetMocks();
+		const { runUnpinAction } = await import(`${unpinModuleUrl}?t=${Math.random()}`);
+		await expect(runUnpinAction()).rejects.toThrow(/not installed/i);
+	});
+});
+
+describe('unpin command registration', () => {
+	test('is registered as a subcommand on the main CLI', async () => {
+		resetMocks();
+		const { mainCommand } = await import(`${mainModuleUrl}?t=${Math.random()}`);
+		const sub = (mainCommand.subCommands as Record<string, () => Promise<unknown>>).unpin;
+		expect(typeof sub).toBe('function');
+		const cmd = (await sub()) as { meta?: { name?: string } };
+		expect(cmd.meta?.name).toBe('unpin');
+	});
+});

--- a/packages/cli/src/commands/unpin.ts
+++ b/packages/cli/src/commands/unpin.ts
@@ -1,0 +1,43 @@
+import { defineCommand } from 'citty';
+import { clearRollbackPins, SERVICE_VERSION_KEYS } from '@openpalm/lib';
+import { defineAction } from '../lib/action.ts';
+import { ensureValidState } from '../lib/cli-state.ts';
+
+export default defineCommand({
+	meta: {
+		name: 'unpin',
+		description:
+			'Clear a stack.env rollback-generation-* image pin left behind by a failed update, so the next update/start pulls the normal release tag again. Never touches a deliberate operator pin.'
+	},
+	run: defineAction(async () => {
+		await runUnpinAction();
+	})
+});
+
+export async function runUnpinAction(): Promise<void> {
+	const state = ensureValidState();
+	const { cleared, kept } = clearRollbackPins(state);
+	const clearedKeys = Object.keys(cleared) as Array<keyof typeof cleared>;
+
+	if (clearedKeys.length === 0) {
+		console.log('No rollback-generation-* pins found in state/stack.env. Nothing to clear.');
+		return;
+	}
+
+	console.log('Cleared the following rollback pin(s):');
+	for (const key of clearedKeys) {
+		const change = cleared[key];
+		if (!change) continue;
+		console.log(`  ${key}: ${change.from} -> ${change.to}`);
+	}
+
+	const untouched = SERVICE_VERSION_KEYS.filter((key) => !clearedKeys.includes(key));
+	if (untouched.length > 0) {
+		console.log('Left the following key(s) untouched (not a rollback pin):');
+		for (const key of untouched) {
+			console.log(`  ${key}: ${kept[key]}`);
+		}
+	}
+
+	console.log('This only updates state/stack.env. Run `openpalm update` (or `openpalm start`) to apply it.');
+}

--- a/packages/cli/src/lib/cli-compose.ts
+++ b/packages/cli/src/lib/cli-compose.ts
@@ -56,7 +56,7 @@ export async function runComposeWithPreflight(
 	// down/stop resolve no addon profiles and leave addon containers running
 	// while reporting success. Only the heavier activation preflight below is
 	// skipped for teardown.
-	runHomeMigrations(state.homeDir);
+	await runHomeMigrations(state.homeDir);
 
 	if (operation === 'down' || operation === 'stop') {
 		const composeArgs = buildComposeCliArgs(state);

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -143,6 +143,7 @@ const subCommands = {
   scan: () => import('./commands/scan.ts').then((m) => m.default),
   'audit-secrets': () => import('./commands/audit-secrets.ts').then((m) => m.default),
   rollback: () => import('./commands/rollback.ts').then((m) => m.default),
+  unpin: () => import('./commands/unpin.ts').then((m) => m.default),
   automations: () => import('./commands/automations.ts').then((m) => m.default),
   unlock: () => import('./commands/unlock.ts').then((m) => m.default),
   'reset-password': () => import('./commands/reset-password.ts').then((m) => m.default),

--- a/packages/electron/src/updater.ts
+++ b/packages/electron/src/updater.ts
@@ -282,6 +282,31 @@ export class DesktopUpdater {
   private lastCheckAt: number | null = null;
   /** Token for the in-flight download, so dispose() can cancel it (review E3). */
   private downloadCancellation: CancellationTokenLike | null = null;
+  /**
+   * Set the first time THIS staged update's install has actually been handed
+   * to electron-updater, via EITHER `quitAndInstall()` or `installOnQuit()`;
+   * cleared when a new download starts. (#635)
+   *
+   * electron-updater's own re-entry guard (`BaseUpdater#quitAndInstallCalled`)
+   * is set unconditionally by `install()` before it even attempts the install,
+   * and on failure is reset back to `false` ONLY inside `quitAndInstall()`'s
+   * own wrapper — never when `install()` is called directly, which is exactly
+   * the path `installOnQuit()` uses (see its docblock). So once a silent
+   * install-on-quit has been attempted once, EVERY later call on EITHER path —
+   * for the rest of this process's life — is guaranteed to fail, and
+   * electron-updater itself only logs that as a quiet
+   * "install call ignored: quitAndInstallCalled is set to true" warning.
+   * Worse, `quitAndInstall()`'s own `app.quit()` fires Electron's real 'quit'
+   * lifecycle, which main.ts's before-quit handler reaches too — so a single
+   * user click on "Restart and update" was already making TWO raw calls into
+   * electron-updater (one via `quitAndInstall()`, one via the `installOnQuit()`
+   * that before-quit calls unconditionally afterward).
+   *
+   * This flag stops OUR code from ever making that doomed (or redundant)
+   * second call — a repeat attempt is refused right here, loudly, instead of
+   * silently retrying into a no-op.
+   */
+  private installAttempted = false;
   // Bound listener references, kept so dispose() can remove exactly these
   // from the shared singleton updater (review E6 — see dispose() below).
   private readonly onDownloadProgress: ((...args: unknown[]) => void) | null;
@@ -456,6 +481,8 @@ export class DesktopUpdater {
     }
 
     this.patch({ status: 'downloading', percent: 0, error: null });
+    // A fresh downloaded artifact gets a fresh, one-shot install budget (#635).
+    this.installAttempted = false;
     // Held so dispose() can cancel this download if the channel toggle
     // discards the instance mid-flight (review E3).
     this.downloadCancellation = this.deps.createCancellationToken?.() ?? null;
@@ -485,9 +512,24 @@ export class DesktopUpdater {
   /**
    * Install the staged update now. No-op unless a download completed — calling
    * quitAndInstall without one would quit the app and install nothing.
+   *
+   * At most once per downloaded update (#635): a repeat call — e.g. the
+   * `installOnQuit()` that main.ts's before-quit handler makes unconditionally
+   * once electron-updater's own `app.quit()` (fired below) reaches it — is
+   * refused here rather than making a second, doomed raw call into
+   * electron-updater. See `installAttempted`'s docblock.
    */
   quitAndInstall(): boolean {
     if (!this.state.supported || this.state.status !== 'downloaded') return false;
+    if (this.installAttempted) {
+      console.error(
+        '[updater] quitAndInstall() refused: an install was already attempted for this ' +
+          'staged update (#635 single-attempt guard) — electron-updater would silently ' +
+          'ignore a second call anyway.',
+      );
+      return false;
+    }
+    this.installAttempted = true;
     this.deps.updater.quitAndInstall(false, true);
     return true;
   }
@@ -504,9 +546,37 @@ export class DesktopUpdater {
    * non-silent, force-run-after).
    *
    * No-op (returns false) unless a download has actually completed.
+   *
+   * At most once per downloaded update (#635). Two distinct "already handled"
+   * cases share that budget with `quitAndInstall()`:
+   *  - Expected, benign: `quitAndInstall()` already installed this update and
+   *    its own `app.quit()` is what brought us to this before-quit call in the
+   *    first place. Nothing failed — refuse quietly instead of making a second
+   *    raw call electron-updater would ignore anyway.
+   *  - Genuine failure: an EARLIER `installOnQuit()` in this same process
+   *    already tried and failed. electron-updater's guard means a retry here
+   *    is guaranteed to fail too (see `installAttempted`'s docblock), so
+   *    refuse — loudly, since this is the only path a stuck-forever updater
+   *    would otherwise never be reported on.
    */
   installOnQuit(): boolean {
     if (!this.state.supported || this.state.status !== 'downloaded') return false;
-    return this.deps.updater.install(true, false);
+    if (this.installAttempted) return false;
+    this.installAttempted = true;
+    const launched = this.deps.updater.install(true, false);
+    if (!launched) {
+      // Loud and unconditional: this quit proceeds regardless (main.ts's
+      // before-quit handler calls app.exit(0) right after), so this is the
+      // only chance to record that the staged update was NOT applied — the
+      // app is about to relaunch on its OLD version, and (#635)
+      // electron-updater's own quitAndInstallCalled guard means no later
+      // attempt in this process can ever succeed either.
+      console.error(
+        '[updater] installOnQuit() failed to launch the update installer; the staged ' +
+          'update was NOT applied. This process cannot retry it — electron-updater\'s ' +
+          'quitAndInstallCalled guard is now permanently set for this run.',
+      );
+    }
+    return launched;
   }
 }

--- a/packages/electron/test/updater.test.ts
+++ b/packages/electron/test/updater.test.ts
@@ -543,6 +543,150 @@ describe('installOnQuit', () => {
   });
 });
 
+// #635: "install call ignored: quitAndInstallCalled is set to true" jams the
+// updater — the operator's log shows exactly one v0.13.0 start against 24
+// reverts to v0.12.42, with that warning recurring for weeks.
+//
+// FakeRealUpdater below is NOT the loose FakeUpdater above: it mirrors
+// electron-updater 6.8.9's ACTUAL BaseUpdater#install/#quitAndInstall
+// (node_modules/electron-updater/out/BaseUpdater.js) line for line, including
+// the part that matters here — `install()` sets `quitAndInstallCalled = true`
+// BEFORE it attempts anything, and on failure only `quitAndInstall()`'s own
+// wrapper resets that flag back to false; a direct `install()` call (which is
+// exactly what `installOnQuit()` makes) never resets it. `onAppQuit` stands
+// in for the real Electron `app.quit()` that `quitAndInstall()` schedules —
+// wiring it straight to `installOnQuit()` reproduces the exact cascade
+// main.ts's before-quit handler creates: it calls `installOnQuit()`
+// unconditionally on every quit, including the one electron-updater's own
+// `quitAndInstall()` triggers internally.
+describe('quitAndInstall single-attempt guard (#635)', () => {
+  class FakeRealUpdater implements AppUpdaterLike {
+    autoDownload = true;
+    autoInstallOnAppQuit = false;
+    channel: string | null = null;
+    allowPrerelease = false;
+    /** Mirrors BaseUpdater#quitAndInstallCalled exactly. */
+    quitAndInstallCalled = false;
+    /** Raw calls that reached electron-updater's real install() — not refused by its guard. */
+    rawInstallCalls: Array<[boolean, boolean]> = [];
+    /** Mirrors electron-updater's own `_logger` output (console by default). */
+    logs: Array<string> = [];
+    doInstallOutcome: 'succeed' | 'throw' | 'return-false' = 'succeed';
+    /** Stands in for the real Electron app.quit() that quitAndInstall() schedules. */
+    onAppQuit: (() => void) | null = null;
+    private listeners = new Map<string, Array<(...a: unknown[]) => void>>();
+
+    async checkForUpdates() {
+      return { updateInfo: { version: '2.0.0' } };
+    }
+    async downloadUpdate() {
+      return [];
+    }
+
+    // Mirrors BaseUpdater.js's install() (lines 42-68) exactly.
+    install(isSilent = false, isForceRunAfter = false): boolean {
+      if (this.quitAndInstallCalled) {
+        this.logs.push('install call ignored: quitAndInstallCalled is set to true');
+        return false;
+      }
+      this.quitAndInstallCalled = true;
+      try {
+        this.rawInstallCalls.push([isSilent, isForceRunAfter]);
+        if (this.doInstallOutcome === 'throw') throw new Error('mv failed: EACCES');
+        return this.doInstallOutcome === 'succeed';
+      } catch (e) {
+        this.logs.push(`error: ${e instanceof Error ? e.message : String(e)}`);
+        return false;
+      }
+    }
+
+    // Mirrors BaseUpdater.js's quitAndInstall() (lines 13-27) exactly,
+    // `autoRunAppAfterInstall` defaulting true as it does in real
+    // electron-updater.
+    quitAndInstall(isSilent = false, isForceRunAfter = false): void {
+      const isInstalled = this.install(isSilent, isSilent ? isForceRunAfter : true);
+      if (isInstalled) {
+        this.onAppQuit?.();
+      } else {
+        this.quitAndInstallCalled = false;
+      }
+    }
+
+    on(event: string, listener: (...args: unknown[]) => void) {
+      const list = this.listeners.get(event) ?? [];
+      list.push(listener);
+      this.listeners.set(event, list);
+      return this;
+    }
+    removeListener(event: string, listener: (...args: unknown[]) => void) {
+      const list = this.listeners.get(event) ?? [];
+      const idx = list.indexOf(listener);
+      if (idx >= 0) list.splice(idx, 1);
+      return this;
+    }
+    emit(event: string, ...args: unknown[]): void {
+      for (const l of this.listeners.get(event) ?? []) l(...args);
+    }
+  }
+
+  async function makeRealisticUpdater() {
+    const fake = new FakeRealUpdater();
+    const updater = new DesktopUpdater({
+      updater: fake,
+      currentVersion: '0.12.42',
+      platform: 'linux',
+      isPackaged: true,
+      windowsInstallerPresent: false,
+      prerelease: false,
+    });
+    await updater.check();
+    fake.emit('update-downloaded');
+    await updater.download();
+    expect(updater.getState().status).toBe('downloaded');
+    return { updater, fake };
+  }
+
+  // The exact operator sequence: click "Restart and update" -> electron-updater's
+  // quitAndInstall() installs and schedules its own app.quit() -> that fires
+  // Electron's real 'before-quit' -> main.ts's handler calls installOnQuit()
+  // unconditionally, REGARDLESS of how the quit started.
+  it('makes at most one raw install() call across quitAndInstall -> cascading installOnQuit', async () => {
+    const { updater, fake } = await makeRealisticUpdater();
+    fake.onAppQuit = () => updater.installOnQuit();
+
+    expect(updater.quitAndInstall()).toBe(true);
+
+    expect(fake.rawInstallCalls).toEqual([[false, true]]);
+    expect(fake.logs).not.toContain('install call ignored: quitAndInstallCalled is set to true');
+  });
+
+  // Ordinary quit, no button click: installOnQuit() is the ONLY and FIRST
+  // attempt. When electron-updater's doInstall step itself fails (a real
+  // AppImage/NSIS failure — disk full, EACCES, whatever), the failure must be
+  // loud, and this process must never retry into electron-updater's now
+  // permanently-stuck quitAndInstallCalled guard.
+  it('logs a failed quit-time install loudly and never retries the doomed call', async () => {
+    const { updater, fake } = await makeRealisticUpdater();
+    fake.doInstallOutcome = 'throw';
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      expect(updater.installOnQuit()).toBe(false);
+      expect(errorSpy).toHaveBeenCalled();
+      errorSpy.mockClear();
+
+      // A later quit attempt in the SAME process must be refused WITHOUT a
+      // second raw call — electron-updater's guard makes it unrecoverable, so
+      // retrying would only ever reproduce the silent "install call ignored"
+      // no-op this fix exists to avoid.
+      expect(updater.installOnQuit()).toBe(false);
+      expect(fake.rawInstallCalls).toHaveLength(1);
+      expect(fake.logs).not.toContain('install call ignored: quitAndInstallCalled is set to true');
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+});
+
 // E6: createDesktopUpdater rebuilds a DesktopUpdater over the SAME singleton
 // autoUpdater on every prerelease-channel toggle. Without dispose(), each
 // rebuild leaves the PRIOR instance's listeners registered on the shared

--- a/packages/lib/src/control-plane/akm-sources.test.ts
+++ b/packages/lib/src/control-plane/akm-sources.test.ts
@@ -457,6 +457,58 @@ describe("stripRetiredAkmConfigKeys (upgrade heals a pre-0.9 config)", () => {
     expect(stripRetiredAkmConfigKeys(state)).toBe(false);
   });
 
+  it("issue #645: translates a 0.12.x profiles.llm.default into engines.default instead of dropping it into engines: {}", () => {
+    // The exact reported shape: a 0.12.x-era config upgraded in place. Before
+    // the fix, stripRetiredAkmConfigKeys deleted `profiles` and stamped
+    // configVersion "0.9.0" without ever reading it, leaving `engines: {}` —
+    // structurally valid, silently useless.
+    writeFileSync(opConfigPath, JSON.stringify({
+      profiles: {
+        llm: {
+          default: {
+            endpoint: "https://api.openai.com/v1/chat/completions",
+            model: "gpt-4o-mini",
+            provider: "openai",
+            apiKey: "sk-live-legacy-secret-abc123",
+          },
+        },
+      },
+      defaults: { llm: "default" },
+      bundles: { openpalm: { path: "/stash", writable: true } },
+      defaultBundle: "openpalm",
+    }, null, 2));
+
+    expect(stripRetiredAkmConfigKeys(state)).toBe(true);
+
+    const cfg = readJson(opConfigPath);
+    expect(cfg.profiles).toBeUndefined();
+    // The whole point: an engine now exists instead of `engines: {}`.
+    expect(cfg.engines).toEqual({
+      default: { kind: "llm", endpoint: "https://api.openai.com/v1/chat/completions", model: "gpt-4o-mini", provider: "openai" },
+    });
+    expect((cfg.defaults as Record<string, unknown>).llmEngine).toBe("default");
+    expect((cfg.defaults as Record<string, unknown>).llm).toBeUndefined();
+    // A literal apiKey is never carried over: akm 0.9's engine schema requires
+    // an env-var reference ($VAR), and config/akm/config.json is non-secret.
+    expect((cfg.engines as Record<string, Record<string, unknown>>).default.apiKey).toBeUndefined();
+  });
+
+  it("issue #645: never overwrites a live engine with the same name as a legacy profile", () => {
+    writeFileSync(opConfigPath, JSON.stringify({
+      profiles: { llm: { default: { endpoint: "https://old/v1/chat/completions", model: "old-model" } } },
+      engines: { default: { kind: "llm", endpoint: "https://new/v1/chat/completions", model: "new-model" } },
+      bundles: { openpalm: { path: "/stash", writable: true } },
+      defaultBundle: "openpalm",
+      configVersion: "0.9.0",
+    }, null, 2));
+
+    expect(stripRetiredAkmConfigKeys(state)).toBe(true);
+
+    const cfg = readJson(opConfigPath);
+    expect(cfg.profiles).toBeUndefined();
+    expect(cfg.engines).toEqual({ default: { kind: "llm", endpoint: "https://new/v1/chat/completions", model: "new-model" } });
+  });
+
   it("leaves an unparseable config alone rather than destroying it", () => {
     writeFileSync(opConfigPath, "{ not json");
     expect(stripRetiredAkmConfigKeys(state)).toBe(false);

--- a/packages/lib/src/control-plane/apply-stack-di.test.ts
+++ b/packages/lib/src/control-plane/apply-stack-di.test.ts
@@ -122,9 +122,67 @@ describe("applyStack", () => {
 
     expect(applied.ok).toBe(false);
     expect(applied.started).toEqual([]);
+    // The templated ps-state reason is kept, with the real `up` stderr
+    // (#644) appended — "wait timeout" here is the whole of what compose
+    // said, so it rides along even though it is not itself very specific.
     expect(applied.failed).toEqual([
-      { service: "assistant", reason: "container assistant did not become healthy (state: running)" },
+      {
+        service: "assistant",
+        reason: "container assistant did not become healthy (state: running): wait timeout",
+      },
     ]);
     expect(applied.upFailed).toBe(true);
+  });
+
+  // Regression (#644): a reapply that fails with `ps -a` still finding a row
+  // (e.g. a `created`-but-not-started container after a failed recreate) used
+  // to report ONLY the templated ps-state sentence — the real Docker daemon
+  // error in `up`'s stderr was computed (`upResult.stderr`) but never reached
+  // the caller. `rawStderr` carried it, but `error`/`failed[].reason` — what
+  // lifecycle.ts's reapply path and every other `.error`-only caller actually
+  // read — did not. Compose's own progress noise (including the `Recreate`
+  // status line compose-errors.ts previously failed to filter, see its own
+  // regression test) sits between the "up" call and the daemon error line, so
+  // this also exercises that the real fix (summarizeComposeStderr) is used
+  // here, not just "stderr is non-empty".
+  test("folds the real daemon error into a per-service reason when ps -a still finds a row", async () => {
+    const daemonError =
+      "Error response from daemon: failed to set up container networking: driver failed " +
+      "programming external connectivity on endpoint proj-assistant-1: failed to bind host " +
+      "port 127.0.0.1:3810/tcp: address already in use";
+    const upStderr = [
+      " Container proj-assistant-1 Recreate ",
+      " Container proj-assistant-1 Recreated ",
+      " Container proj-assistant-1 Starting ",
+      daemonError,
+    ].join("\n");
+    const docker = new FakeDocker((args) => {
+      if (args.includes("up")) return result(false, upStderr);
+      if (args.includes("ps")) {
+        return {
+          ok: true,
+          stdout: JSON.stringify({ Service: "assistant", State: "created", Health: "" }),
+          stderr: "",
+          code: 0,
+        };
+      }
+      return result(true);
+    });
+
+    const applied = await applyStack(
+      { kind: "service", service: "assistant" },
+      OPTIONS,
+      deps(docker),
+      { pull: "always" },
+    );
+
+    expect(applied.ok).toBe(false);
+    expect(applied.failed).toHaveLength(1);
+    // The real cause must be present verbatim...
+    expect(applied.failed[0]?.reason).toContain(daemonError);
+    expect(applied.error).toContain(daemonError);
+    // ...and the progress-only status line must NOT be what stands in for it.
+    expect(applied.failed[0]?.reason).not.toBe("Container proj-assistant-1 Recreate");
+    expect(applied.error).not.toBe("Container proj-assistant-1 Recreate");
   });
 });

--- a/packages/lib/src/control-plane/backup.test.ts
+++ b/packages/lib/src/control-plane/backup.test.ts
@@ -18,6 +18,7 @@
  */
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
 import {
+  chmodSync,
   cpSync,
   existsSync,
   mkdirSync,
@@ -39,6 +40,15 @@ import {
   planBackupPrune,
   pruneBackupDirs,
 } from './backup.js';
+
+// chmod 0 only blocks a NON-root process; root bypasses DAC permission checks
+// entirely, so the two #642 reproductions below need to run unprivileged to
+// actually hit EACCES. Same guard style as
+// config-persistence-operator-ids.test.ts, inverted: that suite needs root,
+// these need to NOT be root.
+function isRootProcess(): boolean {
+  return process.platform !== 'win32' && typeof process.getuid === 'function' && process.getuid() === 0;
+}
 
 let homeDir: string;
 
@@ -177,6 +187,56 @@ describe('backupOpenPalmHome atomicity', () => {
     const backupsDir = join(homeDir, 'data', 'backups');
     const remaining = existsSync(backupsDir) ? readdirSync(backupsDir) : [];
     expect(remaining).toEqual([]);
+  });
+});
+
+describe('backupOpenPalmHome tolerates unreadable files (#642)', () => {
+  // #642: an operator-created root-owned file anywhere under OP_HOME (e.g. a
+  // `sudo cp state/stack.env state/stack.env.bak` left behind before a hand
+  // edit) previously threw EACCES on the first unreadable entry and aborted
+  // `openpalm update` entirely, mid-way through applying managed files. One
+  // stray backup artifact should not block the whole update.
+  it('skips an unreadable non-essential file, names it in the marker, and still completes the backup', () => {
+    if (isRootProcess()) return; // see isRootProcess() docblock above
+    mkdirSync(join(homeDir, 'state'), { recursive: true });
+    writeFileSync(join(homeDir, 'state', 'stack.env'), 'OP_HOME=x\n');
+    const blocked = join(homeDir, 'state', 'stack.env.bak-portfix-test');
+    writeFileSync(blocked, 'OP_ENABLED_ADDONS=old\n');
+    chmodSync(blocked, 0o000); // unreadable, simulating a root-owned sudo artifact
+
+    try {
+      const backupDir = backupOpenPalmHome(homeDir);
+      expect(backupDir).not.toBeNull();
+      if (backupDir === null) return; // narrow for TS
+      // The file this backup actually needs still made it in.
+      expect(existsSync(join(backupDir, 'state', 'stack.env'))).toBe(true);
+      // The unreadable one was skipped, not fatal.
+      expect(existsSync(join(backupDir, 'state', 'stack.env.bak-portfix-test'))).toBe(false);
+      const marker = readFileSync(join(backupDir, BACKUP_COMPLETE_MARKER), 'utf-8');
+      expect(marker).toContain('state/stack.env.bak-portfix-test');
+    } finally {
+      chmodSync(blocked, 0o600); // restore so afterEach's rmSync(homeDir) can clean up
+    }
+  });
+
+  it('fails loud, naming the path, when a file the restore genuinely needs is unreadable', () => {
+    if (isRootProcess()) return; // see isRootProcess() docblock above
+    mkdirSync(join(homeDir, 'state'), { recursive: true });
+    const stackEnv = join(homeDir, 'state', 'stack.env');
+    writeFileSync(stackEnv, 'OP_HOME=x\n');
+    chmodSync(stackEnv, 0o000);
+
+    try {
+      // Not just "it throws" (a raw EACCES already did, pre-fix) — the message
+      // must be the actionable one naming the exact path and the reason it
+      // matters, distinguishing "genuinely needed, fails loud" from the
+      // tolerant skip-and-warn path the previous test exercises.
+      expect(() => backupOpenPalmHome(homeDir)).toThrow(
+        /Backup staging cannot read .*state\/stack\.env.*openpalm rollback/,
+      );
+    } finally {
+      chmodSync(stackEnv, 0o600); // restore so afterEach's rmSync(homeDir) can clean up
+    }
   });
 });
 

--- a/packages/lib/src/control-plane/backup.ts
+++ b/packages/lib/src/control-plane/backup.ts
@@ -1,6 +1,10 @@
-import { cpSync, type Dirent, existsSync, mkdirSync, readdirSync, renameSync, rmSync, statSync, statfsSync, writeFileSync } from "node:fs";
+import { cpSync, type Dirent, existsSync, lstatSync, mkdirSync, readdirSync, renameSync, rmSync, statSync, statfsSync, writeFileSync } from "node:fs";
 import { dirname, join, relative, sep } from "node:path";
+import { errMessage } from "./errors.js";
 import { resolveBackupsDirFor, stateEnvDir } from "./home.js";
+import { createLogger } from "../logger.js";
+
+const logger = createLogger("backup");
 
 export function timestampDirName(now = new Date()): string {
   return now.toISOString().replace(/[:.]/g, "-");
@@ -70,6 +74,96 @@ export function resolveBackupScope(homeDir: string): BackupScope {
     },
     skippedCredentials,
   };
+}
+
+/**
+ * Relative-to-home paths this backup exists to protect — the same files
+ * `openpalm rollback` actually restores (rollback.ts's SNAPSHOT_FILES, minus
+ * the auth.json copy it deliberately never restores automatically). An
+ * unreadable copy of one of these is not a stray operator artifact to warn
+ * past (#642) — it is the backup's whole reason to exist, so staging fails
+ * loud, naming the exact path, instead of shipping a snapshot missing the one
+ * file a restore would need.
+ */
+const REQUIRED_BACKUP_PATHS: ReadonlySet<string> = new Set([
+  "state/stack.env",
+  "state/schema-version",
+  "config/stack/custom.compose.yml",
+  ".skeleton-version",
+]);
+
+export interface BackupSkipWarning {
+  /** Absolute source path that could not be read. */
+  path: string;
+  /** The read error's message. */
+  error: string;
+}
+
+function requiredOrWarn(
+  source: string,
+  homeDir: string,
+  err: unknown,
+  warnings: BackupSkipWarning[],
+): void {
+  const rel = relative(homeDir, source);
+  if (REQUIRED_BACKUP_PATHS.has(rel)) {
+    throw new Error(
+      `Backup staging cannot read ${source}, which "openpalm rollback" depends on (${errMessage(err)}). ` +
+        "This is usually a file made root-owned by a manual `sudo` edit — fix its ownership/permissions " +
+        "(e.g. `sudo chown $(id -u):$(id -g) " +
+        `${source}\`) and retry.`,
+    );
+  }
+  warnings.push({ path: source, error: errMessage(err) });
+}
+
+/**
+ * Copy `source` into `target`, walking directories by hand rather than one
+ * blind `cpSync(..., { recursive: true })`. An operator-created root-owned
+ * file anywhere under OP_HOME (e.g. a `sudo cp state/stack.env
+ * state/stack.env.bak` left behind before a hand edit, #642) previously threw
+ * EACCES on the FIRST unreadable entry and aborted `openpalm update` entirely
+ * — after migrations had already run. Per-entry handling means one unreadable
+ * file is recorded in `warnings` and skipped; the rest of the backup still
+ * completes. A file this backup actually needs (REQUIRED_BACKUP_PATHS) is the
+ * one exception: that fails loud, naming the path, rather than shipping a
+ * snapshot silently missing it.
+ */
+function copyTreeTolerant(
+  source: string,
+  target: string,
+  scope: BackupScope,
+  homeDir: string,
+  warnings: BackupSkipWarning[],
+): void {
+  let stats: ReturnType<typeof lstatSync>;
+  try {
+    stats = lstatSync(source);
+  } catch (err) {
+    requiredOrWarn(source, homeDir, err, warnings);
+    return;
+  }
+  if (!stats.isDirectory()) {
+    try {
+      cpSync(source, target);
+    } catch (err) {
+      requiredOrWarn(source, homeDir, err, warnings);
+    }
+    return;
+  }
+  let entries: Dirent[];
+  try {
+    entries = readdirSync(source, { withFileTypes: true });
+  } catch (err) {
+    requiredOrWarn(source, homeDir, err, warnings);
+    return;
+  }
+  mkdirSync(target, { recursive: true });
+  for (const entry of entries) {
+    const childSource = join(source, entry.name);
+    if (!scope.includes(childSource)) continue;
+    copyTreeTolerant(childSource, join(target, entry.name), scope, homeDir, warnings);
+  }
 }
 
 /**
@@ -227,9 +321,9 @@ export interface BackupOpenPalmHomeOptions {
   /** Fraction of destination free space the backup may consume before it's refused (default 0.8, see {@link checkBackupFreeSpace}). */
   threshold?: number;
   /**
-   * Test seam: override the per-entry copy primitive (defaults to `fs.cpSync`).
-   * Lets tests deterministically simulate a mid-copy failure without mocking
-   * `node:fs` globally.
+   * Test seam: override the per-entry copy primitive (defaults to
+   * {@link copyTreeTolerant}). Lets tests deterministically simulate a
+   * mid-copy failure without mocking `node:fs` globally.
    */
   copyEntry?: (source: string, target: string) => void;
 }
@@ -287,9 +381,10 @@ export function backupOpenPalmHome(homeDir: string, options: BackupOpenPalmHomeO
   rmSync(stagingDir, { recursive: true, force: true });
   mkdirSync(stagingDir, { recursive: true });
 
+  const warnings: BackupSkipWarning[] = [];
   const copyEntry =
     options.copyEntry ??
-    ((source: string, target: string) => cpSync(source, target, { recursive: true, filter: scope.includes }));
+    ((source: string, target: string) => copyTreeTolerant(source, target, scope, homeDir, warnings));
 
   let copiedAny = false;
   try {
@@ -319,10 +414,18 @@ export function backupOpenPalmHome(homeDir: string, options: BackupOpenPalmHomeO
   // dir (cleaned up by the next call's cleanupStaleStaging, or manually) —
   // never a half-written directory at the name callers/listBackupDirs expect.
   //
-  // The marker also NAMES the credentials the scope left out (§5). Whoever
-  // restores this snapshot months from now is the person who needs to know
-  // that a service's login secret is not in it, and the marker travels with
-  // the snapshot; a log line at backup time does not.
+  // The marker also NAMES the credentials the scope left out (§5), and (#642)
+  // any file the copy could not read — an operator-owned root file this
+  // backup skipped rather than aborting for. Whoever restores this snapshot
+  // months from now is the person who needs to know what is missing from it,
+  // and the marker travels with the snapshot; a log line at backup time does
+  // not.
+  if (warnings.length > 0) {
+    logger.warn("backup skipped unreadable file(s)", {
+      count: warnings.length,
+      paths: warnings.map((w) => w.path)
+    });
+  }
   writeFileSync(
     join(stagingDir, BACKUP_COMPLETE_MARKER),
     [
@@ -333,6 +436,14 @@ export function backupOpenPalmHome(homeDir: string, options: BackupOpenPalmHomeO
             "Skipped — these belong to a service whose data/ tree is out of scope,",
             "and are restored with it (see docs/backup-restore.md):",
             ...scope.skippedCredentials.map((path) => `  ${relative(homeDir, path)}`),
+          ]
+        : []),
+      ...(warnings.length > 0
+        ? [
+            "",
+            "Skipped — unreadable (likely root-owned from a manual `sudo` edit;",
+            "fix ownership/permissions and back up manually if you need this file):",
+            ...warnings.map((w) => `  ${relative(homeDir, w.path)}: ${w.error}`),
           ]
         : []),
     ].join("\n"),

--- a/packages/lib/src/control-plane/compose-errors.test.ts
+++ b/packages/lib/src/control-plane/compose-errors.test.ts
@@ -94,6 +94,32 @@ describe("summarizeComposeStderr", () => {
     // instead of a progress line masquerading as a diagnosis.
     expect(summarizeComposeStderr("voice Pulling\nvoice Pulled\n")).toBe("");
   });
+
+  // Regression (#644): a real `--force-recreate` reapply failed, and the
+  // operator-facing error was reduced to `Container <proj>-assistant-1
+  // Recreate` — the compose PROGRESS line, not the Docker daemon error a
+  // manual `docker compose up -d assistant` immediately revealed (a port
+  // conflict). Every other in-progress/done verb pair here is listed
+  // together (Creating/Created, Starting/Started, Stopping/Stopped,
+  // Removing/Removed) but `Recreate` (compose's bare present-tense verb, not
+  // `Recreating`) had only its past tense `Recreated` covered, so it was the
+  // FIRST unmatched line and became the whole summary — hiding the real
+  // `Error response from daemon: ...` line further down the same stderr.
+  it("skips the Recreate progress line and reports the real daemon error below it", () => {
+    const stderr = [
+      "Container proj-assistant-1 Recreate",
+      "Container proj-assistant-1 Recreated",
+      "Container proj-assistant-1 Starting",
+      "Error response from daemon: failed to set up container networking: driver failed " +
+        "programming external connectivity on endpoint proj-assistant-1: failed to bind host " +
+        "port 127.0.0.1:3810/tcp: address already in use",
+    ].join("\n");
+    expect(summarizeComposeStderr(stderr)).toBe(
+      "Error response from daemon: failed to set up container networking: driver failed " +
+        "programming external connectivity on endpoint proj-assistant-1: failed to bind host " +
+        "port 127.0.0.1:3810/tcp: address already in use",
+    );
+  });
 });
 
 describe("mapDockerError", () => {

--- a/packages/lib/src/control-plane/compose-errors.ts
+++ b/packages/lib/src/control-plane/compose-errors.ts
@@ -61,9 +61,20 @@ const NETWORK_ERROR_RE = /(?:dial tcp|connection reset by peer|EOF|i\/o timeout|
  * line through as the operator-facing error. Worse, because the summary is the
  * FIRST unmatched line, a status line surviving the filter can mask the real
  * error further down the same stderr.
+ *
+ * `Recreate` (#644): every other in-progress/done pair is listed together
+ * (Creating/Created, Starting/Started, Stopping/Stopped, Removing/Removed,
+ * Pulling/Pulled) — this list had only the done half, `Recreated`. Compose
+ * emits the bare present-tense `Recreate` (not `Recreating`) the moment a
+ * `--force-recreate` up begins working on an existing container, one or more
+ * lines before `Recreated`/`Starting` and — on a real failure — the daemon
+ * error further down. Missing it meant that progress line, not the failure,
+ * was the FIRST unmatched line and thus the whole summary: a reapply's real
+ * cause (e.g. `Error response from daemon: ... port is already allocated`)
+ * was replaced by `Container <name> Recreate`, which names no problem.
  */
 const COMPOSE_PROGRESS_RE =
-  /^(?:\S+\s+){0,2}(?:Pulling fs layer|Pulling|Pulled|Waiting|Downloading|Download complete|Verifying Checksum|Extracting|Pull complete|Already exists|Creating|Created|Starting|Started|Healthy|Stopping|Stopped|Removing|Removed|Recreated|Skipped)\b/;
+  /^(?:\S+\s+){0,2}(?:Pulling fs layer|Pulling|Pulled|Waiting|Downloading|Download complete|Verifying Checksum|Extracting|Pull complete|Already exists|Creating|Created|Starting|Started|Healthy|Stopping|Stopped|Removing|Removed|Recreate|Recreated|Skipped)\b/;
 
 /**
  * Summarise compose stderr in a single short line, suitable for log

--- a/packages/lib/src/control-plane/config-persistence-consolidated-port-migration.test.ts
+++ b/packages/lib/src/control-plane/config-persistence-consolidated-port-migration.test.ts
@@ -1,0 +1,72 @@
+/**
+ * issue #643: `migrateConsolidatedDefaultPorts` used to swap the retired
+ * 3800/3810 pair by value alone, with no regard for whether the target port
+ * (the corrected default, 3810) was actually free on the host. On a host
+ * running several OpenPalm instances, an operator who set OP_ASSISTANT_PORT
+ * to 3800 specifically to dodge a sibling instance already on 3810 had that
+ * explicit, working choice silently reverted on the next update — landing
+ * them right back on the port they were avoiding.
+ */
+import { describe, expect, test } from 'bun:test';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { migrateConsolidatedDefaultPorts } from './config-persistence.js';
+
+async function withStackEnv(
+  content: string,
+  run: (homeDir: string, path: string) => void | Promise<void>,
+): Promise<void> {
+  const homeDir = mkdtempSync(join(tmpdir(), 'openpalm-consolidated-port-migration-'));
+  const path = join(homeDir, 'state', 'stack.env');
+  mkdirSync(join(homeDir, 'state'), { recursive: true });
+  writeFileSync(path, content);
+  try {
+    await run(homeDir, path);
+  } finally {
+    rmSync(homeDir, { recursive: true, force: true });
+  }
+}
+
+describe('consolidated default port migration', () => {
+  test('swaps the retired pair when the corrected default is free', async () => {
+    await withStackEnv('OP_ASSISTANT_PORT=3800\nOP_SETUP_COMPLETE=true\n', async (homeDir, path) => {
+      expect(await migrateConsolidatedDefaultPorts(homeDir)).toBe(true);
+      const migrated = readFileSync(path, 'utf8');
+      expect(migrated).toContain('OP_ASSISTANT_PORT=3810');
+      expect(migrated).toContain('OP_UI_PORT=3800');
+    });
+  });
+
+  test('leaves a custom pair alone', async () => {
+    const original = 'OP_ASSISTANT_PORT=4800\nOP_UI_PORT=4900\nOP_SETUP_COMPLETE=true\n';
+    await withStackEnv(original, async (homeDir, path) => {
+      expect(await migrateConsolidatedDefaultPorts(homeDir)).toBe(false);
+      expect(readFileSync(path, 'utf8')).toBe(original);
+    });
+  });
+
+  // The regression test: reproduces the reported bug (before the fix, this
+  // FAILS — the swap runs regardless of what a real listener already holds)
+  // and proves the fix (the operator's explicit 3800 survives).
+  test('does not revert an explicit assistant port that equals the retired default when a real listener already holds the corrected target', async () => {
+    const server = Bun.serve({ port: 3810, hostname: '127.0.0.1', fetch: () => new Response('x') });
+    try {
+      await withStackEnv('OP_ASSISTANT_PORT=3800\nOP_SETUP_COMPLETE=true\n', async (homeDir, path) => {
+        expect(await migrateConsolidatedDefaultPorts(homeDir)).toBe(false);
+        const after = readFileSync(path, 'utf8');
+        expect(after).toContain('OP_ASSISTANT_PORT=3800');
+        expect(after).not.toContain('OP_ASSISTANT_PORT=3810');
+      });
+    } finally {
+      server.stop(true);
+    }
+  });
+
+  test('a second run is a no-op once the target is free', async () => {
+    await withStackEnv('OP_ASSISTANT_PORT=3800\nOP_SETUP_COMPLETE=true\n', async (homeDir) => {
+      expect(await migrateConsolidatedDefaultPorts(homeDir)).toBe(true);
+      expect(await migrateConsolidatedDefaultPorts(homeDir)).toBe(false);
+    });
+  });
+});

--- a/packages/lib/src/control-plane/config-persistence-port-migration.test.ts
+++ b/packages/lib/src/control-plane/config-persistence-port-migration.test.ts
@@ -4,69 +4,94 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { migrateLegacyDefaultPorts } from './config-persistence.js';
 
-function withStackEnv(content: string, run: (homeDir: string, path: string) => void): void {
+async function withStackEnv(
+  content: string,
+  run: (homeDir: string, path: string) => void | Promise<void>,
+): Promise<void> {
   const homeDir = mkdtempSync(join(tmpdir(), 'openpalm-port-migration-'));
   const path = join(homeDir, 'knowledge', 'env', 'stack.env');
   mkdirSync(join(homeDir, 'knowledge', 'env'), { recursive: true });
   writeFileSync(path, content);
   try {
-    run(homeDir, path);
+    await run(homeDir, path);
   } finally {
     rmSync(homeDir, { recursive: true, force: true });
   }
 }
 
 describe('legacy default port migration', () => {
-  test('materializes the corrected defaults when an old stack env omitted both ports', () => {
-    withStackEnv('OP_OWNER_NAME=Alice\n', (homeDir, path) => {
-      expect(migrateLegacyDefaultPorts(homeDir)).toBe(true);
+  test('materializes the corrected defaults when an old stack env omitted both ports', async () => {
+    await withStackEnv('OP_OWNER_NAME=Alice\n', async (homeDir, path) => {
+      expect(await migrateLegacyDefaultPorts(homeDir)).toBe(true);
       const migrated = readFileSync(path, 'utf8');
       expect(migrated).toContain('OP_UI_PORT=3800');
       expect(migrated).toContain('OP_ASSISTANT_PORT=3810');
     });
   });
 
-  test('swaps a persisted assistant default and the old implicit UI default', () => {
-    withStackEnv('OP_ASSISTANT_PORT=3800\nOP_OWNER_NAME=Alice\n', (homeDir, path) => {
-      expect(migrateLegacyDefaultPorts(homeDir)).toBe(true);
+  test('swaps a persisted assistant default and the old implicit UI default', async () => {
+    await withStackEnv('OP_ASSISTANT_PORT=3800\nOP_OWNER_NAME=Alice\n', async (homeDir, path) => {
+      expect(await migrateLegacyDefaultPorts(homeDir)).toBe(true);
       const migrated = readFileSync(path, 'utf8');
       expect(migrated).toContain('OP_UI_PORT=3800');
       expect(migrated).toContain('OP_ASSISTANT_PORT=3810');
       expect(migrated).toContain('OP_OWNER_NAME=Alice');
-      expect(migrateLegacyDefaultPorts(homeDir)).toBe(false);
+      expect(await migrateLegacyDefaultPorts(homeDir)).toBe(false);
     });
   });
 
-  test('swaps the fully explicit old default pair', () => {
-    withStackEnv('OP_UI_PORT=3810\nOP_ASSISTANT_PORT=3800\n', (homeDir, path) => {
-      expect(migrateLegacyDefaultPorts(homeDir)).toBe(true);
+  test('swaps the fully explicit old default pair', async () => {
+    await withStackEnv('OP_UI_PORT=3810\nOP_ASSISTANT_PORT=3800\n', async (homeDir, path) => {
+      expect(await migrateLegacyDefaultPorts(homeDir)).toBe(true);
       expect(readFileSync(path, 'utf8')).toBe('OP_UI_PORT=3800\nOP_ASSISTANT_PORT=3810\n');
     });
   });
 
-  test('preserves custom port combinations', () => {
+  test('preserves custom port combinations', async () => {
     const original = 'OP_UI_PORT=4900\nOP_ASSISTANT_PORT=4800\n';
-    withStackEnv(original, (homeDir, path) => {
-      expect(migrateLegacyDefaultPorts(homeDir)).toBe(false);
+    await withStackEnv(original, async (homeDir, path) => {
+      expect(await migrateLegacyDefaultPorts(homeDir)).toBe(false);
       expect(readFileSync(path, 'utf8')).toBe(original);
     });
   });
 
-  test('materializes the old implicit UI port beside a custom assistant port', () => {
-    withStackEnv('OP_ASSISTANT_PORT=4800\n', (homeDir, path) => {
-      expect(migrateLegacyDefaultPorts(homeDir)).toBe(true);
+  test('materializes the old implicit UI port beside a custom assistant port', async () => {
+    await withStackEnv('OP_ASSISTANT_PORT=4800\n', async (homeDir, path) => {
+      expect(await migrateLegacyDefaultPorts(homeDir)).toBe(true);
       const migrated = readFileSync(path, 'utf8');
       expect(migrated).toContain('OP_ASSISTANT_PORT=4800');
       expect(migrated).toContain('OP_UI_PORT=3810');
     });
   });
 
-  test('materializes the old implicit assistant port beside a custom UI port', () => {
-    withStackEnv('OP_UI_PORT=4900\n', (homeDir, path) => {
-      expect(migrateLegacyDefaultPorts(homeDir)).toBe(true);
+  test('materializes the old implicit assistant port beside a custom UI port', async () => {
+    await withStackEnv('OP_UI_PORT=4900\n', async (homeDir, path) => {
+      expect(await migrateLegacyDefaultPorts(homeDir)).toBe(true);
       const migrated = readFileSync(path, 'utf8');
       expect(migrated).toContain('OP_UI_PORT=4900');
       expect(migrated).toContain('OP_ASSISTANT_PORT=3800');
     });
+  });
+
+  // Issue #643: a sibling OpenPalm instance on the same host can already hold
+  // the corrected default (3810) at the moment this migration materializes it
+  // for a home that never configured a port at all. Blindly writing 3810
+  // handed the next `docker compose up` a guaranteed "port is already
+  // allocated" failure. Occupy the port with a REAL listener (matching how
+  // `checkPortAvailable` actually probes) and confirm the migration steps
+  // past it instead.
+  test('steps past the default assistant port when a real listener already holds it', async () => {
+    const server = Bun.serve({ port: 3810, hostname: '127.0.0.1', fetch: () => new Response('x') });
+    try {
+      await withStackEnv('OP_OWNER_NAME=Alice\n', async (homeDir, path) => {
+        expect(await migrateLegacyDefaultPorts(homeDir)).toBe(true);
+        const migrated = readFileSync(path, 'utf8');
+        expect(migrated).toContain('OP_UI_PORT=3800');
+        expect(migrated).not.toContain('OP_ASSISTANT_PORT=3810');
+        expect(migrated).toContain('OP_ASSISTANT_PORT=3811');
+      });
+    } finally {
+      server.stop(true);
+    }
   });
 });

--- a/packages/lib/src/control-plane/config-persistence.ts
+++ b/packages/lib/src/control-plane/config-persistence.ts
@@ -8,7 +8,8 @@
 import { mkdirSync, writeFileSync, readFileSync, existsSync, chmodSync, chownSync, rmSync } from "node:fs";
 import { errMessage } from './errors.js';
 import { dirname, resolve as resolvePath } from "node:path";
-import { composeConfigJsonSync, type ComposeConfigJsonResult } from "./docker.js";
+import { composeConfigJsonSync, resolveComposeProjectName, type ComposeConfigJsonResult } from "./docker.js";
+import { isHostPortAvailableForUs, pickAvailableHostPort } from "./port-probe.js";
 import { createLogger } from "../logger.js";
 import { parseEnabledAddons, parseEnvContent, parseEnvFile, mergeEnvContent, removeEnvKey } from './env.js';
 import {
@@ -25,7 +26,7 @@ import { writeSecret } from './secrets-files.js';
 import { needsWorkspaceLoopbackPublish } from './bind-warning.js';
 import { isVoiceLanAccessEnabled } from './voice-host-probes.js';
 import type { ControlPlaneState, ArtifactMeta } from "./types.js";
-import { stackEnvFile, legacyKnowledgeStackEnvFile, legacyStateEnvFile, composeFilePath, customComposeFilePath } from "./home.js";
+import { stackEnvFile, legacyKnowledgeStackEnvFile, legacyStateEnvFile, composeFilePath, customComposeFilePath, stackDirFor } from "./home.js";
 import { stackEnvPath } from "./paths.js";
 import { writeFileAtomic } from "./fs-atomic.js";
 import {
@@ -76,8 +77,17 @@ export function buildEnvFiles(state: ControlPlaneState): string[] {
  * Custom combinations retain their old effective values. If only one custom
  * port was persisted, the other old implicit default is materialized so the
  * corrected defaults do not silently move it.
+ *
+ * Issue #643: materializing the CORRECTED defaults is itself a fresh port
+ * assignment for a home that never configured one — on a host running
+ * several OpenPalm instances, the default this writes can already be bound by
+ * a sibling install, and writing it blind is how the next `docker compose up`
+ * fails with "port is already allocated" instead of ever starting. Before
+ * writing a default, {@link pickAvailableHostPort} confirms it is actually
+ * free (or already ours) and steps to the next candidate otherwise — the
+ * same host-wide check `openpalm doctor` already performs for install ports.
  */
-export function migrateLegacyDefaultPorts(homeDir: string): boolean {
+export async function migrateLegacyDefaultPorts(homeDir: string): Promise<boolean> {
   const path = legacyKnowledgeStackEnvFile(homeDir);
   if (!existsSync(path)) return false;
 
@@ -93,8 +103,11 @@ export function migrateLegacyDefaultPorts(homeDir: string): boolean {
   const updates: Record<string, string> = {};
 
   if ((!hasAssistantPort && !hasUiPort) || (oldEffectiveAssistantPort === "3800" && oldEffectiveUiPort === "3810")) {
-    updates.OP_ASSISTANT_PORT = String(STACK_DEFAULTS.ports.assistant);
-    updates.OP_UI_PORT = String(STACK_DEFAULTS.ports.ui);
+    const composeProject = { name: resolveComposeProjectName(parsed), workingDir: stackDirFor(homeDir) };
+    updates.OP_ASSISTANT_PORT = String(
+      await pickAvailableHostPort(STACK_DEFAULTS.ports.assistant, composeProject),
+    );
+    updates.OP_UI_PORT = String(await pickAvailableHostPort(STACK_DEFAULTS.ports.ui, composeProject));
   } else {
     if (!assistantPort) updates.OP_ASSISTANT_PORT = oldEffectiveAssistantPort;
     if (!uiPort) updates.OP_UI_PORT = oldEffectiveUiPort;
@@ -169,8 +182,20 @@ export function migrateLegacyBindAddresses(homeDir: string): boolean {
  *
  * Only the retired PAIR is swapped. An absent value needs no write: the compose
  * fallbacks already resolve to the corrected defaults.
+ *
+ * Issue #643: the docblock above already named the risk this used to run
+ * into unguarded — "clobbering an operator who had deliberately chosen 3800
+ * for the assistant" — which is exactly what happens when that choice was
+ * made to dodge a SIBLING OpenPalm instance already holding the corrected
+ * default (3810) on a shared host: the swap moved the operator's working,
+ * explicit config onto the very port it was chosen to avoid, and the next
+ * `docker compose up` failed with "port is already allocated". Before
+ * swapping, confirm the target is actually free (or already ours) via
+ * {@link isHostPortAvailableForUs}; if not, the operator's current value is
+ * left in place rather than reverted — it is evidently the reason this
+ * install still runs.
  */
-export function migrateConsolidatedDefaultPorts(homeDir: string): boolean {
+export async function migrateConsolidatedDefaultPorts(homeDir: string): Promise<boolean> {
   const path = stackEnvFile(homeDir);
   if (!existsSync(path)) return false;
 
@@ -183,6 +208,9 @@ export function migrateConsolidatedDefaultPorts(homeDir: string): boolean {
   // implicit (its old default was 3810).
   const isRetiredPair = assistantPort === "3800" && (uiPort === "3810" || !uiPort);
   if (!isRetiredPair) return false;
+
+  const composeProject = { name: resolveComposeProjectName(parsed), workingDir: stackDirFor(homeDir) };
+  if (!(await isHostPortAvailableForUs(STACK_DEFAULTS.ports.assistant, composeProject))) return false;
 
   const next = mergeEnvContent(content, {
     OP_ASSISTANT_PORT: String(STACK_DEFAULTS.ports.assistant),

--- a/packages/lib/src/control-plane/config-persistence.ts
+++ b/packages/lib/src/control-plane/config-persistence.ts
@@ -103,11 +103,28 @@ export async function migrateLegacyDefaultPorts(homeDir: string): Promise<boolea
   const updates: Record<string, string> = {};
 
   if ((!hasAssistantPort && !hasUiPort) || (oldEffectiveAssistantPort === "3800" && oldEffectiveUiPort === "3810")) {
+    // A home whose schema-version got reset below 1 (e.g. a rollback restored
+    // it alongside a pre-rollback stack.env) re-runs migrateToSingleStackEnv
+    // right after this. That merge takes the legacy file as its base and only
+    // ADDS keys the base doesn't already define ("target-only" keys) from the
+    // consolidated state/stack.env — so a default THIS function writes here
+    // for a key the operator already set explicitly in the consolidated file
+    // would silently beat it, even though state/stack.env is the one file an
+    // operator is told they may hand-edit. Carry that explicit value over
+    // instead of probing for a fresh default; only probe for a key that is
+    // explicit NOWHERE (neither file).
+    const consolidatedPath = stackEnvFile(homeDir);
+    const consolidated = existsSync(consolidatedPath)
+      ? parseEnvContent(readFileSync(consolidatedPath, "utf-8"))
+      : {};
+    const explicitAssistant = consolidated.OP_ASSISTANT_PORT?.trim();
+    const explicitUi = consolidated.OP_UI_PORT?.trim();
+
     const composeProject = { name: resolveComposeProjectName(parsed), workingDir: stackDirFor(homeDir) };
-    updates.OP_ASSISTANT_PORT = String(
+    updates.OP_ASSISTANT_PORT = explicitAssistant || String(
       await pickAvailableHostPort(STACK_DEFAULTS.ports.assistant, composeProject),
     );
-    updates.OP_UI_PORT = String(await pickAvailableHostPort(STACK_DEFAULTS.ports.ui, composeProject));
+    updates.OP_UI_PORT = explicitUi || String(await pickAvailableHostPort(STACK_DEFAULTS.ports.ui, composeProject));
   } else {
     if (!assistantPort) updates.OP_ASSISTANT_PORT = oldEffectiveAssistantPort;
     if (!uiPort) updates.OP_UI_PORT = oldEffectiveUiPort;

--- a/packages/lib/src/control-plane/core-assets.test.ts
+++ b/packages/lib/src/control-plane/core-assets.test.ts
@@ -6,11 +6,20 @@
  * skip-existing copy, so they are not tested here.
  */
 import { describe, it, expect, beforeEach, afterEach } from "bun:test";
-import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, existsSync, rmSync, symlinkSync } from "node:fs";
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, existsSync, rmSync, symlinkSync, chmodSync, readdirSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, dirname } from "node:path";
 
 import { overwriteSystemTree } from "./core-assets.js";
+
+// chmod 0 only blocks a NON-root process; root bypasses DAC permission checks
+// entirely, so the reproduction below (#641) needs to run as an unprivileged
+// user to actually hit EACCES. Same environment-guard style as
+// config-persistence-operator-ids.test.ts, inverted: that suite needs root,
+// this one needs to NOT be root.
+function isRootProcess(): boolean {
+  return process.platform !== "win32" && typeof process.getuid === "function" && process.getuid() === 0;
+}
 
 let tmpRoot = "";
 let opHome = "";
@@ -147,6 +156,49 @@ describe("overwriteSystemTree", () => {
 		expect(existsSync(join(opHome, "system", "stack", "portals.compose.yml"))).toBe(false);
 		expect(updated).toContain("system/stack/portals.compose.yml");
 		expect(backupDir).not.toBeNull();
+	});
+
+	// #641: an operator upgrading from a release whose guardian installed its
+	// own dependencies at boot (pre-0.13.1) can have root-owned entries under
+	// system/guardian/node_modules on their FIRST 0.13.1 upgrade. The rename
+	// that retires the old tree needs only write on its PARENT directory and
+	// succeeds regardless of who owns the entries inside, but a non-root CLI
+	// then cannot unlink a file inside a root-owned, non-writable directory —
+	// so the final best-effort cleanup must warn and continue rather than
+	// throw and report a completed update as a failure.
+	it("does not abort a completed update when the retired system/ copy has an unremovable directory", () => {
+		if (isRootProcess()) return; // see isRootProcess() docblock above
+		seedSource("old\n");
+		overwriteSystemTree(sourceRoot, opHome);
+		const blockedDir = join(opHome, "system", "guardian", "node_modules", "some-pkg");
+		mkdirSync(blockedDir, { recursive: true });
+		writeFileSync(join(blockedDir, "index.js"), "module.exports = {}\n");
+		// r-xr-xr-x, matching a real npm-installed package directory: readable/
+		// listable (so the pre-swap backup copy still succeeds, as it does in
+		// the real bug) but not writable, so unlinking its entry fails. 0o000
+		// would additionally block the read/scan the backup copy needs,
+		// reproducing a different (scandir) failure than the reported one.
+		chmodSync(blockedDir, 0o555);
+		seedSource("new\n");
+
+		try {
+			expect(() => overwriteSystemTree(sourceRoot, opHome)).not.toThrow();
+			// The swap itself must have completed: the new tree is live.
+			expect(readFileSync(join(opHome, first), "utf-8")).toBe("new\n");
+		} finally {
+			// A successful (fixed) run renames the retired tree to
+			// .system-previous-<nonce> and leaves it in place (rm best-effort
+			// failed, by design) — the blocked directory now lives there, not at
+			// its original system/ path. Restore its permissions wherever it
+			// landed so afterEach's rmSync(tmpRoot) can actually clean up; a
+			// pre-fix run throws before any rename, so the original path is the
+			// fallback.
+			const previous = readdirSync(opHome).find((name) => name.startsWith(".system-previous-"));
+			const stillBlocked = previous
+				? join(opHome, previous, "guardian", "node_modules", "some-pkg")
+				: blockedDir;
+			if (existsSync(stillBlocked)) chmodSync(stillBlocked, 0o755);
+		}
 	});
 });
 

--- a/packages/lib/src/control-plane/core-assets.ts
+++ b/packages/lib/src/control-plane/core-assets.ts
@@ -185,7 +185,26 @@ export function overwriteSystemTree(
 		rmSync(stageRoot, { recursive: true, force: true });
 		throw error;
 	}
-	rmSync(previousRoot, { recursive: true, force: true });
+	// The swap above already succeeded — the new system/ tree is live. This is
+	// best-effort cleanup of the retired copy, not a step the update's success
+	// depends on. An operator upgrading from a release whose guardian installed
+	// its own dependencies at boot (pre-0.13.1) can still have root-owned
+	// entries under system/guardian/node_modules on their FIRST upgrade; a
+	// non-root CLI can rename that directory (needs only write on its parent)
+	// but cannot unlink files inside a root-owned subdirectory it doesn't own
+	// (#641). Failing the whole update here — after migrations already ran —
+	// for a leftover directory nothing reads again would turn a completed
+	// update into a reported failure. Warn, name the path, and move on; a
+	// stray `.system-previous-*` directory is inert and can be removed by hand
+	// (`sudo rm -rf`) or left for the next OS temp/disk cleanup.
+	try {
+		rmSync(previousRoot, { recursive: true, force: true });
+	} catch (error) {
+		logger.warn('could not remove the retired system/ tree copy after a successful update — leaving it in place', {
+			path: previousRoot,
+			error: errMessage(error)
+		});
+	}
 
 	return {
 		backupDir,

--- a/packages/lib/src/control-plane/docker.ts
+++ b/packages/lib/src/control-plane/docker.ts
@@ -2,7 +2,7 @@
 import { execFile, execFileSync, spawn } from "node:child_process";
 import { existsSync } from "node:fs";
 import { parseEnvFile } from "./env.js";
-import { mapDockerError } from "./compose-errors.js";
+import { mapDockerError, summarizeComposeStderr } from "./compose-errors.js";
 
 export type DockerResult = {
   ok: boolean;
@@ -1115,6 +1115,16 @@ export async function applyStack(
     }
     const started: string[] = [];
     const failed: { service: string; reason: string }[] = [];
+    // #644: `ps -a` gives us WHICH service didn't come up (the row/state
+    // below), but not WHY — that lives only in `upResult.stderr`, which this
+    // branch used to ignore entirely once `ps` returned any rows. A reapply
+    // (`kind: "all"`) that fails one service out of a mostly-healthy stack
+    // took this path and reported a templated "did not become healthy" with
+    // the real Docker daemon error (a port conflict, a networking failure,
+    // …) dropped on the floor. Fold the same summarized stderr line the
+    // `rows.length === 0` branch above already surfaces into each per-service
+    // reason too, so the underlying cause travels with it.
+    const composeErrorLine = summarizeComposeStderr(upResult.stderr);
     for (const svc of targetServices) {
       const row = rows.find((r) => r.service === svc);
       if (isComposePsRowHealthy(row)) {
@@ -1126,7 +1136,8 @@ export async function applyStack(
         : row.health === "unhealthy"
           ? `container ${svc} is unhealthy`
           : `container ${svc} did not become healthy (state: ${row.state || "unknown"})`;
-      failed.push({ service: svc, reason: mapDockerError(rawReason).message });
+      const reasonWithCause = composeErrorLine ? `${rawReason}: ${composeErrorLine}` : rawReason;
+      failed.push({ service: svc, reason: mapDockerError(reasonWithCause).message });
     }
     return {
       ok: false,

--- a/packages/lib/src/control-plane/home-schema.test.ts
+++ b/packages/lib/src/control-plane/home-schema.test.ts
@@ -44,40 +44,40 @@ function seedLegacyHome(): void {
 }
 
 describe('a fresh home runs no legacy migrations', () => {
-  test('ensureHomeDirs stamps a brand-new home as current', () => {
+  test('ensureHomeDirs stamps a brand-new home as current', async () => {
     ensureHomeDirs(homeDir);
     expect(readHomeSchemaVersion(homeDir)).toBe(HOME_SCHEMA_VERSION);
   });
 
-  test('runHomeMigrations does not touch stack.env on a fresh home', () => {
+  test('runHomeMigrations does not touch stack.env on a fresh home', async () => {
     ensureHomeDirs(homeDir);
     writeFileSync(legacyKnowledgeStackEnvFile(homeDir), 'OP_ASSISTANT_PORT=3810\nOP_UI_PORT=3800\n');
     const before = readFileSync(legacyKnowledgeStackEnvFile(homeDir), 'utf-8');
 
-    expect(runHomeMigrations(homeDir)).toBe(false);
+    expect(await runHomeMigrations(homeDir)).toBe(false);
     expect(readFileSync(legacyKnowledgeStackEnvFile(homeDir), 'utf-8')).toBe(before);
   });
 });
 
 describe('an absent install is left alone', () => {
-  test('a home with no stack env in any location is not migrated and not stamped', () => {
+  test('a home with no stack env in any location is not migrated and not stamped', async () => {
     // Read-only commands migrate before reading state, so this runs against
     // machines that have no install at all. It must not materialize state/.
-    expect(runHomeMigrations(homeDir)).toBe(false);
+    expect(await runHomeMigrations(homeDir)).toBe(false);
     expect(existsSync(homeSchemaVersionFile(homeDir))).toBe(false);
     expect(existsSync(stackEnvFile(homeDir))).toBe(false);
   });
 });
 
 describe('an existing home migrates exactly once', () => {
-  test('an unstamped legacy home is migrated, then recorded as current', () => {
+  test('an unstamped legacy home is migrated, then recorded as current', async () => {
     seedLegacyHome();
     // No stamp: ensureHomeDirs would have declined to write one because
     // stack.env already existed.
     ensureHomeDirs(homeDir);
     expect(existsSync(homeSchemaVersionFile(homeDir))).toBe(false);
 
-    expect(runHomeMigrations(homeDir)).toBe(true);
+    expect(await runHomeMigrations(homeDir)).toBe(true);
 
     // The port fix landed, and the file it landed in is the consolidated one.
     const migrated = readFileSync(stackEnvFile(homeDir), 'utf-8');
@@ -87,17 +87,17 @@ describe('an existing home migrates exactly once', () => {
     expect(readHomeSchemaVersion(homeDir)).toBe(HOME_SCHEMA_VERSION);
   });
 
-  test('a second run is a no-op and leaves the file byte-identical', () => {
+  test('a second run is a no-op and leaves the file byte-identical', async () => {
     seedLegacyHome();
     ensureHomeDirs(homeDir);
-    runHomeMigrations(homeDir);
+    await runHomeMigrations(homeDir);
     const afterFirst = readFileSync(stackEnvFile(homeDir), 'utf-8');
 
-    expect(runHomeMigrations(homeDir)).toBe(false);
+    expect(await runHomeMigrations(homeDir)).toBe(false);
     expect(readFileSync(stackEnvFile(homeDir), 'utf-8')).toBe(afterFirst);
   });
 
-  test('schema 5 migrates the persisted Paperclip signing key', () => {
+  test('schema 5 migrates the persisted Paperclip signing key', async () => {
     mkdirSync(join(homeDir, 'state'), { recursive: true });
     mkdirSync(join(homeDir, 'state', 'env'), { recursive: true });
     writeFileSync(stackEnvFile(homeDir), 'OP_ENABLED_ADDONS=paperclip\n');
@@ -107,21 +107,21 @@ describe('an existing home migrates exactly once', () => {
     );
     writeHomeSchemaVersion(homeDir, 5);
 
-    expect(runHomeMigrations(homeDir)).toBe(true);
+    expect(await runHomeMigrations(homeDir)).toBe(true);
     expect(readFileSync(join(homeDir, 'state', 'env', 'paperclip.env'), 'utf8')).toBe(
       'BETTER_AUTH_SECRET=auth\nPAPERCLIP_AGENT_JWT_SECRET=legacy\n',
     );
     expect(readHomeSchemaVersion(homeDir)).toBe(HOME_SCHEMA_VERSION);
   });
 
-  test('the two stack env files are merged into one, and the originals removed', () => {
+  test('the two stack env files are merged into one, and the originals removed', async () => {
     mkdirSync(join(homeDir, 'knowledge', 'env'), { recursive: true });
     mkdirSync(join(homeDir, 'state'), { recursive: true });
     writeFileSync(legacyKnowledgeStackEnvFile(homeDir), '# operator notes\nOP_OWNER_NAME=alice\nOP_UI_PORT=3800\n');
     writeFileSync(legacyStateEnvFile(homeDir), 'OP_UI_PORT=9999\nOP_ENABLED_ADDONS=slack\n');
     writeHomeSchemaVersion(homeDir, 1);
 
-    expect(runHomeMigrations(homeDir)).toBe(true);
+    expect(await runHomeMigrations(homeDir)).toBe(true);
 
     const merged = readFileSync(stackEnvFile(homeDir), 'utf-8');
     expect(merged).toContain('OP_OWNER_NAME=alice');
@@ -134,7 +134,7 @@ describe('an existing home migrates exactly once', () => {
     expect(existsSync(legacyStateEnvFile(homeDir))).toBe(false);
   });
 
-  test('a version in the knowledge file is dropped, because it recorded the last applied release rather than a pin', () => {
+  test('a version in the knowledge file is dropped, because it recorded the last applied release rather than a pin', async () => {
     mkdirSync(join(homeDir, 'knowledge', 'env'), { recursive: true });
     mkdirSync(join(homeDir, 'state'), { recursive: true });
     writeFileSync(
@@ -144,7 +144,7 @@ describe('an existing home migrates exactly once', () => {
     writeFileSync(legacyStateEnvFile(homeDir), 'OP_GUARDIAN_VERSION=0.13.0\n');
     writeHomeSchemaVersion(homeDir, 1);
 
-    runHomeMigrations(homeDir);
+    await runHomeMigrations(homeDir);
 
     const merged = readFileSync(stackEnvFile(homeDir), 'utf-8');
     // Promoting this would have frozen the install at its current image.
@@ -153,7 +153,7 @@ describe('an existing home migrates exactly once', () => {
     expect(merged).toContain('OP_GUARDIAN_VERSION=0.13.0');
   });
 
-  test('a bootstrap stub at the target never overrides the operator real state', () => {
+  test('a bootstrap stub at the target never overrides the operator real state', async () => {
     // ensureSystemSecrets writes state/stack.env with OP_SETUP_COMPLETE=false
     // whenever the file is absent — which, on a pre-consolidation home, is
     // every time. If that stub wins the merge, a fully-installed operator is
@@ -165,7 +165,7 @@ describe('an existing home migrates exactly once', () => {
     writeFileSync(stackEnvFile(homeDir), '# OpenPalm — Stack Configuration\nOP_SETUP_COMPLETE=false\nOP_ONLY_IN_STUB=keep\n');
     writeHomeSchemaVersion(homeDir, 1);
 
-    runHomeMigrations(homeDir);
+    await runHomeMigrations(homeDir);
 
     const merged = readFileSync(stackEnvFile(homeDir), 'utf-8');
     expect(merged).toContain('OP_SETUP_COMPLETE=true');
@@ -176,18 +176,18 @@ describe('an existing home migrates exactly once', () => {
     expect(merged).toContain('OP_ONLY_IN_STUB=keep');
   });
 
-  test('an unreadable version record is treated as pre-record, not as current', () => {
+  test('an unreadable version record is treated as pre-record, not as current', async () => {
     seedLegacyHome();
     ensureHomeDirs(homeDir);
     writeFileSync(homeSchemaVersionFile(homeDir), 'not-a-number\n');
 
     expect(readHomeSchemaVersion(homeDir)).toBe(0);
-    expect(runHomeMigrations(homeDir)).toBe(true);
+    expect(await runHomeMigrations(homeDir)).toBe(true);
   });
 });
 
 describe("retired skeleton files are removed from an upgraded home", () => {
-  test("deletes the moved opencode.jsonc pair and the three retired tasks, and nothing else", () => {
+  test("deletes the moved opencode.jsonc pair and the three retired tasks, and nothing else", async () => {
     // Seeding outside system/ is add-only, so a file a release DELETED stays
     // on every upgraded home. Both orphan sets were confirmed present on a
     // real install: the .jsonc pair is live-read USER config (the assistant's
@@ -214,7 +214,7 @@ describe("retired skeleton files are removed from an upgraded home", () => {
       // install, not an unmigrated one), so give it one.
       mkdirSync(join(home, "state"), { recursive: true });
       writeFileSync(join(home, "state", "stack.env"), "OP_SETUP_COMPLETE=true\n");
-      runHomeMigrations(home);
+      await runHomeMigrations(home);
 
       expect(existsSync(join(home, "config/assistant/opencode.jsonc"))).toBe(false);
       expect(existsSync(join(home, "config/guardian/opencode.jsonc"))).toBe(false);
@@ -229,7 +229,7 @@ describe("retired skeleton files are removed from an upgraded home", () => {
     }
   });
 
-  test("reports the files it actually deleted, not the candidate list", () => {
+  test("reports the files it actually deleted, not the candidate list", async () => {
     // This migration deletes without any modification check — unlike the skills
     // sweep, it never asks whether the operator edited the file first. Its log
     // line is therefore the ONLY record that something of theirs is gone, so it
@@ -250,7 +250,7 @@ describe("retired skeleton files are removed from an upgraded home", () => {
       mkdirSync(join(home, "state"), { recursive: true });
       writeFileSync(join(home, "state", "stack.env"), "OP_SETUP_COMPLETE=true\n");
 
-      runHomeMigrations(home);
+      await runHomeMigrations(home);
 
       const line = warnings.find((w) => w.includes("Removed retired skeleton files"));
       expect(line, "migration did not log a removal line").toBeTruthy();
@@ -281,10 +281,10 @@ describe('v7 → v8: the removed chat addon', () => {
   }
   const env = () => readFileSync(stackEnvFile(homeDir), 'utf-8');
 
-  test('chat as the only guardian reason: substituted with api, exposure untouched', () => {
+  test('chat as the only guardian reason: substituted with api, exposure untouched', async () => {
     seedV7Home('OP_ENABLED_ADDONS=chat\nOP_SETUP_COMPLETE=true\nOP_GUARDIAN_BIND_ADDRESS=127.0.0.1\n');
 
-    expect(runHomeMigrations(homeDir)).toBe(true);
+    expect(await runHomeMigrations(homeDir)).toBe(true);
 
     // The guardian (and its loopback OpenAI-compatible edge) keeps deploying —
     // via the api addon, which is visible and removable, with the install's
@@ -299,12 +299,12 @@ describe('v7 → v8: the removed chat addon', () => {
     expect(readHomeSchemaVersion(homeDir)).toBe(HOME_SCHEMA_VERSION);
   });
 
-  test('chat with the guardianNetwork toggle explicitly OFF: the opt-out is honored, api still substituted', () => {
+  test('chat with the guardianNetwork toggle explicitly OFF: the opt-out is honored, api still substituted', async () => {
     // The population main\'s auto-enable created: guardianNetwork turned on
     // (auto-enabling chat), later turned off — nothing ever disabled chat.
     seedV7Home('OP_ENABLED_ADDONS=chat\nOP_ACCESS_GUARDIAN=false\nOP_GUARDIAN_BIND_ADDRESS=127.0.0.1\nGUARDIAN_DIRECT_INGRESS=false\n');
 
-    expect(runHomeMigrations(homeDir)).toBe(true);
+    expect(await runHomeMigrations(homeDir)).toBe(true);
 
     expect(env()).toMatch(/^OP_ENABLED_ADDONS=api$/m);
     expect(env()).toMatch(/^OP_ACCESS_GUARDIAN=false$/m);
@@ -312,42 +312,42 @@ describe('v7 → v8: the removed chat addon', () => {
     expect(env()).toMatch(/^GUARDIAN_DIRECT_INGRESS=false$/m);
   });
 
-  test('chat beside another ingress addon: dropped with NO substitution and NO exposure change', () => {
+  test('chat beside another ingress addon: dropped with NO substitution and NO exposure change', async () => {
     seedV7Home('OP_ENABLED_ADDONS=chat,discord\nOP_GUARDIAN_BIND_ADDRESS=127.0.0.1\n');
 
-    expect(runHomeMigrations(homeDir)).toBe(true);
+    expect(await runHomeMigrations(homeDir)).toBe(true);
 
     expect(env()).toMatch(/^OP_ENABLED_ADDONS=discord$/m);
     expect(env()).not.toMatch(/^OP_ACCESS_GUARDIAN=true$/m);
     expect(env()).toMatch(/^OP_GUARDIAN_BIND_ADDRESS=127\.0\.0\.1$/m);
   });
 
-  test('chat with guardianNetwork already on: dropped, the toggle is reason enough', () => {
+  test('chat with guardianNetwork already on: dropped, the toggle is reason enough', async () => {
     seedV7Home(
       'OP_ENABLED_ADDONS=chat\nOP_ACCESS_GUARDIAN=true\nOP_GUARDIAN_BIND_ADDRESS=0.0.0.0\nGUARDIAN_DIRECT_INGRESS=true\n',
     );
 
-    expect(runHomeMigrations(homeDir)).toBe(true);
+    expect(await runHomeMigrations(homeDir)).toBe(true);
 
     expect(env()).not.toMatch(/\bchat\b/);
     expect(env()).toMatch(/^OP_ENABLED_ADDONS=$/m);
     expect(env()).toMatch(/^OP_ACCESS_GUARDIAN=true$/m);
   });
 
-  test('chat with a remote tunnel targeting the guardian: dropped, remote is reason enough', () => {
+  test('chat with a remote tunnel targeting the guardian: dropped, remote is reason enough', async () => {
     seedV7Home('OP_ENABLED_ADDONS=chat,remote\nOP_REMOTE_TARGET=guardian\n');
 
-    expect(runHomeMigrations(homeDir)).toBe(true);
+    expect(await runHomeMigrations(homeDir)).toBe(true);
 
     expect(env()).toMatch(/^OP_ENABLED_ADDONS=remote$/m);
     expect(env()).not.toMatch(/^OP_ACCESS_GUARDIAN=true$/m);
   });
 
-  test('a v7 home without chat is a no-op that still stamps v8', () => {
+  test('a v7 home without chat is a no-op that still stamps v8', async () => {
     seedV7Home('OP_ENABLED_ADDONS=discord\n');
     const before = env();
 
-    expect(runHomeMigrations(homeDir)).toBe(false);
+    expect(await runHomeMigrations(homeDir)).toBe(false);
 
     expect(env()).toBe(before);
     expect(readHomeSchemaVersion(homeDir)).toBe(HOME_SCHEMA_VERSION);
@@ -369,10 +369,10 @@ describe('schema 9 → 10: the OP_HOME layout change', () => {
     writeHomeSchemaVersion(homeDir, 9);
   }
 
-  test('credentials move to state/, and the emptied private/ tree is removed', () => {
+  test('credentials move to state/, and the emptied private/ tree is removed', async () => {
     seedV9Home();
 
-    expect(runHomeMigrations(homeDir)).toBe(true);
+    expect(await runHomeMigrations(homeDir)).toBe(true);
 
     expect(readFileSync(join(homeDir, 'state', 'secrets', 'op_ui_login_password'), 'utf8')).toBe('hunter2\n');
     expect(readFileSync(join(homeDir, 'state', 'secrets', 'ts_authkey'), 'utf8')).toBe('tskey-abc\n');
@@ -381,12 +381,12 @@ describe('schema 9 → 10: the OP_HOME layout change', () => {
     expect(readHomeSchemaVersion(homeDir)).toBe(HOME_SCHEMA_VERSION);
   });
 
-  test('a name present in BOTH locations with different content leaves both alone', () => {
+  test('a name present in BOTH locations with different content leaves both alone', async () => {
     seedV9Home();
     mkdirSync(join(homeDir, 'state', 'secrets'), { recursive: true });
     writeFileSync(join(homeDir, 'state', 'secrets', 'ts_authkey'), 'tskey-different\n');
 
-    runHomeMigrations(homeDir);
+    await runHomeMigrations(homeDir);
 
     // Neither version of a credential is discarded to resolve a conflict.
     expect(readFileSync(join(homeDir, 'private', 'secrets', 'ts_authkey'), 'utf8')).toBe('tskey-abc\n');
@@ -396,33 +396,33 @@ describe('schema 9 → 10: the OP_HOME layout change', () => {
     expect(existsSync(join(homeDir, 'private', 'secrets', 'op_ui_login_password'))).toBe(false);
   });
 
-  test('identical content in both locations completes the interrupted move', () => {
+  test('identical content in both locations completes the interrupted move', async () => {
     seedV9Home();
     mkdirSync(join(homeDir, 'state', 'secrets'), { recursive: true });
     writeFileSync(join(homeDir, 'state', 'secrets', 'ts_authkey'), 'tskey-abc\n');
 
-    runHomeMigrations(homeDir);
+    await runHomeMigrations(homeDir);
 
     expect(existsSync(join(homeDir, 'private'))).toBe(false);
     expect(readFileSync(join(homeDir, 'state', 'secrets', 'ts_authkey'), 'utf8')).toBe('tskey-abc\n');
   });
 
-  test('the always-empty knowledge/paperclip overlay dirs are removed', () => {
+  test('the always-empty knowledge/paperclip overlay dirs are removed', async () => {
     seedV9Home();
     mkdirSync(join(homeDir, 'knowledge', 'paperclip', 'env'), { recursive: true });
     mkdirSync(join(homeDir, 'knowledge', 'paperclip', 'secrets'), { recursive: true });
 
-    runHomeMigrations(homeDir);
+    await runHomeMigrations(homeDir);
 
     expect(existsSync(join(homeDir, 'knowledge', 'paperclip'))).toBe(false);
   });
 
-  test('an operator file under the retired overlay keeps its directory', () => {
+  test('an operator file under the retired overlay keeps its directory', async () => {
     seedV9Home();
     mkdirSync(join(homeDir, 'knowledge', 'paperclip', 'secrets'), { recursive: true });
     writeFileSync(join(homeDir, 'knowledge', 'paperclip', 'secrets', 'mine.txt'), 'keep\n');
 
-    runHomeMigrations(homeDir);
+    await runHomeMigrations(homeDir);
 
     expect(readFileSync(join(homeDir, 'knowledge', 'paperclip', 'secrets', 'mine.txt'), 'utf8')).toBe('keep\n');
   });
@@ -430,12 +430,12 @@ describe('schema 9 → 10: the OP_HOME layout change', () => {
   // The stash-skill dedup is NOT a migration: it needs the shipped tree to
   // compare against, so it runs from applyHomeSeed (see ui-assets.test.ts).
 
-  test('a home with none of the retired trees reports no change but is still stamped current', () => {
+  test('a home with none of the retired trees reports no change but is still stamped current', async () => {
     mkdirSync(join(homeDir, 'state'), { recursive: true });
     writeFileSync(stackEnvFile(homeDir), 'OP_SETUP_COMPLETE=true\n');
     writeHomeSchemaVersion(homeDir, 9);
 
-    expect(runHomeMigrations(homeDir)).toBe(false);
+    expect(await runHomeMigrations(homeDir)).toBe(false);
     expect(readHomeSchemaVersion(homeDir)).toBe(HOME_SCHEMA_VERSION);
   });
 });
@@ -467,35 +467,35 @@ describe('schema 10 → 11: the versionless retired task files', () => {
 
   const tasks = () => readdirSync(join(homeDir, 'knowledge', 'tasks')).sort();
 
-  test('the three versionless files go, and the home is stamped current', () => {
+  test('the three versionless files go, and the home is stamped current', async () => {
     seedV10Home();
     // A shipped task that akm still accepts must survive.
     writeFileSync(join(homeDir, 'knowledge', 'tasks', 'akm-improve.yml'), 'version: 4\nname: improve\n');
 
-    expect(runHomeMigrations(homeDir)).toBe(true);
+    expect(await runHomeMigrations(homeDir)).toBe(true);
 
     expect(tasks()).toEqual(['akm-improve.yml']);
     expect(readHomeSchemaVersion(homeDir)).toBe(HOME_SCHEMA_VERSION);
   });
 
-  test('the opencode.jsonc pair is deliberately NOT re-swept on a home stamped 10', () => {
+  test('the opencode.jsonc pair is deliberately NOT re-swept on a home stamped 10', async () => {
     // Only the task files break anything (they take down akm's whole scheduler
     // sync). These two are stale, not broken, and they live in the tree the
     // operator owns and edits — so this entry does not blind-delete there.
     seedV10Home();
 
-    runHomeMigrations(homeDir);
+    await runHomeMigrations(homeDir);
 
     expect(readFileSync(join(homeDir, 'config', 'assistant', 'opencode.jsonc'), 'utf8')).toBe(
       '{"plugin":[]}\n',
     );
   });
 
-  test("an operator's own task file is untouched", () => {
+  test("an operator's own task file is untouched", async () => {
     seedV10Home();
     writeFileSync(join(homeDir, 'knowledge', 'tasks', 'wiki-ingestion.yml'), 'version: 2\nname: wiki\n');
 
-    runHomeMigrations(homeDir);
+    await runHomeMigrations(homeDir);
 
     expect(readFileSync(join(homeDir, 'knowledge', 'tasks', 'wiki-ingestion.yml'), 'utf8')).toBe(
       'version: 2\nname: wiki\n',
@@ -503,7 +503,7 @@ describe('schema 10 → 11: the versionless retired task files', () => {
     expect(tasks()).toEqual(['wiki-ingestion.yml']);
   });
 
-  test("an operator's own task AT one of the three retired names is deleted too", () => {
+  test("an operator's own task AT one of the three retired names is deleted too", async () => {
     // Pinning the collision, not endorsing it: the sweep matches on filename
     // with no modification check, so a task the operator wrote at one of these
     // three names goes with the retired seed. Nothing on disk distinguishes
@@ -513,22 +513,22 @@ describe('schema 10 → 11: the versionless retired task files', () => {
     seedV10Home();
     writeFileSync(join(homeDir, 'knowledge', 'tasks', 'health-check.yml'), 'version: 2\nname: mine\n');
 
-    runHomeMigrations(homeDir);
+    await runHomeMigrations(homeDir);
 
     expect(tasks()).toEqual([]);
   });
 
-  test('re-running removes nothing and reports no change', () => {
+  test('re-running removes nothing and reports no change', async () => {
     seedV10Home();
     writeFileSync(join(homeDir, 'knowledge', 'tasks', 'wiki-ingestion.yml'), 'version: 2\nname: wiki\n');
-    runHomeMigrations(homeDir);
+    await runHomeMigrations(homeDir);
     const afterFirst = tasks();
 
     // The gate stops the second call outright.
-    expect(runHomeMigrations(homeDir)).toBe(false);
+    expect(await runHomeMigrations(homeDir)).toBe(false);
     // And the sweep itself is a no-op when re-armed against an already-clean home.
     writeHomeSchemaVersion(homeDir, 10);
-    expect(runHomeMigrations(homeDir)).toBe(false);
+    expect(await runHomeMigrations(homeDir)).toBe(false);
     expect(tasks()).toEqual(afterFirst);
   });
 });

--- a/packages/lib/src/control-plane/home-schema.test.ts
+++ b/packages/lib/src/control-plane/home-schema.test.ts
@@ -97,6 +97,45 @@ describe('an existing home migrates exactly once', () => {
     expect(readFileSync(stackEnvFile(homeDir), 'utf-8')).toBe(afterFirst);
   });
 
+  // issue #643 follow-up: a rollback can restore state/schema-version
+  // alongside a pre-rollback stack.env, so an operator's post-rollback hand
+  // edit to the CONSOLIDATED state/stack.env sits there while schema-version
+  // reads 0 and knowledge/env/stack.env (never deleted by the failed update)
+  // still carries no ports. The next runHomeMigrations then re-runs the whole
+  // chain from since:0: migrateLegacyDefaultPorts used to probe a FRESH
+  // default for the legacy file with no regard for the explicit value already
+  // sitting in state/stack.env, and migrateToSingleStackEnv's target-only-key
+  // merge only preserves a target key the legacy-derived merge does NOT
+  // already define — so that freshly-probed default silently beat the
+  // operator's real, explicit value.
+  test("an operator's explicit consolidated ports survive a schema-version reset to 0, even when a sibling instance occupies the corrected default", async () => {
+    seedLegacyHome();
+    // Overwrite the legacy seed: neither port is set there at all (the shape
+    // that makes migrateLegacyDefaultPorts probe for fresh defaults).
+    writeFileSync(legacyKnowledgeStackEnvFile(homeDir), 'OP_PROJECT_NAME=verify643\nOP_ENABLED_ADDONS=\n');
+    mkdirSync(join(homeDir, 'state'), { recursive: true });
+    writeFileSync(
+      stackEnvFile(homeDir),
+      'OP_PROJECT_NAME=verify643\nOP_ASSISTANT_PORT=3812\nOP_UI_PORT=3802\n',
+    );
+    writeHomeSchemaVersion(homeDir, 0);
+
+    // A sibling OpenPalm instance already holding the corrected default —
+    // proves the fix carries the operator's value over rather than merely
+    // probing past the collision onto some OTHER value.
+    const server = Bun.serve({ port: 3810, hostname: '127.0.0.1', fetch: () => new Response('sibling') });
+    try {
+      expect(await runHomeMigrations(homeDir)).toBe(true);
+    } finally {
+      server.stop(true);
+    }
+
+    const migrated = readFileSync(stackEnvFile(homeDir), 'utf-8');
+    expect(migrated).toContain('OP_ASSISTANT_PORT=3812');
+    expect(migrated).toContain('OP_UI_PORT=3802');
+    expect(readHomeSchemaVersion(homeDir)).toBe(HOME_SCHEMA_VERSION);
+  });
+
   test('schema 5 migrates the persisted Paperclip signing key', async () => {
     mkdirSync(join(homeDir, 'state'), { recursive: true });
     mkdirSync(join(homeDir, 'state', 'env'), { recursive: true });

--- a/packages/lib/src/control-plane/home-schema.ts
+++ b/packages/lib/src/control-plane/home-schema.ts
@@ -335,7 +335,7 @@ function migrateOpHomeLayout(homeDir: string): boolean {
  * consolidation; `migrateProfileOnlyAddonEnablement` reads the *effective*
  * env and writes the app-owned record, so it must follow it.
  */
-const MIGRATIONS: { since: number; run: (homeDir: string) => boolean }[] = [
+const MIGRATIONS: { since: number; run: (homeDir: string) => boolean | Promise<boolean> }[] = [
   // Layout: private/ → state/, plus the skeleton tree this release retired.
   // FIRST on purpose — see the docblock for why the credential move has to
   // precede the two knowledge/secrets sweeps below.
@@ -403,8 +403,13 @@ const MIGRATIONS: { since: number; run: (homeDir: string) => boolean }[] = [
  *
  * Returns whether anything actually changed on disk. An up-to-date home reads
  * one small file and returns — it never touches stack.env.
+ *
+ * Async because the port-default migrations (issue #643) probe host-wide
+ * port availability before writing a value the operator never set; every
+ * other migration here stays synchronous and simply resolves immediately
+ * under the `await`.
  */
-export function runHomeMigrations(homeDir: string): boolean {
+export async function runHomeMigrations(homeDir: string): Promise<boolean> {
   const recorded = readHomeSchemaVersion(homeDir);
   if (recorded >= HOME_SCHEMA_VERSION) return false;
 
@@ -417,7 +422,7 @@ export function runHomeMigrations(homeDir: string): boolean {
   let changed = false;
   for (const migration of MIGRATIONS) {
     if (migration.since < recorded) continue;
-    if (migration.run(homeDir)) changed = true;
+    if (await migration.run(homeDir)) changed = true;
   }
 
   writeHomeSchemaVersion(homeDir, HOME_SCHEMA_VERSION);

--- a/packages/lib/src/control-plane/home-version-skew-lifecycle.test.ts
+++ b/packages/lib/src/control-plane/home-version-skew-lifecycle.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Regression tests for #636 at the lifecycle entry points: `applyInstall`,
+ * `applyUpdate`, and `performUpgrade` must refuse a home stamped newer than
+ * the running app BEFORE doing any work — no ownership reconcile, no backup,
+ * no Docker call, nothing. That "before any work" property is what a plain
+ * unit test on `detectHomeVersionSkew` (home-version-skew.test.ts) cannot
+ * prove by itself; these tests mock the first write/Docker call each entry
+ * point would otherwise make and assert it is never reached.
+ *
+ * `reconcileHostOwnership`/`backupOpenPalmHome`/the Docker client are
+ * statically imported by lifecycle.ts, so — mirroring
+ * lifecycle-install-ownership.test.ts and lifecycle-rollback-pin.test.ts —
+ * each test mocks the relevant module via `mock.module` and re-imports
+ * lifecycle.ts with a cache-busting query.
+ */
+import { afterEach, describe, expect, mock, test } from 'bun:test';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import * as realOwnershipReconcile from './ownership-reconcile.js';
+import * as realBackup from './backup.js';
+import * as realDocker from './docker.js';
+import * as realActivation from './activation.js';
+import { SKELETON_VERSION_STAMP } from './ui-assets.js';
+
+const realReconcileHostOwnership = realOwnershipReconcile.reconcileHostOwnership;
+const realBackupOpenPalmHome = realBackup.backupOpenPalmHome;
+const realDockerClient = realDocker.realDockerClient;
+const realActivateStack = realActivation.activateStack;
+
+// mock.module() is NOT undone by mock.restore() and leaks across test files
+// sharing this bun test process — always re-point back to the real
+// implementation afterward (same pattern as lifecycle-install-ownership.test.ts
+// / lifecycle-rollback-pin.test.ts).
+afterEach(() => {
+	mock.restore();
+	mock.module('./ownership-reconcile.js', () => ({
+		...realOwnershipReconcile,
+		reconcileHostOwnership: realReconcileHostOwnership
+	}));
+	mock.module('./backup.js', () => ({ ...realBackup, backupOpenPalmHome: realBackupOpenPalmHome }));
+	mock.module('./docker.js', () => ({ ...realDocker, realDockerClient: realDockerClient }));
+	mock.module('./activation.js', () => ({ ...realActivation, activateStack: realActivateStack }));
+});
+
+function withEnv(homeDir: string, run: () => Promise<void>): Promise<void> {
+	const saved = {
+		OP_HOME: process.env.OP_HOME,
+		OP_SKIP_COMPOSE_PREFLIGHT: process.env.OP_SKIP_COMPOSE_PREFLIGHT,
+		OP_SKIP_OWNERSHIP_RECONCILE: process.env.OP_SKIP_OWNERSHIP_RECONCILE
+	};
+	process.env.OP_HOME = homeDir;
+	process.env.OP_SKIP_COMPOSE_PREFLIGHT = '1';
+	delete process.env.OP_SKIP_OWNERSHIP_RECONCILE;
+	return run().finally(() => {
+		for (const [key, value] of Object.entries(saved)) {
+			if (value === undefined) delete process.env[key as keyof NodeJS.ProcessEnv];
+			else process.env[key as keyof NodeJS.ProcessEnv] = value;
+		}
+	});
+}
+
+describe('applyInstall refuses a home stamped newer than this app, before any write (#636)', () => {
+	test('never calls reconcileHostOwnership and never creates system/', async () => {
+		const homeDir = mkdtempSync(join(tmpdir(), 'openpalm-skew-install-'));
+		try {
+			// A home someone already seeded (e.g. a partially-run newer install, or
+			// a copied-over OP_HOME) at a version ahead of the code running now.
+			mkdirSync(homeDir, { recursive: true });
+			writeFileSync(join(homeDir, SKELETON_VERSION_STAMP), '99.0.0\n');
+
+			await withEnv(homeDir, async () => {
+				const reconcileHostOwnershipMock = mock(async () => {});
+				mock.module('./ownership-reconcile.js', () => ({
+					...realOwnershipReconcile,
+					reconcileHostOwnership: reconcileHostOwnershipMock
+				}));
+
+				const { applyInstall, createState } = await import(
+					`./lifecycle.js?skew-install-test=${Math.random()}`
+				);
+				const state = createState();
+
+				await expect(applyInstall(state)).rejects.toThrow(/99\.0\.0/);
+				expect(reconcileHostOwnershipMock).not.toHaveBeenCalled();
+				// The managed tree was never written — this build's skeleton never
+				// overwrote the newer home's.
+				expect(existsSync(join(homeDir, 'system'))).toBe(false);
+			});
+		} finally {
+			rmSync(homeDir, { recursive: true, force: true });
+		}
+	});
+});
+
+describe('applyUpdate refuses a home stamped newer than this app, before any write (#636)', () => {
+	test('never calls backupOpenPalmHome and leaves .skeleton-version untouched', async () => {
+		const homeDir = mkdtempSync(join(tmpdir(), 'openpalm-skew-update-'));
+		try {
+			mkdirSync(join(homeDir, 'state'), { recursive: true });
+			mkdirSync(join(homeDir, 'system'), { recursive: true });
+			writeFileSync(join(homeDir, 'state', 'stack.env'), 'OP_SETUP_COMPLETE=true\n');
+			writeFileSync(join(homeDir, SKELETON_VERSION_STAMP), '99.0.0\n');
+
+			await withEnv(homeDir, async () => {
+				const backupOpenPalmHomeMock = mock(() => null);
+				mock.module('./backup.js', () => ({ ...realBackup, backupOpenPalmHome: backupOpenPalmHomeMock }));
+
+				const { applyUpdate, createState } = await import(
+					`./lifecycle.js?skew-update-test=${Math.random()}`
+				);
+				const state = createState();
+
+				await expect(applyUpdate(state)).rejects.toThrow(/99\.0\.0/);
+				expect(backupOpenPalmHomeMock).not.toHaveBeenCalled();
+				expect(readFileSync(join(homeDir, SKELETON_VERSION_STAMP), 'utf-8').trim()).toBe('99.0.0');
+			});
+		} finally {
+			rmSync(homeDir, { recursive: true, force: true });
+		}
+	});
+});
+
+describe('performUpgrade refuses a home stamped newer than this app, before any Docker call (#636)', () => {
+	test('never calls captureRunningImageIds / activateStack', async () => {
+		const homeDir = mkdtempSync(join(tmpdir(), 'openpalm-skew-upgrade-'));
+		try {
+			mkdirSync(join(homeDir, 'state'), { recursive: true });
+			mkdirSync(join(homeDir, 'system'), { recursive: true });
+			writeFileSync(join(homeDir, 'state', 'stack.env'), 'OP_SETUP_COMPLETE=true\n');
+			writeFileSync(join(homeDir, SKELETON_VERSION_STAMP), '99.0.0\n');
+
+			await withEnv(homeDir, async () => {
+				const dockerRunMock = mock(async () => ({ ok: true, stdout: '', stderr: '', code: 0 }));
+				const activateStackMock = mock(async () => ({ ok: true }));
+				mock.module('./docker.js', () => ({ ...realDocker, realDockerClient: { run: dockerRunMock } }));
+				mock.module('./activation.js', () => ({ ...realActivation, activateStack: activateStackMock }));
+
+				const { performUpgrade, createState } = await import(
+					`./lifecycle.js?skew-upgrade-test=${Math.random()}`
+				);
+				const state = createState();
+
+				await expect(performUpgrade(state)).rejects.toThrow(/99\.0\.0/);
+				expect(dockerRunMock).not.toHaveBeenCalled();
+				expect(activateStackMock).not.toHaveBeenCalled();
+			});
+		} finally {
+			rmSync(homeDir, { recursive: true, force: true });
+		}
+	});
+});

--- a/packages/lib/src/control-plane/home-version-skew.test.ts
+++ b/packages/lib/src/control-plane/home-version-skew.test.ts
@@ -1,0 +1,174 @@
+/**
+ * Regression tests for #636: nothing compared a home's recorded version
+ * stamps (`.skeleton-version`, `state/schema-version`) against the code
+ * running now before writing to it, so an older app pointed at a home a
+ * newer app had already upgraded silently downgraded it — advancing version
+ * pins to its own older PLATFORM_VERSION, overwriting the managed `system/`
+ * tree, and re-stamping `.skeleton-version` backwards.
+ *
+ * `detectHomeVersionSkew`/`assertHomeNotNewerThanApp` (versions.ts) are the
+ * one guard both `clearRollbackPins` and lifecycle.ts's entry points now
+ * check first. This file unit-tests the guard itself and proves
+ * `clearRollbackPins` refuses instead of downgrading; lifecycle.test.ts-style
+ * coverage for the install/update/upgrade entry points lives in
+ * home-version-skew-lifecycle.test.ts (mocks Docker, so it belongs beside the
+ * other lifecycle mock-module tests).
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import { mkdtempSync, mkdirSync, readFileSync, writeFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import {
+	assertHomeNotNewerThanApp,
+	clearRollbackPins,
+	detectHomeVersionSkew
+} from './versions.js';
+import type { ControlPlaneState } from './types.js';
+import { PLATFORM_VERSION } from './versioning.js';
+import { SKELETON_VERSION_STAMP } from './ui-assets.js';
+import { HOME_SCHEMA_VERSION, homeSchemaVersionFile } from './home.js';
+
+// ── Harness ──────────────────────────────────────────────────────────────────
+
+function makeState(): { state: ControlPlaneState; cleanup: () => void } {
+	const homeDir = mkdtempSync(join(tmpdir(), 'op-version-skew-test-'));
+	mkdirSync(join(homeDir, 'state'), { recursive: true });
+	const state: ControlPlaneState = {
+		homeDir,
+		stackDir: join(homeDir, 'system', 'stack'),
+		stashDir: join(homeDir, 'knowledge'),
+		configDir: join(homeDir, 'config'),
+		dataDir: join(homeDir, 'data'),
+		workspaceDir: join(homeDir, 'workspace'),
+		services: {},
+		artifacts: { compose: '' },
+		artifactMeta: []
+	};
+	return { state, cleanup: () => rmSync(homeDir, { recursive: true, force: true }) };
+}
+
+function stampSkeletonVersion(homeDir: string, version: string): void {
+	writeFileSync(join(homeDir, SKELETON_VERSION_STAMP), `${version}\n`);
+}
+
+function stampSchemaVersion(homeDir: string, version: number): void {
+	writeFileSync(homeSchemaVersionFile(homeDir), `${version}\n`);
+}
+
+describe('detectHomeVersionSkew (#636)', () => {
+	let home: ReturnType<typeof makeState>;
+	beforeEach(() => {
+		home = makeState();
+	});
+	afterEach(() => home.cleanup());
+
+	it('reports no skew when .skeleton-version is absent (fresh install)', () => {
+		const skew = detectHomeVersionSkew(home.state);
+		expect(skew.newer).toBe(false);
+		expect(skew.homeSkeletonVersion).toBeNull();
+	});
+
+	it('reports no skew for a non-semver stamp (very old / hand-edited home)', () => {
+		stampSkeletonVersion(home.state.homeDir, 'not-a-version');
+		const skew = detectHomeVersionSkew(home.state);
+		expect(skew.newer).toBe(false);
+	});
+
+	it('reports no skew when the home is older than the running app', () => {
+		stampSkeletonVersion(home.state.homeDir, '0.1.0');
+		expect(detectHomeVersionSkew(home.state).newer).toBe(false);
+	});
+
+	it('reports no skew when the home matches the running app exactly', () => {
+		stampSkeletonVersion(home.state.homeDir, PLATFORM_VERSION);
+		expect(detectHomeVersionSkew(home.state).newer).toBe(false);
+	});
+
+	it('reports skew when .skeleton-version is a newer patch than the running app', () => {
+		stampSkeletonVersion(home.state.homeDir, '99.0.0');
+		const skew = detectHomeVersionSkew(home.state);
+		expect(skew.newer).toBe(true);
+		expect(skew.homeSkeletonVersion).toBe('99.0.0');
+		expect(skew.runningPlatformVersion).toBe(PLATFORM_VERSION);
+	});
+
+	it('reports skew from state/schema-version alone, even with no .skeleton-version stamp', () => {
+		stampSchemaVersion(home.state.homeDir, HOME_SCHEMA_VERSION + 1);
+		const skew = detectHomeVersionSkew(home.state);
+		expect(skew.newer).toBe(true);
+		expect(skew.homeSchemaVersion).toBe(HOME_SCHEMA_VERSION + 1);
+	});
+
+	it('does not flag skew from an EQUAL or lower schema-version', () => {
+		stampSchemaVersion(home.state.homeDir, HOME_SCHEMA_VERSION);
+		expect(detectHomeVersionSkew(home.state).newer).toBe(false);
+	});
+});
+
+describe('assertHomeNotNewerThanApp (#636)', () => {
+	let home: ReturnType<typeof makeState>;
+	beforeEach(() => {
+		home = makeState();
+	});
+	afterEach(() => home.cleanup());
+
+	it('is a no-op when the home is not newer than the running app', () => {
+		stampSkeletonVersion(home.state.homeDir, '0.1.0');
+		expect(() => assertHomeNotNewerThanApp(home.state)).not.toThrow();
+	});
+
+	it('throws an actionable message naming both versions when the home is newer', () => {
+		stampSkeletonVersion(home.state.homeDir, '0.99.0');
+		expect(() => assertHomeNotNewerThanApp(home.state)).toThrow(
+			/0\.99\.0.*0\.13\.0|OpenPalm 0\.99\.0/
+		);
+		try {
+			assertHomeNotNewerThanApp(home.state);
+			throw new Error('expected assertHomeNotNewerThanApp to throw');
+		} catch (err) {
+			const message = err instanceof Error ? err.message : String(err);
+			expect(message).toContain('0.99.0');
+			expect(message).toContain(PLATFORM_VERSION);
+			expect(message).toMatch(/refus/i);
+		}
+	});
+});
+
+describe('clearRollbackPins refuses on a newer home instead of downgrading it (#636)', () => {
+	let home: ReturnType<typeof makeState>;
+	beforeEach(() => {
+		home = makeState();
+	});
+	afterEach(() => home.cleanup());
+
+	it('THE BUG (would pass on unfixed code): clearing a rollback pin on a home stamped newer than this app must refuse, not advance the pin to this app\'s own older version', () => {
+		writeFileSync(
+			join(home.state.homeDir, 'state', 'stack.env'),
+			'OP_ASSISTANT_VERSION=rollback-generation-1700000000-1234-1\n' +
+				'OP_GUARDIAN_VERSION=0.99.0\n' +
+				'OP_MANAGED_GUARDIAN_VERSION=0.99.0\n'
+		);
+		// Written by a build ahead of this one — e.g. a desktop app stuck on an
+		// old version (#635) pointed at a home a newer app already upgraded.
+		stampSkeletonVersion(home.state.homeDir, '0.99.0');
+
+		expect(() => clearRollbackPins(home.state)).toThrow(/0\.99\.0/);
+
+		// Refused BEFORE writing anything: the rollback pin is exactly as it was,
+		// not silently advanced to this (older) build's PLATFORM_VERSION.
+		const content = readFileSync(join(home.state.homeDir, 'state', 'stack.env'), 'utf-8');
+		expect(content).toContain('OP_ASSISTANT_VERSION=rollback-generation-1700000000-1234-1');
+		expect(content).not.toContain(`OP_ASSISTANT_VERSION=${PLATFORM_VERSION}`);
+	});
+
+	it('still clears the pin normally once the home is not newer than this app', () => {
+		writeFileSync(
+			join(home.state.homeDir, 'state', 'stack.env'),
+			'OP_ASSISTANT_VERSION=rollback-generation-1700000000-1234-1\n'
+		);
+		stampSkeletonVersion(home.state.homeDir, PLATFORM_VERSION);
+
+		const { cleared } = clearRollbackPins(home.state);
+		expect(cleared.OP_ASSISTANT_VERSION?.to).toBe(PLATFORM_VERSION);
+	});
+});

--- a/packages/lib/src/control-plane/lifecycle-rollback-pin.test.ts
+++ b/packages/lib/src/control-plane/lifecycle-rollback-pin.test.ts
@@ -1,0 +1,167 @@
+/**
+ * Regression test for #639: a failed `performUpgrade` re-tags the running
+ * images as `<namespace>/<service>:rollback-generation-<id>` and pins
+ * `state/stack.env` to them (restoreRunningImageIds, image-snapshots.ts, run
+ * as `performUpgrade`'s snapshot-rollback `preserveImages` callback). The
+ * ONLY code that ever clears a `rollback-` pin, `advanceManagedImageVersions`,
+ * runs earlier in the SAME attempt (applyManagedFiles, before activateStack)
+ * — so on every repeated failure the sequence is unpin -> attempt -> fail ->
+ * re-pin to a NEW generation. Before the fix there was no supported,
+ * non-hand-editing way to break that cycle.
+ *
+ * This reproduces N (3) consecutive failed `performUpgrade` calls, asserts
+ * the stack stays pinned to the Nth rollback generation the whole time (the
+ * bug), then proves `clearRollbackPins` (the shared function behind
+ * `openpalm unpin` and the admin UI's clear action) is a supported way off
+ * the pin.
+ *
+ * `activateStack`/`applyStack` and the low-level `DockerClient` used by
+ * captureRunningImageIds/restoreRunningImageIds are statically imported by
+ * lifecycle.ts, so this test mocks them via `mock.module` and re-imports
+ * lifecycle.ts with a cache-busting query — the same pattern used by
+ * lifecycle-volume-reap.test.ts / lifecycle-install-ownership.test.ts.
+ */
+import { afterEach, describe, expect, mock, test } from 'bun:test';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import * as realDocker from './docker.js';
+import * as realActivation from './activation.js';
+import { readVersions, SERVICE_VERSION_KEYS, clearRollbackPins } from './versions.js';
+
+const realActivateStack = realActivation.activateStack;
+const realDockerClient = realDocker.realDockerClient;
+
+// mock.module() is NOT undone by mock.restore() and leaks across test files
+// sharing this bun test process — always re-point back to the real
+// implementation afterward (mirrors lifecycle-volume-reap.test.ts's comment).
+afterEach(() => {
+	mock.restore();
+	mock.module('./docker.js', () => ({ ...realDocker, realDockerClient: realDockerClient }));
+	mock.module('./activation.js', () => ({ ...realActivation, activateStack: realActivateStack }));
+});
+
+function withUpgradeEnv(homeDir: string, run: () => Promise<void>): Promise<void> {
+	const saved = {
+		OP_HOME: process.env.OP_HOME,
+		OP_SKIP_COMPOSE_PREFLIGHT: process.env.OP_SKIP_COMPOSE_PREFLIGHT,
+		OP_SKIP_OWNERSHIP_RECONCILE: process.env.OP_SKIP_OWNERSHIP_RECONCILE
+	};
+	process.env.OP_HOME = homeDir;
+	process.env.OP_SKIP_COMPOSE_PREFLIGHT = '1';
+	process.env.OP_SKIP_OWNERSHIP_RECONCILE = '1';
+	return run().finally(() => {
+		for (const [key, value] of Object.entries(saved)) {
+			if (value === undefined) delete process.env[key as keyof NodeJS.ProcessEnv];
+			else process.env[key as keyof NodeJS.ProcessEnv] = value;
+		}
+	});
+}
+
+/** Container ids -> the running image each one reports, keyed by compose service. */
+const RUNNING_CONTAINERS: Record<string, { image: string; service: string }> = {
+	'cid-assistant': { image: 'openpalm/assistant:0.13.0', service: 'assistant' },
+	'cid-guardian': { image: 'openpalm/guardian:0.13.0', service: 'guardian' },
+	'cid-portal': { image: 'openpalm/portal:0.13.0', service: 'portal' }
+};
+
+/** A fake DockerClient standing in for the real `docker compose`/`docker inspect`/`docker image tag` calls. */
+function fakeDockerClient() {
+	return {
+		run: mock(async (args: string[]) => {
+			// `compose ... ps -q` — report one running container per core/managed service.
+			if (args.includes('ps') && args.at(-1) === '-q') {
+				return { ok: true, stdout: `${Object.keys(RUNNING_CONTAINERS).join('\n')}\n`, stderr: '', code: 0 };
+			}
+			// `docker inspect --format {{json .}} <id> <id> ...`
+			if (args[0] === 'inspect') {
+				const ids = args.slice(3);
+				const lines = ids.map((id, i) => {
+					const row = RUNNING_CONTAINERS[id];
+					return JSON.stringify({
+						Image: `sha256:${'a'.repeat(63)}${i}`,
+						Config: { Image: row.image, Labels: { 'com.docker.compose.service': row.service } }
+					});
+				});
+				return { ok: true, stdout: `${lines.join('\n')}\n`, stderr: '', code: 0 };
+			}
+			// `docker image tag <id> <ref>` — the rollback re-tag itself.
+			if (args[0] === 'image' && args[1] === 'tag') {
+				return { ok: true, stdout: '', stderr: '', code: 0 };
+			}
+			return { ok: true, stdout: '', stderr: '', code: 0 };
+		})
+	};
+}
+
+describe('a repeatedly failing performUpgrade never releases its own rollback pin (#639)', () => {
+	test('3 consecutive failed upgrades leave the stack pinned to the 3rd rollback generation, with no supported non-UI clear path before the fix', async () => {
+		const homeDir = mkdtempSync(join(tmpdir(), 'openpalm-rollback-pin-'));
+		try {
+			await withUpgradeEnv(homeDir, async () => {
+				const docker = fakeDockerClient();
+				// Every attempt fails during activation (e.g. a bad image pull) —
+				// pullFailed: true keeps containersMutated false, so no reapply of
+				// the restored stack is attempted and no extra docker calls happen.
+				const activateStackMock = mock(async () => ({
+					ok: false,
+					error: 'simulated activation failure',
+					pullFailed: true
+				}));
+
+				mock.module('./docker.js', () => ({ ...realDocker, realDockerClient: docker }));
+				mock.module('./activation.js', () => ({
+					...realActivation,
+					activateStack: activateStackMock
+				}));
+
+				const { performUpgrade, createState } = await import(
+					`./lifecycle.js?rollback-pin-test=${Math.random()}`
+				);
+
+				const state = createState();
+				const seenPins: string[] = [];
+
+				for (let attempt = 1; attempt <= 3; attempt++) {
+					await expect(performUpgrade(state)).rejects.toThrow();
+
+					const versions = readVersions(state);
+					for (const key of SERVICE_VERSION_KEYS) {
+						if (key === 'OP_VOICE_VERSION') continue; // no running voice container in this fixture
+						expect(versions[key]).toMatch(/^rollback-generation-/);
+					}
+					seenPins.push(versions.OP_ASSISTANT_VERSION);
+				}
+
+				expect(activateStackMock).toHaveBeenCalledTimes(3);
+				// Each failure re-pins to a NEW generation — the bug: the pin never
+				// clears itself, it just keeps moving forward.
+				expect(new Set(seenPins).size).toBe(3);
+
+				const stillPinnedAfterThreeFailures = readVersions(state).OP_ASSISTANT_VERSION;
+				expect(stillPinnedAfterThreeFailures).toBe(seenPins[2]);
+
+				// The fix: clearRollbackPins is the supported, non-hand-editing way
+				// off the pin (backs both `openpalm unpin` and the admin UI action).
+				const { cleared } = clearRollbackPins(state, '0.13.1');
+				expect(cleared.OP_ASSISTANT_VERSION).toEqual({
+					from: stillPinnedAfterThreeFailures,
+					to: '0.13.1'
+				});
+				expect(cleared.OP_GUARDIAN_VERSION?.to).toBe('0.13.1');
+				expect(cleared.OP_PORTAL_VERSION?.to).toBe('0.13.1');
+
+				const clearedVersions = readVersions(state);
+				for (const key of ['OP_ASSISTANT_VERSION', 'OP_GUARDIAN_VERSION', 'OP_PORTAL_VERSION'] as const) {
+					expect(clearedVersions[key]).toBe('0.13.1');
+					expect(clearedVersions[key]).not.toMatch(/^rollback-/);
+				}
+
+				const content = readFileSync(join(homeDir, 'state', 'stack.env'), 'utf-8');
+				expect(content).not.toContain('rollback-generation-');
+			});
+		} finally {
+			rmSync(homeDir, { recursive: true, force: true });
+		}
+	});
+});

--- a/packages/lib/src/control-plane/lifecycle.ts
+++ b/packages/lib/src/control-plane/lifecycle.ts
@@ -47,7 +47,7 @@ import type { InstallLockHandle } from './install-lock.js';
 import { getAddonServiceNames, listEnabledAddonIds, pruneRemovedAddonState } from './addons.js';
 import { backupOpenPalmHome, pruneBackupDirs } from './backup.js';
 import { guardianRequired } from './guardian-required.js';
-import { advanceManagedImageVersions, ensureVersionDefaults } from './versions.js';
+import { advanceManagedImageVersions, assertHomeNotNewerThanApp, ensureVersionDefaults } from './versions.js';
 import { ensureSystemBundle, reconcileDuplicateBundles, stripRetiredAkmConfigKeys } from './akm-sources.js';
 import { reconcileAkmDbJournalMode } from './akm-db-journal.js';
 import {
@@ -182,6 +182,12 @@ async function reconcileCore(
  * rollback snapshot — a launch holds none of those.
  */
 export async function applyHomeAssets(state: ControlPlaneState): Promise<void> {
+	// #636: a plain launch reaches this directly (Electron's seedBundledSkeleton,
+	// the CLI's spawnUiChild) with no snapshot/rollback safety net around it, so
+	// the check belongs here too, not only at the install/update/upgrade entry
+	// points below — this is the call that overwrites system/ and re-stamps
+	// .skeleton-version.
+	assertHomeNotNewerThanApp(state);
 	await applyHomeSeed(state.homeDir);
 	// An upgrade can leave the assistant's akm config carrying keys the newer
 	// pinned akm-cli hard-rejects, which breaks every akm call in the container.
@@ -387,6 +393,10 @@ export async function applyInstall(
 	const lock = resolveLifecycleLock(state, opts);
 	if (!lock) throw new Error('Another install is already in progress');
 	try {
+		// #636: checked before runWithSnapshotRollback, not inside it — a refusal
+		// here must be a true no-op (no snapshot, no restore-from-an-unrelated
+		// earlier generation), not just "no managed write".
+		assertHomeNotNewerThanApp(state);
 		let generation: string | undefined;
 		await runWithSnapshotRollback(
 			state,
@@ -419,6 +429,8 @@ export async function applyUpdate(
 	const lock = resolveLifecycleLock(state, opts);
 	if (!lock) throw new Error('Another install is already in progress');
 	try {
+		// #636: see applyInstall above for why this runs before the rollback wrapper.
+		assertHomeNotNewerThanApp(state);
 		let generation: string | undefined;
 		await runWithSnapshotRollback(
 			state,
@@ -458,6 +470,10 @@ export async function performUpgrade(
 	let generation: string | undefined;
 	let imageSnapshot: RunningImageSnapshot = {};
 	try {
+		// #636: see applyInstall above for why this runs before the rollback
+		// wrapper — nothing, not even the running-image capture below, should
+		// happen once this home is known to be newer than the running app.
+		assertHomeNotNewerThanApp(state);
 		imageSnapshot = await captureRunningImageIds(buildComposeOptions(state));
 		await runWithSnapshotRollback(
 			state,

--- a/packages/lib/src/control-plane/lifecycle.ts
+++ b/packages/lib/src/control-plane/lifecycle.ts
@@ -234,7 +234,7 @@ async function applyHome(state: ControlPlaneState): Promise<void> {
 	// the file is absent, which on a pre-consolidation home is every time — so
 	// running it first left the migration merging a stub over the operator's real
 	// state and reporting a completed install as unconfigured.
-	runHomeMigrations(state.homeDir);
+	await runHomeMigrations(state.homeDir);
 	ensureSecrets(state);
 	await applyHomeAssets(state);
 	// Make the `remote` addon's generated serve config match its persisted state
@@ -306,7 +306,7 @@ async function applyManagedFiles(
 	// snapshot may capture no stack env at all; every migration below the
 	// consolidation is value-preserving, so there is nothing to roll back.)
 	const generation = snapshotCurrentState(state);
-	runHomeMigrations(state.homeDir);
+	await runHomeMigrations(state.homeDir);
 	const previousPlatformVersion = readSkeletonVersion(state.homeDir);
 	advanceManagedImageVersions(state, previousPlatformVersion);
 	await applyHome(state);

--- a/packages/lib/src/control-plane/port-probe.ts
+++ b/packages/lib/src/control-plane/port-probe.ts
@@ -95,6 +95,48 @@ export async function portHeldByOurContainer(
   return "free";
 }
 
+/**
+ * Is `port` safe for THIS install to bind (issue #643)? True when nothing is
+ * bound there, or when whatever holds it is our own compose project's own
+ * container — which `docker compose up` will simply recreate on the same
+ * port, not a real conflict.
+ *
+ * Resolves `true` on every state this cannot verify (no `composeProject`
+ * given, or Docker unreachable — {@link portHeldByOurContainer}'s own
+ * "unreachable" case) rather than `false`: a caller using this to decide
+ * whether to keep a port must never invent a NEW reason to move it beyond
+ * what it can actually confirm is someone else's.
+ */
+export async function isHostPortAvailableForUs(
+  port: number,
+  composeProject?: { name: string; workingDir: string },
+  client: DockerClient = realDockerClient,
+): Promise<boolean> {
+  if (await checkPortAvailable(port)) return true;
+  if (!composeProject) return true;
+  const ownership = await portHeldByOurContainer(port, composeProject, client);
+  return ownership !== "free";
+}
+
+/**
+ * Return `preferred` when {@link isHostPortAvailableForUs}, else the next
+ * port confirmed available, scanning forward up to `scanLimit` candidates.
+ * Falls back to `preferred` unchanged when nothing in range can be confirmed
+ * free — the eventual conflict still surfaces at `docker compose up` /
+ * `openpalm doctor`, exactly as it did before this existed.
+ */
+export async function pickAvailableHostPort(
+  preferred: number,
+  composeProject?: { name: string; workingDir: string },
+  opts: { client?: DockerClient; scanLimit?: number } = {},
+): Promise<number> {
+  const scanLimit = opts.scanLimit ?? 20;
+  for (let port = preferred; port < preferred + scanLimit; port++) {
+    if (await isHostPortAvailableForUs(port, composeProject, opts.client)) return port;
+  }
+  return preferred;
+}
+
 export interface InstallPortTarget {
   port: number;
   service: string;

--- a/packages/lib/src/control-plane/secret-audit.test.ts
+++ b/packages/lib/src/control-plane/secret-audit.test.ts
@@ -177,6 +177,15 @@ describe('auditComposeSecrets — #563 opencode_server_password (D2/D3)', () => 
 
 describe('auditResolvedComposeSecrets adversarial boundary cases', () => {
   it('accepts the shipped named-secret aliases only at their canonical files', () => {
+    // The files must actually exist on disk (#632): the audit now checks
+    // presence, not just the path shape, so a boundary-only fixture with no
+    // real files would (correctly) fail it.
+    mkdirSync(join(tempDir, 'state', 'secrets'), { recursive: true, mode: 0o700 });
+    mkdirSync(join(tempDir, 'knowledge', 'secrets'), { recursive: true, mode: 0o700 });
+    writeFileSync(join(tempDir, 'state', 'secrets', 'op_opencode_password'), 'x\n', { mode: 0o600 });
+    writeFileSync(join(tempDir, 'state', 'secrets', 'op_ui_login_password'), 'x\n', { mode: 0o600 });
+    writeFileSync(join(tempDir, 'knowledge', 'secrets', 'auth.json'), '{}\n', { mode: 0o600 });
+
     const issues = auditResolvedComposeSecrets({
       secrets: {
         opencode_server_password: { file: `${tempDir}/state/secrets/op_opencode_password` },
@@ -192,6 +201,9 @@ describe('auditResolvedComposeSecrets adversarial boundary cases', () => {
     // Regression: the delegated-name check used to be a pattern list that
     // omitted ts_authkey, so a remote-addon activation failed the audit even
     // though the secret was at exactly the path the provisioner writes.
+    mkdirSync(join(tempDir, 'state', 'secrets'), { recursive: true, mode: 0o700 });
+    writeFileSync(join(tempDir, 'state', 'secrets', 'ts_authkey'), '', { mode: 0o600 });
+
     const issues = auditResolvedComposeSecrets({
       secrets: {
         ts_authkey: { file: `${tempDir}/state/secrets/ts_authkey` },
@@ -204,6 +216,28 @@ describe('auditResolvedComposeSecrets adversarial boundary cases', () => {
     }, { homeDir: tempDir });
 
     expect(issues).toEqual([]);
+  });
+
+  it('#632: reports a specific, actionable issue when a resolved secret file does not exist', () => {
+    // The directory exists (ensureHomeDirs always creates it) but is empty —
+    // exactly the state `install --no-start` leaves behind when setup was
+    // never completed. Regression for the opaque `docker compose up`
+    // "bind source path does not exist" failure this audit now catches first.
+    mkdirSync(join(tempDir, 'state', 'secrets'), { recursive: true, mode: 0o700 });
+
+    const issues = auditResolvedComposeSecrets({
+      secrets: {
+        opencode_server_password: { file: `${tempDir}/state/secrets/op_opencode_password` },
+        ui_login_password: { file: `${tempDir}/state/secrets/op_ui_login_password` },
+      },
+    }, { homeDir: tempDir });
+
+    expect(issues.map((entry) => entry.code)).toEqual([
+      'compose-secret-file-missing',
+      'compose-secret-file-missing',
+    ]);
+    const loginIssue = issues.find((entry) => entry.path === 'secrets.ui_login_password.file');
+    expect(loginIssue?.message).toContain('openpalm reset-password');
   });
 
   it('rejects a top-level source override even when the service grant name is allowed', () => {

--- a/packages/lib/src/control-plane/secret-audit.ts
+++ b/packages/lib/src/control-plane/secret-audit.ts
@@ -381,6 +381,26 @@ export function auditResolvedComposeSecrets(
         `top-level secret ${name} must source exactly ${expected}; secret-name aliases and redirection are forbidden.`,
         `secrets.${name}.file`,
       ));
+    } else if (!existsSync(source)) {
+      // #632: `install --no-start` (or an interrupted wizard) can leave a home
+      // whose compose files are fully materialized but whose secrets were
+      // never minted — `docker compose up` then fails at container-create
+      // time with an opaque "bind source path does not exist", because
+      // `docker compose config` never checks that a secret's file source
+      // actually exists (only that the compose YAML itself is well-formed).
+      // This audit runs before every activation (start/restart/addon/deploy —
+      // see runComposeActivation), so it is the one place that can catch a
+      // missing secret BEFORE the daemon does and say which one, instead of
+      // an operator (or script) hitting the raw bind-mount error with no clue
+      // what to do about it.
+      issues.push(issue(
+        'compose-secret-file-missing',
+        `secret ${name} file does not exist: ${expected}. Setup was never completed for this ` +
+          `OpenPalm home. ${name === 'ui_login_password'
+            ? 'Run `openpalm reset-password` to create it, or re-run setup (`openpalm install --force`), then try again.'
+            : 'Re-run setup (`openpalm install --force`, interactively or with --file) to create it, then try again.'}`,
+        `secrets.${name}.file`,
+      ));
     }
   }
   return issues;

--- a/packages/lib/src/control-plane/setup.ts
+++ b/packages/lib/src/control-plane/setup.ts
@@ -236,11 +236,115 @@ export const RETIRED_AKM_CONFIG_KEYS = [
 ] as const;
 
 export function stripRetiredAkmKeys(config: Record<string, unknown>): void {
+	translateLegacyLlmProfiles(config);
 	for (const key of RETIRED_AKM_CONFIG_KEYS) delete config[key];
 	if (config.defaults && typeof config.defaults === 'object') {
 		delete (config.defaults as Record<string, unknown>).llm;
 		delete (config.defaults as Record<string, unknown>).agent;
 		delete (config.defaults as Record<string, unknown>).improve;
+	}
+}
+
+/**
+ * akm 0.9's `engines.<name>.apiKey` must be an env-var reference
+ * (`$VAR`/`${VAR}`), never a literal secret — mirrors akm-cli's
+ * `ENV_REFERENCE_PATTERN` (core/config/schema/primitives.js). A retired 0.8
+ * `profiles.llm.<name>.apiKey` holding a literal key can't be carried over:
+ * writing it as-is would both fail akm's schema (rejecting the WHOLE config)
+ * and put a secret in the user-owned, non-secret `config/akm/config.json`.
+ */
+const AKM_ENV_REFERENCE_PATTERN = /^\$[A-Za-z_][A-Za-z0-9_]*$|^\$\{[A-Za-z_][A-Za-z0-9_]*\}$/;
+
+function isHttpUrl(value: string): boolean {
+	try {
+		const url = new URL(value);
+		return url.protocol === 'http:' || url.protocol === 'https:';
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * akm 0.9 retires `profiles.*` with no translation of its own — akm's own
+ * upgrade guidance is "Recreate engines ... manually for AKM 0.9.0;
+ * profile-based configuration is not translated automatically"
+ * (config-version-shim.js). OpenPalm drives this migration during
+ * install/update (`stripRetiredAkmConfigKeys`), so without this step the
+ * retired-key strip below silently deletes `profiles.llm.*` and a 0.12.x
+ * upgrade lands on a stamped-valid `engines: {}` with no loud failure
+ * anywhere — issue #645.
+ *
+ * Best-effort translates `profiles.llm.<name>` into the current
+ * `engines.<name>` shape before the strip removes it. Additive only, like
+ * every other writer of this file: never overwrites an engine name that
+ * already exists and never overwrites an already-set `defaults.llmEngine`.
+ * A profile missing a usable `model`/`endpoint`, or one whose `apiKey` is a
+ * literal secret rather than an env-var reference, is left untranslated —
+ * exactly as silently dropped as before — but named in a loud warning
+ * instead. Other retired profile kinds (`profiles.agent`, `profiles.improve`)
+ * are out of scope here the same way they are for akm itself
+ * (docs/migration/v0.8-to-v0.9.md: "engine settings are never guessed") —
+ * also just named in the warning.
+ */
+function translateLegacyLlmProfiles(config: Record<string, unknown>): void {
+	const profiles = config.profiles;
+	if (!profiles || typeof profiles !== 'object' || Array.isArray(profiles)) return;
+	const profileKinds = profiles as Record<string, unknown>;
+
+	const engines = (
+		config.engines && typeof config.engines === 'object' && !Array.isArray(config.engines)
+			? (config.engines as Record<string, unknown>)
+			: {}
+	) as Record<string, Record<string, unknown>>;
+	const translated: string[] = [];
+	const dropped: string[] = [];
+
+	const llmProfiles = profileKinds.llm;
+	if (llmProfiles && typeof llmProfiles === 'object' && !Array.isArray(llmProfiles)) {
+		for (const [name, raw] of Object.entries(llmProfiles as Record<string, unknown>)) {
+			if (!raw || typeof raw !== 'object' || Array.isArray(raw)) continue;
+			if (name in engines) continue; // never overwrite a live engine
+			const profile = raw as Record<string, unknown>;
+			const model = typeof profile.model === 'string' ? profile.model.trim() : '';
+			const provider = typeof profile.provider === 'string' ? profile.provider : undefined;
+			const rawEndpoint = typeof profile.endpoint === 'string' ? profile.endpoint : '';
+			const endpoint = rawEndpoint ? buildAkmEndpoint(provider ?? '', rawEndpoint, '/chat/completions') : '';
+			if (!model || !isHttpUrl(endpoint)) {
+				dropped.push(`profiles.llm.${name}`);
+				continue;
+			}
+			const engine: Record<string, unknown> = { kind: 'llm', endpoint, model };
+			if (provider) engine.provider = provider;
+			if (typeof profile.apiKey === 'string' && profile.apiKey.length > 0) {
+				if (AKM_ENV_REFERENCE_PATTERN.test(profile.apiKey)) {
+					engine.apiKey = profile.apiKey;
+				} else {
+					dropped.push(`profiles.llm.${name}.apiKey`);
+				}
+			}
+			engines[name] = engine;
+			translated.push(name);
+		}
+	}
+	for (const kind of Object.keys(profileKinds)) {
+		if (kind !== 'llm') dropped.push(`profiles.${kind}`);
+	}
+
+	if (translated.length > 0) {
+		config.engines = engines;
+		const defaults = { ...(config.defaults && typeof config.defaults === 'object' ? (config.defaults as Record<string, unknown>) : {}) };
+		if (typeof defaults.llmEngine !== 'string') {
+			const legacyDefault = typeof defaults.llm === 'string' && translated.includes(defaults.llm) ? defaults.llm : translated[0];
+			defaults.llmEngine = legacyDefault;
+		}
+		config.defaults = defaults;
+		logger.warn('akm config migration: translated retired profiles.llm into engines', { translated });
+	}
+	if (dropped.length > 0) {
+		logger.warn(
+			'akm config migration: retired akm config fields dropped with no automatic translation — reconfigure manually',
+			{ dropped }
+		);
 	}
 }
 

--- a/packages/lib/src/control-plane/validate.test.ts
+++ b/packages/lib/src/control-plane/validate.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Tests for validateProposedState()'s akm-engines advisory (issue #645).
+ *
+ * `openpalm validate` used to report "Configuration OK." with no signal at
+ * all when the assistant's akm config had migrated to the current
+ * `configVersion` but ended up with zero configured `engines` — exactly the
+ * state a 0.12.x -> 0.13.x upgrade left behind before profiles.llm.* was
+ * translated forward. This is a non-blocking WARNING, not an error: akm 0.9
+ * itself treats zero configured engines as a supported state (it falls back
+ * to opencode-sdk when the opencode binary is present), so promoting this to
+ * an error would fail closed on a state akm does not consider broken.
+ */
+import { afterEach, describe, expect, it } from 'bun:test';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { validateProposedState } from './validate.js';
+import type { ControlPlaneState } from './types.js';
+
+const homes: string[] = [];
+
+afterEach(() => {
+  let home = homes.pop();
+  while (home) {
+    rmSync(home, { recursive: true, force: true });
+    home = homes.pop();
+  }
+});
+
+/** A temp OP_HOME with the two required-secret checks already satisfied. */
+function seedHome(): { state: ControlPlaneState; home: string } {
+  const home = mkdtempSync(join(tmpdir(), 'validate-akm-engines-'));
+  homes.push(home);
+
+  mkdirSync(join(home, 'state'), { recursive: true });
+  writeFileSync(join(home, 'state', 'stack.env'), 'OP_IMAGE_TAG=v0.13.1\n');
+  const stateSecrets = join(home, 'state', 'secrets');
+  mkdirSync(stateSecrets, { recursive: true, mode: 0o700 });
+  writeFileSync(join(stateSecrets, 'op_ui_login_password'), 'test-password\n', { mode: 0o600 });
+
+  const state = {
+    homeDir: home,
+    configDir: join(home, 'config'),
+    stashDir: join(home, 'knowledge'),
+    workspaceDir: join(home, 'workspace'),
+    dataDir: join(home, 'data'),
+  } as unknown as ControlPlaneState;
+
+  return { state, home };
+}
+
+function writeAkmConfig(home: string, config: Record<string, unknown>): void {
+  const dir = join(home, 'config', 'akm');
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, 'config.json'), JSON.stringify(config, null, 2));
+}
+
+describe('validateProposedState: akm engines advisory (issue #645)', () => {
+  it('warns, but stays ok, when an existing akm config has zero engines', async () => {
+    const { state, home } = seedHome();
+    writeAkmConfig(home, {
+      configVersion: '0.9.0',
+      bundles: { openpalm: { path: '/stash', writable: true } },
+      defaultBundle: 'openpalm',
+      engines: {},
+    });
+
+    const result = await validateProposedState(state);
+    expect(result.ok).toBe(true);
+    expect(result.errors).toEqual([]);
+    expect(result.warnings.length).toBe(1);
+    expect(result.warnings[0]).toContain('no akm engines configured');
+  });
+
+  it('does not warn when the config carries a configured engine', async () => {
+    const { state, home } = seedHome();
+    writeAkmConfig(home, {
+      configVersion: '0.9.0',
+      bundles: { openpalm: { path: '/stash', writable: true } },
+      defaultBundle: 'openpalm',
+      engines: { default: { kind: 'llm', endpoint: 'https://api.openai.com/v1/chat/completions', model: 'gpt-4o-mini' } },
+    });
+
+    const result = await validateProposedState(state);
+    expect(result.ok).toBe(true);
+    expect(result.warnings).toEqual([]);
+  });
+
+  it('does not warn when there is no akm config yet (nothing installed)', async () => {
+    const { state } = seedHome();
+
+    const result = await validateProposedState(state);
+    expect(result.ok).toBe(true);
+    expect(result.warnings).toEqual([]);
+  });
+
+  it('does not warn on an unparseable akm config — akm itself fails closed and names the parse error', async () => {
+    const { state, home } = seedHome();
+    const dir = join(home, 'config', 'akm');
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, 'config.json'), '{ not json');
+
+    const result = await validateProposedState(state);
+    expect(result.ok).toBe(true);
+    expect(result.warnings).toEqual([]);
+  });
+});

--- a/packages/lib/src/control-plane/validate.ts
+++ b/packages/lib/src/control-plane/validate.ts
@@ -7,10 +7,10 @@
  * #391; everything advisory is surfaced as a non-blocking warning. The
  * function never shells out and never reads schemas.
  */
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { stateSecretsDir } from "./home.js";
 import { readSecret } from "./secrets-files.js";
-import { stackEnvPath } from "./paths.js";
+import { akmConfigPath, stackEnvPath } from "./paths.js";
 import type { ControlPlaneState } from "./types.js";
 
 // Stack-scoped env keys that must always exist and carry a non-empty value
@@ -51,5 +51,39 @@ export async function validateProposedState(state: ControlPlaneState): Promise<{
     }
   }
 
+  const akmWarning = checkAkmEngines(state);
+  if (akmWarning) warnings.push(akmWarning);
+
   return { ok: errors.length === 0, errors, warnings };
+}
+
+/**
+ * Advisory-only (never blocks `ok`): an existing akm config with no
+ * `engines` entries leaves the assistant with no configured LLM — a state
+ * that used to pass silently, including right after a 0.12.x -> 0.13.x
+ * upgrade dropped `profiles.llm.*` with nothing translating it forward
+ * (issue #645). Not promoted to an error: akm 0.9 itself treats zero
+ * configured engines as a supported state and falls back to `opencode-sdk`
+ * when the `opencode` binary is present, so failing `openpalm validate`
+ * closed here would block a deploy that akm does not consider broken.
+ * Skipped entirely when the config file does not exist yet — nothing to
+ * warn about before setup has ever written one.
+ */
+function checkAkmEngines(state: ControlPlaneState): string | undefined {
+  const configPath = akmConfigPath(state);
+  if (!existsSync(configPath)) return undefined;
+  let config: unknown;
+  try {
+    config = JSON.parse(readFileSync(configPath, "utf-8"));
+  } catch {
+    // Unparseable akm config is a real problem, but not this check's problem
+    // to report — akm itself fails closed and names the parse error.
+    return undefined;
+  }
+  if (!config || typeof config !== "object" || Array.isArray(config)) return undefined;
+  const engines = (config as Record<string, unknown>).engines;
+  const engineCount =
+    engines && typeof engines === "object" && !Array.isArray(engines) ? Object.keys(engines).length : 0;
+  if (engineCount > 0) return undefined;
+  return `WARNING: no akm engines configured in ${configPath} — the assistant has no LLM engine unless opencode itself is configured`;
 }

--- a/packages/lib/src/control-plane/versions.test.ts
+++ b/packages/lib/src/control-plane/versions.test.ts
@@ -11,7 +11,10 @@ import {
 	readVersions,
 	ensureVersionDefaults,
 	advanceManagedImageVersions,
-	stripRetiredToolVersions
+	stripRetiredToolVersions,
+	clearRollbackPins,
+	MANAGED_VERSION_MARKERS,
+	SERVICE_VERSION_KEYS
 } from './versions.js';
 import type { ControlPlaneState } from './types.js';
 import { PLATFORM_VERSION } from './versioning.js';
@@ -270,5 +273,95 @@ describe('retired OP_TOOL_*_VERSION keys', () => {
 		writeFileSync(envPath(), 'OP_TOOL_AKM_VERSION=0.8.14\n');
 		ensureVersionDefaults(home.state);
 		expect(readFileSync(envPath(), 'utf-8')).not.toContain('OP_TOOL_AKM_VERSION');
+	});
+
+	// #639: a failed performUpgrade/runDeploy re-pins every SERVICE_VERSION_KEY
+	// to a preserved rollback-generation-* tag via restoreRunningImageIds, which
+	// ALWAYS leaves the OP_MANAGED_* marker blank — the exact same shape
+	// writeVersions leaves after a genuine operator pin. clearRollbackPins is
+	// the supported way off that pin (backing both `openpalm unpin` and the
+	// admin UI's dedicated clear action).
+	describe('clearRollbackPins (#639)', () => {
+		it('clears every rollback- pin to the target version and re-stamps its managed marker', () => {
+			// The operator's exact reported shape: rollback- values with BLANK
+			// markers (restoreRunningImageIds never stamps them).
+			writeFileSync(
+				envPath(),
+				[
+					'OP_ASSISTANT_VERSION=rollback-generation-1788212586188-217761-1',
+					'OP_VOICE_VERSION=rollback-generation-1788212586188-217761-1',
+					'OP_GUARDIAN_VERSION=rollback-generation-1788212586188-217761-1',
+					'OP_PORTAL_VERSION=rollback-generation-1788212586188-217761-1',
+					'OP_MANAGED_ASSISTANT_VERSION=',
+					'OP_MANAGED_GUARDIAN_VERSION=',
+					'OP_MANAGED_PORTAL_VERSION=',
+					'OP_MANAGED_VOICE_VERSION='
+				].join('\n')
+			);
+
+			const result = clearRollbackPins(home.state, '0.13.1');
+
+			expect(Object.keys(result.cleared).sort()).toEqual([...SERVICE_VERSION_KEYS].sort());
+			for (const key of ['OP_ASSISTANT_VERSION', 'OP_GUARDIAN_VERSION', 'OP_PORTAL_VERSION'] as const) {
+				expect(result.cleared[key]).toEqual({
+					from: 'rollback-generation-1788212586188-217761-1',
+					to: '0.13.1'
+				});
+			}
+			expect(result.cleared.OP_VOICE_VERSION).toEqual({
+				from: 'rollback-generation-1788212586188-217761-1',
+				to: 'latest'
+			});
+
+			const versions = readVersions(home.state);
+			expect(versions.OP_ASSISTANT_VERSION).toBe('0.13.1');
+			expect(versions.OP_GUARDIAN_VERSION).toBe('0.13.1');
+			expect(versions.OP_PORTAL_VERSION).toBe('0.13.1');
+			expect(versions.OP_VOICE_VERSION).toBe('latest');
+
+			// Re-stamped (not blanked) so a later advanceManagedImageVersions still
+			// recognizes these as managed and keeps advancing them.
+			const content = readFileSync(envPath(), 'utf-8');
+			for (const key of ['OP_ASSISTANT_VERSION', 'OP_GUARDIAN_VERSION', 'OP_PORTAL_VERSION'] as const) {
+				expect(content).toContain(`${MANAGED_VERSION_MARKERS[key]}=0.13.1`);
+			}
+			expect(content).toContain(`${MANAGED_VERSION_MARKERS.OP_VOICE_VERSION}=latest`);
+		});
+
+		it('never touches a value without the rollback- prefix, even with a blank marker (a genuine operator pin)', () => {
+			writeFileSync(
+				envPath(),
+				[
+					'OP_ASSISTANT_VERSION=rollback-generation-1',
+					'OP_GUARDIAN_VERSION=my-custom-build',
+					'OP_MANAGED_ASSISTANT_VERSION=',
+					'OP_MANAGED_GUARDIAN_VERSION='
+				].join('\n')
+			);
+
+			const result = clearRollbackPins(home.state, '0.13.1');
+
+			expect(result.cleared.OP_ASSISTANT_VERSION).toEqual({
+				from: 'rollback-generation-1',
+				to: '0.13.1'
+			});
+			expect(result.cleared.OP_GUARDIAN_VERSION).toBeUndefined();
+			expect(result.kept.OP_GUARDIAN_VERSION).toBe('my-custom-build');
+
+			const content = readFileSync(envPath(), 'utf-8');
+			expect(content).toContain('OP_GUARDIAN_VERSION=my-custom-build');
+			// The operator pin's marker stays exactly as it was — untouched.
+			expect(content).toMatch(/OP_MANAGED_GUARDIAN_VERSION=(\r?\n|$)/);
+		});
+
+		it('is a no-op when nothing is pinned to a rollback generation', () => {
+			writeFileSync(envPath(), 'OP_ASSISTANT_VERSION=0.13.0\n');
+			const before = readFileSync(envPath(), 'utf-8');
+
+			const result = clearRollbackPins(home.state, '0.13.1');
+
+			expect(result.cleared).toEqual({});
+			expect(readFileSync(envPath(), 'utf-8')).toBe(before);
+		});
 	});
 });

--- a/packages/lib/src/control-plane/versions.ts
+++ b/packages/lib/src/control-plane/versions.ts
@@ -17,9 +17,10 @@
 import { existsSync, readFileSync, mkdirSync } from 'node:fs';
 import { writeFileAtomic } from './fs-atomic.js';
 import { parseEnvFile, mergeEnvContent, removeEnvKey } from './env.js';
-import { stackEnvFile } from './home.js';
+import { HOME_SCHEMA_VERSION, readHomeSchemaVersion, stackEnvFile } from './home.js';
+import { readSkeletonVersion } from './ui-assets.js';
 import type { ControlPlaneState } from './types.js';
-import { normalizeVersion, PLATFORM_VERSION } from './versioning.js';
+import { compareComparableVersions, isComparableSemver, normalizeVersion, PLATFORM_VERSION } from './versioning.js';
 
 /** Docker image tags — one per deployable OpenPalm image. */
 export const SERVICE_VERSION_KEYS = [
@@ -83,6 +84,73 @@ export const RETIRED_TOOL_VERSION_KEYS = [
 	'OP_GUARDIAN_NPMRC',
 	'OP_GUARDIAN_NPMRC_FILE'
 ] as const;
+
+// ── Version-skew guard (#636) ────────────────────────────────────────────────
+//
+// An OP_HOME is written by whichever app last ran install/update against it —
+// `.skeleton-version` (ui-assets.ts) and `state/schema-version` (home.ts) both
+// record that. Nothing used to compare those stamps against the CODE now
+// running before writing to the home, so an older app (e.g. a desktop build
+// stuck mid-self-update, #635) pointed at a home a newer app had already
+// upgraded would silently downgrade it: `advanceManagedImageVersions` and
+// `clearRollbackPins` both default their target to THIS build's
+// `PLATFORM_VERSION`, and `applyHomeSeed` unconditionally overwrites `system/`
+// and re-stamps `.skeleton-version` from THIS build's skeleton — all three
+// moving a newer home backwards with no operator confirmation.
+//
+// This is that comparison, done once. `newer` is true when either stamp says
+// the home was written by a build ahead of this one; every caller that would
+// mutate managed files, version pins, or the version stamps themselves must
+// check it FIRST and refuse before touching anything. A missing or
+// non-semver `.skeleton-version` (fresh install, a pre-stamp home) never
+// trips it — `isComparableSemver` guards that — and neither does an equal or
+// older home, which is the normal upgrade direction and must stay unguarded.
+
+export type HomeVersionSkew = {
+	/** True when the home was written by a build newer than the one running now. */
+	newer: boolean;
+	/** `.skeleton-version` stamped into the home, or null when absent/unparseable. */
+	homeSkeletonVersion: string | null;
+	/** This build's platform version (bare semver). */
+	runningPlatformVersion: string;
+	/** Recorded OP_HOME layout schema version (0 when unrecorded). */
+	homeSchemaVersion: number;
+	/** This build's OP_HOME layout schema version. */
+	runningSchemaVersion: number;
+};
+
+/** Compare the home's recorded version stamps against the code running now. */
+export function detectHomeVersionSkew(state: ControlPlaneState): HomeVersionSkew {
+	const homeSkeletonVersion = readSkeletonVersion(state.homeDir);
+	const homeSchemaVersion = readHomeSchemaVersion(state.homeDir);
+	const skeletonNewer =
+		isComparableSemver(homeSkeletonVersion) &&
+		compareComparableVersions(homeSkeletonVersion as string, PLATFORM_VERSION) > 0;
+	const schemaNewer = homeSchemaVersion > HOME_SCHEMA_VERSION;
+	return {
+		newer: skeletonNewer || schemaNewer,
+		homeSkeletonVersion,
+		runningPlatformVersion: PLATFORM_VERSION,
+		homeSchemaVersion,
+		runningSchemaVersion: HOME_SCHEMA_VERSION
+	};
+}
+
+/**
+ * Refuse to continue when `state.homeDir` was written by a newer OpenPalm than
+ * the one running now. Call this BEFORE any managed-file write, version-pin
+ * advance, or version-stamp write — see the module docblock above.
+ */
+export function assertHomeNotNewerThanApp(state: ControlPlaneState): void {
+	const skew = detectHomeVersionSkew(state);
+	if (!skew.newer) return;
+	const homeLabel = skew.homeSkeletonVersion ?? `schema ${skew.homeSchemaVersion}`;
+	throw new Error(
+		`OP_HOME (${state.homeDir}) was set up by OpenPalm ${homeLabel}, but this app is ${skew.runningPlatformVersion}. ` +
+			'Refusing to overwrite managed files, advance image versions, or downgrade this home. ' +
+			`Update this app to ${homeLabel} or later, then try again.`
+	);
+}
 
 // ── Version configuration ────────────────────────────────────────────────────
 
@@ -249,6 +317,11 @@ export function clearRollbackPins(
 	state: ControlPlaneState,
 	targetPlatformVersion = PLATFORM_VERSION
 ): ClearRollbackPinsResult {
+	// #636: a rollback-generation-* pin is cleared TO targetPlatformVersion,
+	// which defaults to this build's own PLATFORM_VERSION — the same
+	// downgrade shape advanceManagedImageVersions guards against, so this
+	// needs the identical check before it writes anything.
+	assertHomeNotNewerThanApp(state);
 	const current = parseEnvFile(stackEnvFile(state.homeDir));
 	const updates: Record<string, string> = {};
 	const cleared: ClearRollbackPinsResult['cleared'] = {};

--- a/packages/lib/src/control-plane/versions.ts
+++ b/packages/lib/src/control-plane/versions.ts
@@ -208,6 +208,67 @@ export function writeManagedVersions(state: ControlPlaneState, updates: Record<s
  */
 const VOICE_VARIANT_SUFFIX_RE = /-(?:cpu|cu\d+|rocm\d+)$/i;
 
+export type ClearRollbackPinsResult = {
+	/** Keys that carried a `rollback-` pin and were just advanced off it. */
+	cleared: Partial<Record<VersionKey, { from: string; to: string }>>;
+	/** Every other key's current value (default, moving tag, or a genuine operator pin), left untouched. */
+	kept: Partial<Record<VersionKey, string>>;
+};
+
+/**
+ * Clear rollback-generation-* pins that {@link restoreRunningImageIds}
+ * (image-snapshots.ts) writes into every SERVICE_VERSION_KEY on EVERY failed
+ * performUpgrade/runDeploy attempt (it runs as the snapshot-rollback catch's
+ * preserveImages callback). Nothing else ever un-pins that value: the only
+ * OTHER code that clears a `rollback-` value is advanceManagedImageVersions,
+ * and it only runs earlier in the SAME upgrade attempt, before the failure
+ * that re-pins it — so a repeatedly-failing upgrade never releases the pin on
+ * its own (#639).
+ *
+ * Distinguishing rule (decided here, once, rather than per caller): a
+ * `rollback-` prefixed value is by construction never an operator-typed pin
+ * -- no CLI flag or UI field accepts that shape, only restoreRunningImageIds
+ * writes it -- and it always pairs with a BLANK OP_MANAGED_* marker, the
+ * exact shape writeVersions leaves after a genuine operator pin. The marker
+ * alone can't tell the two apart; only the `rollback-` prefix can. So this
+ * clears purely on that prefix, regardless of the marker's state, and it
+ * never touches a key whose value lacks the prefix -- a deliberate operator
+ * pin, a release default, or a moving tag -- no matter what its marker says.
+ *
+ * Mirrors the target selection advanceManagedImageVersions's own rollback arm
+ * already uses (platform version for assistant/guardian/portal,
+ * VERSION_DEFAULTS.OP_VOICE_VERSION for voice) and, like writeManagedVersions,
+ * re-stamps the OP_MANAGED_* marker to match the new value so a later release
+ * still recognizes the key as managed and advances it.
+ *
+ * Does not touch Compose or containers — the caller (CLI `unpin` command, or
+ * the admin UI's dedicated clear action) is responsible for telling the
+ * operator to run `openpalm update`/`start` afterward to apply the change.
+ */
+export function clearRollbackPins(
+	state: ControlPlaneState,
+	targetPlatformVersion = PLATFORM_VERSION
+): ClearRollbackPinsResult {
+	const current = parseEnvFile(stackEnvFile(state.homeDir));
+	const updates: Record<string, string> = {};
+	const cleared: ClearRollbackPinsResult['cleared'] = {};
+	const kept: ClearRollbackPinsResult['kept'] = {};
+	for (const key of SERVICE_VERSION_KEYS) {
+		const value = current[key]?.trim() ?? '';
+		if (!value.startsWith('rollback-')) {
+			kept[key] = value || VERSION_DEFAULTS[key];
+			continue;
+		}
+		const markerKey = MANAGED_VERSION_MARKERS[key];
+		const target = key === 'OP_VOICE_VERSION' ? VERSION_DEFAULTS.OP_VOICE_VERSION : targetPlatformVersion;
+		updates[key] = target;
+		updates[markerKey] = target;
+		cleared[key] = { from: value, to: target };
+	}
+	writeVersionState(state, updates);
+	return { cleared, kept };
+}
+
 function writeVersionEntries(
 	state: ControlPlaneState,
 	updates: Record<string, string>,

--- a/packages/lib/src/index.ts
+++ b/packages/lib/src/index.ts
@@ -390,13 +390,15 @@ export {
   RETIRED_TOOL_VERSION_KEYS,
   SERVICE_VERSION_KEYS,
   VERSION_DEFAULTS,
+  assertHomeNotNewerThanApp,
   clearRollbackPins,
+  detectHomeVersionSkew,
   isVersionKey,
   readVersions,
   stripRetiredToolVersions,
   writeVersions,
 } from "./control-plane/versions.js";
-export type { ClearRollbackPinsResult, VersionKey } from "./control-plane/versions.js";
+export type { ClearRollbackPinsResult, HomeVersionSkew, VersionKey } from "./control-plane/versions.js";
 
 // ── Docker ──────────────────────────────────────────────────────────────
 export type { DockerResult, ExistingProject, ComposePsRow, ApplyStackScope, ApplyStackResult } from "./control-plane/docker.js";

--- a/packages/lib/src/index.ts
+++ b/packages/lib/src/index.ts
@@ -457,7 +457,7 @@ export {
 
 // ── Install-port probing (C2) ──────────────────────────────────────────────
 export type { PortOwnership, InstallPortTarget, InstallPortStatus, ProbeInstallPortsOptions } from "./control-plane/port-probe.js";
-export { checkPortAvailable, portHeldByOurContainer, resolveInstallPortTargets, probeInstallPorts, workspacePortTarget } from "./control-plane/port-probe.js";
+export { checkPortAvailable, portHeldByOurContainer, isHostPortAvailableForUs, pickAvailableHostPort, resolveInstallPortTargets, probeInstallPorts, workspacePortTarget } from "./control-plane/port-probe.js";
 
 // ── Docker image/volume retention (S7 — #581 finding #11) ────────────────
 export type {

--- a/packages/lib/src/index.ts
+++ b/packages/lib/src/index.ts
@@ -390,12 +390,13 @@ export {
   RETIRED_TOOL_VERSION_KEYS,
   SERVICE_VERSION_KEYS,
   VERSION_DEFAULTS,
+  clearRollbackPins,
   isVersionKey,
   readVersions,
   stripRetiredToolVersions,
   writeVersions,
 } from "./control-plane/versions.js";
-export type { VersionKey } from "./control-plane/versions.js";
+export type { ClearRollbackPinsResult, VersionKey } from "./control-plane/versions.js";
 
 // ── Docker ──────────────────────────────────────────────────────────────
 export type { DockerResult, ExistingProject, ComposePsRow, ApplyStackScope, ApplyStackResult } from "./control-plane/docker.js";

--- a/packages/ui/src/hooks.server.ts
+++ b/packages/ui/src/hooks.server.ts
@@ -56,11 +56,17 @@ let migrationsDone = false;
 // Schema-gated and idempotent: an up-to-date home reads one small version file
 // and returns. Non-fatal — a home that cannot be migrated must still serve,
 // degraded, rather than refuse to boot.
-function migrateHome(): void {
+//
+// Async since issue #643: the port-default migrations now probe host-wide
+// port availability before writing a value the operator never set. Awaited at
+// the module-level call site below (before loadProcessEnv()) so a home still
+// mid-migration is never read from — the exact race the old process-local
+// port shim (see the comment further down) existed to paper over.
+async function migrateHome(): Promise<void> {
   if (migrationsDone) return;
   migrationsDone = true;
   try {
-    runHomeMigrations(resolveOpenPalmHome());
+    await runHomeMigrations(resolveOpenPalmHome());
   } catch (err) {
     logger.error("home migration failed", { error: String(err) });
   }
@@ -131,7 +137,7 @@ function loadProcessEnv(): void {
 // nothing in stack.env to explain it. Its two triggers also disagreed with the
 // disk migration's at the edges. The real migration now runs here, once, before
 // anything reads the home, so the request path can simply trust the disk.
-migrateHome();
+await migrateHome();
 loadProcessEnv();
 // OpenCode's web UI, at an origin root, behind this app's login. Called from
 // every launch mode because every launch mode loads this module, and a no-op

--- a/packages/ui/src/lib/api/versions.ts
+++ b/packages/ui/src/lib/api/versions.ts
@@ -31,3 +31,18 @@ export async function patchVersions(versions: Partial<Record<VersionKey, string>
 		})
 	);
 }
+
+/** A `rollback-` tag is never an operator-typed pin (#639) — only restoreRunningImageIds writes that shape. */
+export function isRollbackPin(value: string | undefined): boolean {
+	return !!value?.startsWith('rollback-');
+}
+
+export type ClearRollbackPinResponse = {
+	cleared: Partial<Record<VersionKey, { from: string; to: string }>>;
+};
+
+/** Clears only `rollback-` pinned keys via the shared lib function — never a deliberate operator pin. */
+export async function clearRollbackPin(): Promise<ClearRollbackPinResponse> {
+	const response = await requireOk(await request('POST', '/api/host/versions/clear-rollback-pin'));
+	return (await response.json()) as ClearRollbackPinResponse;
+}

--- a/packages/ui/src/lib/api/versions.vitest.ts
+++ b/packages/ui/src/lib/api/versions.vitest.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test, vi } from 'vitest';
-import { applyChanges, applyServiceUpdate } from './versions.js';
+import { applyChanges, applyServiceUpdate, clearRollbackPin, isRollbackPin } from './versions.js';
 
 afterEach(() => {
 	vi.unstubAllGlobals();
@@ -45,5 +45,55 @@ describe('update client', () => {
 		);
 
 		await expect(applyServiceUpdate('assistant')).rejects.toThrow('Docker is unavailable');
+	});
+});
+
+// #639 — distinguishing a rollback-generation-* pin (never operator-typed)
+// from any other configured value.
+describe('isRollbackPin', () => {
+	test('is true only for the rollback-generation- prefix', () => {
+		expect(isRollbackPin('rollback-generation-1788212586188-217761-1')).toBe(true);
+		expect(isRollbackPin('rollback-generation-1')).toBe(true);
+	});
+
+	test('is false for a release tag, a moving tag, a custom pin, or an unset value', () => {
+		expect(isRollbackPin('0.13.1')).toBe(false);
+		expect(isRollbackPin('latest')).toBe(false);
+		expect(isRollbackPin('my-custom-build')).toBe(false);
+		expect(isRollbackPin(undefined)).toBe(false);
+	});
+});
+
+describe('clearRollbackPin', () => {
+	test('POSTs to the dedicated clear-rollback-pin action and returns what was cleared', async () => {
+		const cleared = { OP_ASSISTANT_VERSION: { from: 'rollback-generation-1', to: '0.13.1' } };
+		const fetchMock = vi.fn().mockResolvedValue(
+			new Response(JSON.stringify({ ok: true, cleared }), {
+				status: 200,
+				headers: { 'content-type': 'application/json' }
+			})
+		);
+		vi.stubGlobal('fetch', fetchMock);
+
+		const result = await clearRollbackPin();
+
+		expect(result.cleared).toEqual(cleared);
+		const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+		expect(String(url)).toContain('/api/host/versions/clear-rollback-pin');
+		expect(init.method).toBe('POST');
+	});
+
+	test('throws the server message for non-success responses', async () => {
+		vi.stubGlobal(
+			'fetch',
+			vi.fn().mockResolvedValue(
+				new Response(JSON.stringify({ error: 'clear_rollback_pin_failed', message: 'boom' }), {
+					status: 500,
+					headers: { 'content-type': 'application/json' }
+				})
+			)
+		);
+
+		await expect(clearRollbackPin()).rejects.toThrow('boom');
 	});
 });

--- a/packages/ui/src/lib/components/admin/updates/RecoveryTab.svelte
+++ b/packages/ui/src/lib/components/admin/updates/RecoveryTab.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { onMount } from 'svelte';
-  import type { BackupSummaryView } from '$lib/api.js';
+  import type { BackupSummaryView, VersionKey } from '$lib/api.js';
   import {
     fetchBackups,
     pruneBackups,
@@ -8,6 +8,9 @@
     dismissSecretStripNotice as apiDismissSecretStripNotice,
     fetchInstallLockStatus,
     clearInstallLock,
+    fetchVersions,
+    clearRollbackPin,
+    isRollbackPin,
     type InstallLockStatusView,
   } from '$lib/api.js';
   import Spinner from '$lib/components/common/Spinner.svelte';
@@ -36,11 +39,33 @@
   let unlocking = $state<ActionHandle<{ removed: boolean }> | null>(null);
   let unlockCleared = $state(false);
 
+  // #639 — a failed update pins state/stack.env to a preserved rollback-*
+  // image tag (never `latest`) so automatic recovery restarts exactly what
+  // was running before; nothing else releases that pin. Distinct from a
+  // deliberate operator pin, which never carries the `rollback-` prefix.
+  const versionsRes = resource(async () => (await fetchVersions()).configured);
+  let rollbackPinnedKeys = $derived(
+    (Object.entries(versionsRes.data ?? {}) as [VersionKey, string][])
+      .filter(([, value]) => isRollbackPin(value))
+      .map(([key]) => key),
+  );
+  let clearingPin = $state<ActionHandle<unknown> | null>(null);
+  let pinCleared = $state(false);
+
   onMount(() => {
     void backupsRes.reload();
     void secretNoticeRes.reload();
     void installLockRes.reload();
+    void versionsRes.reload();
   });
+
+  async function onClearRollbackPin(): Promise<void> {
+    const run = runAction(() => clearRollbackPin(), { fallback: 'Failed to clear the rollback pin.' });
+    clearingPin = run;
+    const res = await run.result;
+    if (res) pinCleared = true;
+    await versionsRes.reload();
+  }
 
   async function onClearLock(): Promise<void> {
     const run = runAction(() => clearInstallLock(), { fallback: 'Failed to clear the lock.' });
@@ -132,6 +157,37 @@
         <div class="stuck-notice-text">
           <p class="stuck-notice-title">Cleared</p>
           <p>The stuck operation was cleared. You can run an update again.</p>
+        </div>
+      </div>
+    {/if}
+
+    {#if rollbackPinnedKeys.length > 0}
+      <!-- #639: a failed update pinned the stack to a preserved rollback image tag. -->
+      <div class="stuck-notice" role="status">
+        <div class="stuck-notice-text">
+          <p class="stuck-notice-title">Stack pinned to a rollback image</p>
+          <p>
+            A previous failed update left {rollbackPinnedKeys.join(', ')} pointed at the image that
+            was preserved for automatic recovery, not the normal release tag. This is different
+            from a deliberate version pin you set yourself — it just needs clearing so the next
+            update can move forward. Clearing only edits <code>state/stack.env</code>; run an
+            update afterward to apply it.
+          </p>
+        </div>
+        <button
+          class="btn btn-sm btn-primary"
+          onclick={onClearRollbackPin}
+          disabled={clearingPin?.loading ?? false}
+          aria-busy={clearingPin?.loading ?? false}
+        >
+          {#if clearingPin?.loading}<Spinner /> Clearing…{:else}Clear pin{/if}
+        </button>
+      </div>
+    {:else if pinCleared}
+      <div class="stuck-notice stuck-notice-ok" role="status">
+        <div class="stuck-notice-text">
+          <p class="stuck-notice-title">Cleared</p>
+          <p>The rollback pin was cleared. Run an update to apply the normal release tag.</p>
         </div>
       </div>
     {/if}

--- a/packages/ui/src/lib/components/admin/updates/RecoveryTab.svelte.vitest.ts
+++ b/packages/ui/src/lib/components/admin/updates/RecoveryTab.svelte.vitest.ts
@@ -2,6 +2,24 @@ import { describe, expect, test, vi } from 'vitest';
 import { page, userEvent } from 'vitest/browser';
 import { render } from 'vitest-browser-svelte';
 
+// vi.mock factories are hoisted above their file's top-level statements, so
+// any variable they reference must come from vi.hoisted() too.
+const { DEFAULT_VERSIONS, fetchVersionsMock, clearRollbackPinMock } = vi.hoisted(() => {
+	const defaultVersions = {
+		configured: {
+			OP_ASSISTANT_VERSION: '0.13.0',
+			OP_GUARDIAN_VERSION: '0.13.0',
+			OP_PORTAL_VERSION: '0.13.0',
+			OP_VOICE_VERSION: 'latest'
+		}
+	};
+	return {
+		DEFAULT_VERSIONS: defaultVersions,
+		fetchVersionsMock: vi.fn().mockResolvedValue(defaultVersions),
+		clearRollbackPinMock: vi.fn().mockResolvedValue({ ok: true, cleared: {} })
+	};
+});
+
 vi.mock('$lib/api.js', () => ({
 	fetchBackups: vi.fn().mockResolvedValue({
 		ok: true,
@@ -26,7 +44,11 @@ vi.mock('$lib/api.js', () => ({
 		path: '',
 		staleAfterMs: 0
 	}),
-	clearInstallLock: vi.fn()
+	clearInstallLock: vi.fn(),
+	// #639
+	fetchVersions: fetchVersionsMock,
+	clearRollbackPin: clearRollbackPinMock,
+	isRollbackPin: (value: string | undefined) => !!value?.startsWith('rollback-')
 }));
 
 import RecoveryTab from './RecoveryTab.svelte';
@@ -48,5 +70,44 @@ describe('RecoveryTab prune confirmation accessibility', () => {
 		await userEvent.keyboard('{Escape}');
 		await expect.element(dialog).not.toBeInTheDocument();
 		await expect.element(trigger).toHaveFocus();
+	});
+});
+
+// #639 — the stack must surface a rollback-pinned image without expanding
+// any collapsed panel, distinct from a deliberate operator pin, with a
+// one-click clear that never restarts anything on its own.
+describe('RecoveryTab rollback pin banner (#639)', () => {
+	test('shows no banner when nothing is pinned to a rollback generation', async () => {
+		fetchVersionsMock.mockResolvedValueOnce(DEFAULT_VERSIONS);
+		await render(RecoveryTab);
+
+		await expect.element(page.getByRole('heading', { name: 'Backups' })).toBeVisible();
+		await expect(page.getByText('Stack pinned to a rollback image').query()).not.toBeInTheDocument();
+	});
+
+	test('shows the banner naming the pinned key(s) and clears it on click, without prompting a restart', async () => {
+		fetchVersionsMock.mockResolvedValueOnce({
+			configured: {
+				OP_ASSISTANT_VERSION: 'rollback-generation-1788212586188-217761-1',
+				OP_GUARDIAN_VERSION: '0.13.0',
+				OP_PORTAL_VERSION: '0.13.0',
+				OP_VOICE_VERSION: 'latest'
+			}
+		});
+		fetchVersionsMock.mockResolvedValueOnce(DEFAULT_VERSIONS); // reload() after clearing
+
+		await render(RecoveryTab);
+
+		const banner = page.getByText('Stack pinned to a rollback image');
+		await expect.element(banner).toBeVisible();
+		await expect.element(page.getByText('OP_ASSISTANT_VERSION', { exact: false })).toBeVisible();
+		await expect.element(page.getByText('update afterward', { exact: false })).toBeVisible();
+
+		const clearButton = page.getByRole('button', { name: 'Clear pin' });
+		await clearButton.click();
+
+		expect(clearRollbackPinMock).toHaveBeenCalledTimes(1);
+		await expect.element(page.getByText('Cleared', { exact: true })).toBeVisible();
+		await expect(banner.query()).not.toBeInTheDocument();
 	});
 });

--- a/packages/ui/src/routes/api/host/versions/clear-rollback-pin/+server.ts
+++ b/packages/ui/src/routes/api/host/versions/clear-rollback-pin/+server.ts
@@ -1,0 +1,35 @@
+import { clearRollbackPins } from '@openpalm/lib';
+import { withAdminUpdateLock } from '$lib/server/admin-update-lock.js';
+import { errorResponse, getRequestId, jsonResponse, requireAdmin, requireCapability } from '$lib/server/helpers.js';
+import { getState } from '$lib/server/state.js';
+import type { RequestHandler } from './$types';
+
+/**
+ * POST-only, dedicated action for #639: unlike PATCH /api/host/versions
+ * (writeVersions — the OPERATOR-PIN API, which blanks OP_MANAGED_* markers),
+ * this calls the same clearRollbackPins() the `openpalm unpin` CLI command
+ * uses, so both surfaces share one implementation and one distinguishing
+ * rule for what counts as a rollback pin vs. an operator pin.
+ */
+export const POST: RequestHandler = async (event) => {
+	const requestId = getRequestId(event);
+	const capabilityError = requireCapability(event, 'host:updates', requestId);
+	if (capabilityError) return capabilityError;
+	const authError = requireAdmin(event, requestId);
+	if (authError) return authError;
+
+	const state = getState();
+	if (!state.stackDir) {
+		return errorResponse(503, 'not_initialized', 'Stack directory not configured', {}, requestId);
+	}
+
+	return withAdminUpdateLock(state, requestId, () => {
+		try {
+			const { cleared } = clearRollbackPins(state);
+			return jsonResponse(200, { ok: true, cleared }, requestId);
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			return errorResponse(500, 'clear_rollback_pin_failed', message, {}, requestId);
+		}
+	});
+};

--- a/packages/ui/src/routes/api/host/versions/clear-rollback-pin/server.vitest.ts
+++ b/packages/ui/src/routes/api/host/versions/clear-rollback-pin/server.vitest.ts
@@ -1,0 +1,73 @@
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, test } from 'vitest';
+import { PLATFORM_VERSION } from '@openpalm/lib';
+import { getState } from '$lib/server/state.js';
+import { resetState } from '$lib/server/test-helpers.js';
+import { POST } from './+server.js';
+
+function event(token = 'admin-token') {
+	return {
+		request: new Request('http://localhost/api/host/versions/clear-rollback-pin', {
+			method: 'POST',
+			headers: { cookie: `op_session=${token}`, 'x-request-id': 'req-clear-rollback-pin' }
+		})
+	};
+}
+
+beforeEach(() => {
+	process.env.OP_ENABLE_ADMIN = '1';
+	resetState('admin-token');
+});
+
+afterEach(() => {
+	delete process.env.OP_ENABLE_ADMIN;
+	rmSync(join(getState().dataDir, '.install.lock'), { force: true });
+});
+
+describe('POST /api/host/versions/clear-rollback-pin (#639)', () => {
+	test('requires admin auth', async () => {
+		expect((await POST(event('bad-token') as Parameters<typeof POST>[0])).status).toBe(401);
+	});
+
+	test('clears only rollback- pins, re-stamps their managed marker, and leaves an operator pin alone', async () => {
+		const state = getState();
+		mkdirSync(join(state.homeDir, 'state'), { recursive: true });
+		writeFileSync(
+			join(state.homeDir, 'state', 'stack.env'),
+			[
+				'OP_ASSISTANT_VERSION=rollback-generation-1788212586188-217761-1',
+				'OP_GUARDIAN_VERSION=my-operator-pinned-build',
+				'OP_MANAGED_ASSISTANT_VERSION=',
+				'OP_MANAGED_GUARDIAN_VERSION=',
+				''
+			].join('\n')
+		);
+
+		const response = await POST(event() as Parameters<typeof POST>[0]);
+		expect(response.status).toBe(200);
+		const body = (await response.json()) as { ok: boolean; cleared: Record<string, { from: string; to: string }> };
+		expect(body.ok).toBe(true);
+		expect(body.cleared.OP_ASSISTANT_VERSION).toEqual({
+			from: 'rollback-generation-1788212586188-217761-1',
+			to: PLATFORM_VERSION
+		});
+		expect(body.cleared.OP_GUARDIAN_VERSION).toBeUndefined();
+
+		const content = readFileSync(join(state.homeDir, 'state', 'stack.env'), 'utf-8');
+		expect(content).toContain(`OP_ASSISTANT_VERSION=${PLATFORM_VERSION}`);
+		expect(content).toContain(`OP_MANAGED_ASSISTANT_VERSION=${PLATFORM_VERSION}`);
+		expect(content).toContain('OP_GUARDIAN_VERSION=my-operator-pinned-build');
+	});
+
+	test('rejects while another lifecycle mutation holds the lock', async () => {
+		const state = getState();
+		mkdirSync(state.dataDir, { recursive: true });
+		writeFileSync(join(state.dataDir, '.install.lock'), `${process.pid}\n${Date.now()}\n`);
+
+		const response = await POST(event() as Parameters<typeof POST>[0]);
+
+		expect(response.status).toBe(409);
+		expect(await response.json()).toMatchObject({ error: 'install_in_progress' });
+	});
+});

--- a/scripts/guardian-image-offline-smoke.sh
+++ b/scripts/guardian-image-offline-smoke.sh
@@ -102,16 +102,19 @@ if [ "$ok" != "1" ]; then
 fi
 echo "PASS: guardian reached healthy under --network none."
 
-# The reproducibility receipt (package@version + entry + auth strategy in one
-# structured boot line) is asserted against LOCAL source in
-# packages/guardian/src/server.test.ts ("Guardian boot receipt"), not here:
-# this script builds from the local candidate source. What this script verifies
-# is that the baked package is used as-is with no re-fetch.
+# What this script verifies is that the baked package is used as-is with no
+# re-fetch. The entrypoint no longer announces that with its own log line — the
+# boot-time package override it used to print around was deleted outright
+# (a000687), and the exec is now unconditional — so the proof is the guardian's
+# structured boot receipt: its `entry` is Bun.main, and only the image layer
+# puts @openpalm/guardian at this path (the shipped compose bind-mounts
+# /opt/openpalm/guardian, never /opt/openpalm/guardian-pkg).
+BAKED_ENTRY="/opt/openpalm/guardian-pkg/node_modules/@openpalm/guardian/src/server.ts"
 # Capture once because `docker logs | grep -q` races under pipefail: grep can
 # close the pipe after a match and turn docker's resulting SIGPIPE into failure.
 CONTAINER_LOGS="$(docker logs "$CONTAINER" 2>&1)"
-if ! grep -q "using image-baked Guardian package" <<<"$CONTAINER_LOGS"; then
-  echo "FAIL: entrypoint did not use the baked guardian package" >&2
+if ! grep -qF "\"entry\":\"${BAKED_ENTRY}\"" <<<"$CONTAINER_LOGS"; then
+  echo "FAIL: guardian boot receipt does not name the image-baked entry ${BAKED_ENTRY}" >&2
   printf '%s\n' "$CONTAINER_LOGS" >&2
   exit 1
 fi

--- a/scripts/sync-lockfile-versions.mjs
+++ b/scripts/sync-lockfile-versions.mjs
@@ -1,0 +1,56 @@
+#!/usr/bin/env node
+// sync-lockfile-versions.mjs — true up bun.lock's per-workspace "version"
+// fields to match each workspace's package.json.
+//
+// `bun install --lockfile-only` does not rewrite a workspace's own
+// "version" entry in bun.lock when nothing else about its dependency graph
+// changed: workspace:* references resolve by path, not by version number,
+// so a version-only bump in package.json doesn't invalidate bun's
+// lockfile-only fast path. Left alone, bun.lock silently drifts from the
+// package.json versions on every release (see release issue #633). This
+// patches only the "version" string for each stamped workspace, leaving
+// every resolved dependency untouched.
+//
+// Used by .github/workflows/release.yml, right after bump-unit.mjs and
+// `bun install --lockfile-only`.
+// Preview locally: node scripts/sync-lockfile-versions.mjs
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import { dirname } from 'node:path';
+
+const LOCKFILE = 'bun.lock';
+
+const RELEASE_PACKAGE_GROUPS = JSON.parse(
+	readFileSync('.github/release-package-groups.json', 'utf8')
+).units;
+const files = [...new Set(Object.values(RELEASE_PACKAGE_GROUPS).flat())];
+
+let lock = readFileSync(LOCKFILE, 'utf8');
+let changed = 0;
+
+for (const file of files) {
+	const dir = file === 'package.json' ? '' : dirname(file);
+	const pkg = JSON.parse(readFileSync(file, 'utf8'));
+	if (!pkg.version) continue;
+
+	const key = dir.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+	// Match the workspace's block up to (but not into) its first nested
+	// object, so this only ever touches a "version" field that appears
+	// before "bin"/"dependencies"/etc. — never a nested package's.
+	const re = new RegExp(`("${key}":\\s*{[^{}]*?"version":\\s*)"([^"]*)"`);
+	const match = lock.match(re);
+	if (!match) continue; // no recorded version for this workspace — nothing to true up
+
+	if (match[2] !== pkg.version) {
+		lock = lock.replace(re, `$1"${pkg.version}"`);
+		console.log(`  ${dir || '.'}: ${match[2]} → ${pkg.version}`);
+		changed++;
+	}
+}
+
+if (changed > 0) {
+	writeFileSync(LOCKFILE, lock);
+	console.log(`sync-lockfile-versions: trued up ${changed} workspace version(s) in ${LOCKFILE}`);
+} else {
+	console.log('sync-lockfile-versions: bun.lock already matches package.json versions');
+}


### PR DESCRIPTION
## Summary

Ten defect fixes for the 0.13.1 milestone, one commit per issue (two for #643 and for #641/#642), no features or refactors. Each fix carries a regression test that was shown to fail without it, and each was reproduced before/after against a real isolated `OP_HOME` through the real CLI/lib code paths.

Closes #645, closes #643, closes #641, closes #642, closes #639, closes #636, closes #635, closes #644, closes #632, closes #633.

| Issue | Fix |
|---|---|
| #645 | `stripRetiredAkmKeys` now translates `profiles.llm.*` → akm 0.9 `engines.*` (endpoint via the idempotent `buildAkmEndpoint`, model, provider, env-var `apiKey` refs) before the strip; untranslatable fields are named in a warning; `openpalm validate` warns on zero engines. |
| #643 | `migrateLegacyDefaultPorts` carries an explicit `OP_ASSISTANT_PORT`/`OP_UI_PORT` from the consolidated `state/stack.env` through the chain (a rollback's restored schema-version re-runs it and consolidation let the legacy default win), and probes host-wide availability before writing a fresh default; `migrateConsolidatedDefaultPorts` skips the 3800→3810 swap when 3810 is held by someone else. Migrations became async; the ripple is mechanical (`await` at four call sites, top-level `await` in the UI server hooks). |
| #641 | Still reproduced on a first 0.12→0.13.1 upgrade (old root-owned guardian `node_modules` gets staged). `overwriteSystemTree`'s final `rmSync` of `.system-previous-*` is now best-effort: warn naming the path instead of failing a completed update. |
| #642 | `backupOpenPalmHome` walks the tree itself: an unreadable file outside the four paths `openpalm rollback` restores is skipped and recorded in `.backup-complete`; one of those four fails loud with the path and a `chown` hint. |
| #639 | `clearRollbackPins()` in lib (clears only `rollback-` prefixed values, re-stamps `OP_MANAGED_*`, never touches an operator pin); `openpalm unpin`; `POST /api/host/versions/clear-rollback-pin`; Recovery-tab banner with one-click clear. |
| #636 | `assertHomeNotNewerThanApp()` compares `.skeleton-version`/`state/schema-version` against the running build and refuses `applyInstall`/`applyUpdate`/`performUpgrade`/`applyHomeAssets`/`clearRollbackPins` before any snapshot or write; `status`/`validate`/`start` unaffected; missing or non-semver stamps never trip it. |
| #635 | `DesktopUpdater` gets a per-download `installAttempted` guard so electron-updater's `install()` is never called twice (the before-quit handler was re-entering it after `quitAndInstall()`); a failed quit-time install is logged loudly. |
| #644 | `COMPOSE_PROGRESS_RE` was missing bare `Recreate`; `applyStack`'s post-failure branch discarded compose stderr once `ps -a` found a row. Both fixed in the shared derivation; verified against a real daemon port-bind error. |
| #632 | `auditResolvedComposeSecrets` checks each resolved secret file exists (compose prunes secrets to active services, so no addon false-positives) and names the secret, path, and remedy. |
| #633 | `bun install --lockfile-only` never rewrites a workspace's own version field (the 0.13.0 CI prep commit proves it). `scripts/sync-lockfile-versions.mjs` patches exactly those fields; wired into the release stamp step; lockfile trued up. |

## Verification

- `bun run lint` clean; `bun run test` (CI's command, `--isolate`): 2609 pass / 0 fail; `bun run ui:check`: 0 errors; electron: 188 pass; `bun run --cwd packages/electron typecheck` clean.
- Tests requiring an unprivileged user (#641/#642) were run as a non-root user here; they self-skip under uid 0.
- Environment limits, stated honestly: this sandbox has a Docker daemon and Compose v5 but Docker Hub image pulls are policy-blocked, so no fix was verified on a booted stack. Every fix was instead reproduced and confirmed on a real isolated `OP_HOME` through the real CLI/lib entry points (`runHomeMigrations`, `stripRetiredAkmConfigKeys`, `backupOpenPalmHome`, `overwriteSystemTree`, `applyStack` against the real daemon, `openpalm unpin`/`update`/`start`/`validate`). `./scripts/akm-pin-integration-smoke.sh` could not run for the same reason; in its place the pinned akm-cli 0.9.6 and 0.9.7 binaries were installed directly and `akm config list`/`akm health` were run against the #645 fixture before and after. A live-stack pass on the operator's side is still warranted before tagging.
- Note for maintainers: with bun 1.3.11, `bun test --isolate` on this suite shows 161 cross-file mock-leak failures even on the untouched base; under CI's pinned bun 1.3.14 it is fully green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018rQ2BpDPUCde6Na4gZdKpu

---
_Generated by [Claude Code](https://claude.ai/code/session_018rQ2BpDPUCde6Na4gZdKpu)_