### PR TITLE
chore: move the akm pins to 0.9.14

### DIFF
--- a/containers/assistant/tools/package.json
+++ b/containers/assistant/tools/package.json
@@ -3,6 +3,6 @@
   "private": true,
   "dependencies": {
     "opencode-ai": "1.18.21",
-    "akm-cli": "0.9.10"
+    "akm-cli": "0.9.14"
   }
 }

--- a/docs/technical/paperclip-addon-design.md
+++ b/docs/technical/paperclip-addon-design.md
@@ -63,7 +63,7 @@ software. Upstream publishes no semver tag, so the digest is the pin and the
 AKM is added through standard OpenCode configuration rather than an image
 layer. Managed `system/paperclip/` contains:
 
-- exact dependencies `akm-opencode@0.9.9202609021827` and `akm-cli@0.9.10`;
+- exact dependencies `akm-opencode@0.9.14202609050009` and `akm-cli@0.9.14`;
 - `plugins/akm.ts`, which re-exports only the plugin function;
 - `bin/bun`, which sets `BUN_BE_BUN=1` and executes `opencode`, exposing the
   Bun runtime already embedded in Paperclip's OpenCode binary;

--- a/docs/technical/paperclip-addon-design.md
+++ b/docs/technical/paperclip-addon-design.md
@@ -63,7 +63,7 @@ software. Upstream publishes no semver tag, so the digest is the pin and the
 AKM is added through standard OpenCode configuration rather than an image
 layer. Managed `system/paperclip/` contains:
 
-- exact dependencies `akm-opencode@0.9.14202609050009` and `akm-cli@0.9.14`;
+- exact dependencies `akm-opencode@0.9.14202609050148` and `akm-cli@0.9.14`;
 - `plugins/akm.ts`, which re-exports only the plugin function;
 - `bin/bun`, which sets `BUN_BE_BUN=1` and executes `opencode`, exposing the
   Bun runtime already embedded in Paperclip's OpenCode binary;

--- a/packages/skeleton/system/assistant/opencode.jsonc
+++ b/packages/skeleton/system/assistant/opencode.jsonc
@@ -18,7 +18,7 @@
   // the image-baked-only model removed every other runtime install. Bump this
   // deliberately at release time, same as containers/assistant/tools/package.json.
   "plugin": [
-    "akm-opencode@0.9.14202609050009"
+    "akm-opencode@0.9.14202609050148"
   ],
   // MCP consume-only example: OpenCode can connect to external MCP servers,
   // but it does not serve MCP itself. Seed-only file: existing installs keep

--- a/packages/skeleton/system/assistant/opencode.jsonc
+++ b/packages/skeleton/system/assistant/opencode.jsonc
@@ -18,7 +18,7 @@
   // the image-baked-only model removed every other runtime install. Bump this
   // deliberately at release time, same as containers/assistant/tools/package.json.
   "plugin": [
-    "akm-opencode@0.9.9202609021827"
+    "akm-opencode@0.9.14202609050009"
   ],
   // MCP consume-only example: OpenCode can connect to external MCP servers,
   // but it does not serve MCP itself. Seed-only file: existing installs keep

--- a/packages/skeleton/system/paperclip/package.json
+++ b/packages/skeleton/system/paperclip/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"dependencies": {
-		"akm-cli": "0.9.10",
-		"akm-opencode": "0.9.9202609021827"
+		"akm-cli": "0.9.14",
+		"akm-opencode": "0.9.14202609050009"
 	}
 }

--- a/packages/skeleton/system/paperclip/package.json
+++ b/packages/skeleton/system/paperclip/package.json
@@ -2,6 +2,6 @@
 	"private": true,
 	"dependencies": {
 		"akm-cli": "0.9.14",
-		"akm-opencode": "0.9.14202609050009"
+		"akm-opencode": "0.9.14202609050148"
 	}
 }


### PR DESCRIPTION
Closes #685. Supersedes #683.

akm shipped 0.9.14 and akm-plugins released against it, so both pins move together rather than in two passes.

| pin | file | from | to |
|---|---|---|---|
| `akm-cli` | `containers/assistant/tools/package.json` | `0.9.10` | `0.9.14` |
| `akm-cli` | `packages/skeleton/system/paperclip/package.json` | `0.9.10` | `0.9.14` |
| `akm-opencode` | `packages/skeleton/system/paperclip/package.json` | `0.9.9202609021827` | `0.9.14202609050148` |
| `akm-opencode` | `packages/skeleton/system/assistant/opencode.jsonc` | `0.9.9202609021827` | `0.9.14202609050148` |

Plus the exact-deps line in `docs/technical/paperclip-addon-design.md`, which names both.

### Why this supersedes #683

#683 asked for `akm-opencode@0.9.11202609032044`. That build targets akm 0.9.11. Taking it now would pair a plugin stamped for one CLI with a container running another, and would need a second bump the same day.

### Two corrections made while this PR was open

Both are recorded here rather than force-pushed away, because each is a real defect the gates caught.

**1. A missed pin surface (`49aac541`).** The first commit moved three pins but left `packages/skeleton/system/assistant/opencode.jsonc` naming `akm-opencode@0.9.9202609021827`. That file is the assistant's *runtime* plugin spec — OpenCode resolves it at start — so the container would have loaded the 0.9.9 plugin while paperclip loaded 0.9.14. `paperclip-compose-contract.test.ts` asserts exactly this parity and failed the Quality gates job. The contract did its job.

**2. The plugin build was stale before it merged (`c1d11f8a`).** akm-plugins#120 ("align plugins with akm 0.9.14") merged at 01:47Z; the `0.9.14202609050009` build originally pinned here published at 00:09, so it predates the fix. The difference is load-bearing:

```
0.9.14202609050009   akm-cli: ^0.9.8
0.9.14202609050148   akm-cli: 0.9.14
```

The caret build can resolve a CLI older than 0.9.14 at install time. 0.9.14 advances the derived index to generation 23 and carries state migration 027, and an older CLI **refuses a home that 0.9.14 has already touched** — so the original pin could have produced a container whose akm will not open its own `OP_HOME`. #120 exact-pins the dependency for that reason, and because the plugin imports private dist modules in process and one build must not execute different private APIs across installs.

### What changed in the CLI

0.9.14 is the retrieval release. `akm search` now returns addressable fragment refs — `<ref>#akm-fragment-<n>-<12 hex>` — and `akm show` resolves one to that passage alone rather than the whole document. For a long knowledge doc or a chat-transcript memory, a hit delivers the relevant section instead of the entire file.

The index generation move (v22 → v23) needs no manual step in `OP_HOME`: the index is a regenerable cache and a current binary rebuilds an older one automatically. The first `akm index` after the upgrade does a full rebuild. The one-way part is the reason for the exact pin above — forward is automatic, backward is refused.

### Verification — complete, all six checks green on `c1d11f8a`

The akm bump gate has now run against a live instance. From the Quality gates log, `upgrade-path-smoke.sh` exercising the real pinned binary against homes migrated from two prior skeleton eras:

```
- @openpalm/skeleton@0.12.43
    Exercising akm-cli@0.9.14 on node:22-trixie-slim against the migrated home...
  ok: real akm migrate status is 'current' (not blocked) against the migrated home
  ok: real akm task sync reconciled 3 shipped task(s) from the migrated home
- @openpalm/skeleton@0.13.0-beta.13
    Exercising akm-cli@0.9.14 on node:22-trixie-slim against the migrated home...
  ok: real akm migrate status is 'current' (not blocked) against the migrated home
  ok: real akm task sync reconciled 3 shipped task(s) from the migrated home
```

That is the v23 index generation and migration 027 landing cleanly on real prior installs — the specific risk behind the exact pin above. `akm-pin-integration-smoke.sh` runs as its own step in the same job; the job is green, so it passed.

Also verified:

- `paperclip-compose-contract.test.ts` 6/6.
- Scoped suite (`bun run test`, the 2774-test set CI runs): 2561 pass / 211 fail in the preparation sandbox — **identical on the base commit**, so this change adds no failures. CI's own environment saw 2773/1 before correction 1, and that one failure is fixed.
- Engines floor — the failure class that made the 0.9.1 → 0.9.4 bump ship five cascading failures. Assistant toolbuild is `node:22-trixie-slim`; `akm-cli@0.9.14` declares `engines.node >=22`, unchanged from 0.9.10.
- Fragment-ref handling against a live 0.9.14: a 47KB knowledge doc indexed and searched, and the real returned fragment ref pushed through the plugin's `ref-extraction`. Both `extractAllRefs` and `validateRefCandidates` accept it and resolve to the parent concept; `akm show` on the same ref returned 42 bytes instead of the document. No plugin runtime change was needed for this — #120 added the test coverage for it.

Nothing outstanding.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GdS26JcJ5A9Hqxxe3jo31x